### PR TITLE
refactor(phase6): Decouple ImageLabel from ImageAnnotator via Qt signals + CanvasContext

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,9 @@ See [Building Block View](docs/05_building_block_view.md) for detailed class doc
 2. Set `image_label.current_tool` on click
 3. Handle mouse events in `ImageLabel` (mousePressEvent, mouseMoveEvent)
 4. Render in `ImageLabel.paintEvent()`
-5. Call `main_window.add_annotation()` to commit
+5. Commit via `self.annotationCommitted.emit(annotation_dict)` — the
+   orchestrator routes it to `AnnotationController.add_annotation_to_list`
+   (see ADR-016)
 
 ### Working with Annotations
 

--- a/docs/05_building_block_view.md
+++ b/docs/05_building_block_view.md
@@ -270,7 +270,9 @@ ImageAnnotator (main window)
     └── launches ──> Tool Dialogs (utilities)
 
 ImageLabel
-    ├── references ──> ImageAnnotator (callbacks)
+    ├── emits signals to ──> ImageAnnotator (writes; see ADR-016)
+    ├── reads via ──> CanvasContext (paint/eraser size, current class,
+    │                  class_mapping, is_class_visible, scroll_area, …)
     └── uses ──> utils (area, bbox calculations)
 
 SAMUtils

--- a/docs/08_crosscutting_concepts.md
+++ b/docs/08_crosscutting_concepts.md
@@ -444,3 +444,54 @@ if image_path is None:
 The substring fallback is kept for backward compatibility with old
 projects that may have stored normalised image names (e.g. without
 extension); new code should prefer the exact-key path.
+
+## Canvas Decoupling — Signals + CanvasContext
+
+`ImageLabel` (the canvas widget) does **not** hold a reference to
+`ImageAnnotator`. Communication is split:
+
+- **Writes** (committing an annotation, requesting a SAM prediction,
+  asking for tools to be re-enabled, etc.) leave the widget as Qt
+  `pyqtSignal` emissions. The signal block at the top of `ImageLabel`
+  documents every outbound interaction. `ImageAnnotator` connects
+  each signal to the right controller slot once, in
+  `_connect_image_label_signals` (called at the end of
+  `ImageAnnotator.__init__`).
+- **Reads** (`paint_brush_size`, `current_class`, `class_mapping`,
+  `is_class_visible`, `scroll_area`, etc.) go through a
+  `CanvasContext` object passed in via
+  `image_label.set_context(CanvasContext(self))`.
+  `CanvasContext` wraps the main window rather than copying state,
+  so updates made by controllers are visible on the next read.
+
+**Why both mechanisms.** Signals are inherently one-way (fire and
+forget); a synchronous read like "is this class visible" needs a
+return value, which signals don't provide. Trying to express reads
+as request/response signals adds latency and ordering bugs. The
+`CanvasContext` accessor list is small (~10 methods) and stable.
+
+**Rules for adding traffic in either direction**:
+
+- New write from canvas → orchestrator: declare a `pyqtSignal` on
+  `ImageLabel`, add a slot on a controller, wire it in
+  `_connect_image_label_signals`. Do not add a back-reference to
+  `ImageAnnotator`.
+- New read from canvas → orchestrator: add a method on
+  `CanvasContext`. Do not expose `_ctx._mw` directly.
+
+**Synchronous-emit ordering**. Qt's default `AutoConnection` runs the
+slot synchronously when the sender and receiver share a thread (true
+for everything on the GUI thread). Code that emits a signal and then
+reads state expected to be updated by it is correct — the slot has
+already run by the time `.emit()` returns. This is load-bearing for
+`accept_temp_annotations`, where `classRequested` must complete
+before the subsequent class lookup.
+
+**Batch save signal**. Paint commits and accept-temp commits emit
+`annotationCommitted` per annotation but `annotationsBatchSaved` only
+once at the end. The single batch save preserves O(1) `.iap` writes
+per user action; replacing it with a per-annotation save would turn
+paint commits into O(N). See ADR-016.
+
+See ADR-016 in `09_architecture_decisions.md` for the rationale and
+the full pattern.

--- a/docs/09_architecture_decisions.md
+++ b/docs/09_architecture_decisions.md
@@ -378,6 +378,103 @@ no active modal widget, focus not on `QLineEdit`/`QTextEdit`.
 
 ---
 
+## ADR-016: Decouple ImageLabel from ImageAnnotator via Signals + CanvasContext
+
+**Status**: Accepted (Phase 6 of the modular refactor)
+
+**Context**: Before Phase 6, `ImageLabel.set_main_window(main_window)`
+injected the orchestrator into the canvas widget, and the widget poked
+~50 sites on `main_window` directly — both reading state
+(`paint_brush_size`, `class_mapping`, `current_class`, `scroll_area`,
+`current_slice`, `image_file_name`) and mutating it
+(`all_annotations[name] = …`, `add_class(…)`,
+`update_annotation_list()`, `save_current_annotations()`,
+`update_slice_list_colors()`, `schedule_sam_prediction()`,
+`zoom_in()`, `enable_tools()`, etc.). The coupling made:
+- ImageLabel impossible to test in isolation without a
+  whole-`ImageAnnotator` fixture.
+- Every controller extraction (Phases 3–5) leak through `main_window`
+  delegation pass-throughs, because deleting them would break the
+  widget.
+- The Phase 7 per-tool split (paint / eraser / polygon / rectangle
+  handler classes) impractical, because each handler would need the
+  same `main_window` reference and would multiply the coupling.
+
+Three options were considered:
+
+1. **Protocol / duck-typed callback object** — pass a small protocol
+   with the methods ImageLabel needs. Strict, type-safe, but writes
+   are still synchronous direct calls; the widget still knows the
+   exact method names on the orchestrator.
+2. **Defer the fix** — leave `main_window` for one more phase, accept
+   the debt. Cheapest, but each subsequent refactor pays the cost.
+3. **Qt signals for every write + a narrow read accessor object** —
+   ImageLabel emits typed signals; the orchestrator connects each to
+   a controller slot during `__init__`. Reads go through a
+   `CanvasContext` object with method-style accessors.
+
+**Decision**: Option 3. ImageLabel declares ~20 `pyqtSignal`s covering
+annotation lifecycle, SAM, class, tool/UI state, navigation, and
+batch finalisation. Reads go via a `CanvasContext` instance passed in
+through `set_context(ctx)`. The previous `set_main_window` /
+`self.main_window` field is removed entirely.
+
+The connection block lives in `ImageAnnotator._connect_image_label_signals`,
+called once at the end of `__init__` after every controller exists.
+`CanvasContext` wraps the main window rather than copying state, so
+the source of truth stays on `ImageAnnotator` and controllers see
+their writes reflected on the next read.
+
+**Consequences**:
+- ✅ ImageLabel has zero `main_window` references; signals form the
+  documented public write surface at the top of the class.
+- ✅ ImageLabel is now testable in isolation by connecting signals
+  to stub slots; no controller fixture needed.
+- ✅ Phase 7 (per-tool handlers) can carve `mousePressEvent` /
+  `mouseMoveEvent` etc. without each handler needing the orchestrator.
+- ✅ Signal connections are explicit and grep-able — searching for
+  `il.annotationCommitted.connect` finds the single wiring site.
+- ⚠️ Two parallel mechanisms (signals for writes, `CanvasContext` for
+  reads) need to be kept in step. The widget's signal block and
+  `_connect_image_label_signals` must stay in sync; a missing
+  connection is a silent no-op write.
+- ⚠️ Signal connections rely on Qt's default `AutoConnection` semantics,
+  which is synchronous within a single thread. Consumers that depend
+  on a write taking effect before the next read (e.g. `classRequested`
+  emit followed by `_ctx.class_id(name)` read) must stay on the GUI
+  thread.
+- ⚠️ The synchronous batch-save signal (`annotationsBatchSaved`)
+  preserves the original O(1)-save-per-batch behaviour. Replacing it
+  with per-annotation save would silently turn paint commits into
+  O(N) saves. Future refactors must keep the batch boundary.
+
+**Pattern for adding a new ImageLabel → orchestrator interaction**:
+
+1. Add a `pyqtSignal(<args>)` to `ImageLabel`.
+2. Add a slot method on a controller (or main window) with matching
+   signature.
+3. Wire it in `_connect_image_label_signals`.
+4. Replace the previous direct call site in ImageLabel with
+   `self.<signal>.emit(<args>)`.
+
+**Pattern for adding a new read accessor**:
+
+1. Add a method on `CanvasContext` returning the value.
+2. Use `self._ctx.<accessor>()` at the read site in ImageLabel.
+
+**Related**:
+- Implementation: `widgets/canvas_context.py`,
+  `widgets/image_label.py` (signal block lines 42–70),
+  `annotator_window.py:_connect_image_label_signals`.
+- Cross-cuts: documented in
+  [Cross-cutting Concepts → Canvas Decoupling](08_crosscutting_concepts.md#canvas-decoupling--signals--canvascontext).
+- Predecessor pattern: ADR-015 (DINO event filter) showed that
+  ImageLabel can't reliably observe global keyboard state without
+  help; ADR-016 generalises "explicit interaction surface, narrow
+  read surface" to all canvas ↔ orchestrator traffic.
+
+---
+
 ## Decisions Under Consideration
 
 ### Consider pytest-qt for Utility Testing

--- a/docs/11_risks_and_technical_debt.md
+++ b/docs/11_risks_and_technical_debt.md
@@ -159,29 +159,18 @@ return None
 
 ---
 
-### Tight Coupling Between ImageAnnotator and ImageLabel
+### Tight Coupling Between ImageAnnotator and ImageLabel — Resolved (Phase 6)
 
-**Debt Level**: Medium
+**Status**: Resolved. `ImageLabel.main_window` and `set_main_window()`
+were removed; every write path is now a `pyqtSignal` emission and every
+read goes through a narrow `CanvasContext` accessor.
 
-**Description**: ImageLabel has `main_window` reference and calls methods directly
+**Pattern**: see `widgets/canvas_context.py` and
+`ImageAnnotator._connect_image_label_signals`. ImageLabel emits ~20
+signals (annotation lifecycle, SAM, class, tool/UI state, navigation);
+the orchestrator wires each to the matching controller slot.
 
-**Examples**:
-```python
-# In ImageLabel
-self.main_window.add_annotation(polygon)
-self.main_window.update_annotation_list()
-```
-
-**Impact**:
-- Hard to test ImageLabel independently
-- Changes ripple between classes
-- Circular dependency concerns
-
-**Effort to Resolve**: Medium (refactor to signals/slots)
-
-**Priority**: Low
-
-**Plan**: Refactor to Qt signals for loose coupling
+**ADR**: see ADR-016 in `09_architecture_decisions.md`.
 
 ---
 

--- a/src/digitalsreeni_image_annotator/annotator_window.py
+++ b/src/digitalsreeni_image_annotator/annotator_window.py
@@ -53,6 +53,7 @@ from .dialogs.dicom_converter import DicomConverter
 from .dialogs.dino_merge_dialog import show_dino_merge_dialog
 from .dialogs.help_window import HelpWindow
 from .dialogs.image_augmenter import show_image_augmenter
+from .widgets.canvas_context import CanvasContext
 from .widgets.image_label import ImageLabel
 from .dialogs.image_patcher import show_image_patcher
 from .inference.sam_utils import SAMUtils
@@ -90,7 +91,6 @@ class ImageAnnotator(QMainWindow):
         self.image_label.sam_points_active = False
         self.image_label.sam_positive_points = []
         self.image_label.sam_negative_points = []
-        self.image_label.set_main_window(self)
 
         # Initialize attributes
         self.current_image = None
@@ -140,6 +140,12 @@ class ImageAnnotator(QMainWindow):
         self.yolo_controller = YOLOController(self)
         self.annotation_controller = AnnotationController(self)
         self.class_controller = ClassController(self)
+
+        # CanvasContext gives ImageLabel a narrow read view of main-window
+        # state. All write paths from the canvas leave as Qt signals
+        # connected to controllers below.
+        self.image_label.set_context(CanvasContext(self))
+        self._connect_image_label_signals()
 
         # Create sam_magic_wand_button
         self.sam_magic_wand_button = QPushButton("Magic Wand")
@@ -210,6 +216,55 @@ class ImageAnnotator(QMainWindow):
 
         # Start in maximized mode
         self.showMaximized()
+
+    def _connect_image_label_signals(self):
+        """Wire ImageLabel events to controller slots. ImageLabel does not
+        hold a main_window reference any more — every write path is a
+        Qt signal connected here."""
+        il = self.image_label
+        ac = self.annotation_controller
+        cc = self.class_controller
+        sc = self.sam_controller
+
+        # Annotation lifecycle
+        il.annotationCommitted.connect(ac.add_annotation_to_list)
+        il.annotationsBatchSaved.connect(self._on_annotations_batch_saved)
+        il.annotationsReplaced.connect(ac.replace_annotations)
+        il.annotationListUpdateRequested.connect(ac.update_annotation_list)
+        il.annotationSelected.connect(ac.select_annotation_in_list)
+        il.deleteSelectionRequested.connect(ac.delete_selected_annotations)
+        il.finishPolygonRequested.connect(ac.finish_polygon)
+        il.finishRectangleRequested.connect(ac.finish_rectangle)
+
+        # Class
+        il.classRequested.connect(cc.add_class)
+
+        # SAM
+        il.samPredictionRequested.connect(sc.schedule_sam_prediction)
+        il.samPredictionApplyRequested.connect(sc.apply_sam_prediction)
+        il.samPredictionAccepted.connect(sc.accept_sam_prediction)
+        il.samPointsCleared.connect(sc.cancel_sam_prediction)
+
+        # Tool / UI state
+        il.enableToolsRequested.connect(self.enable_tools)
+        il.disableToolsRequested.connect(self.disable_tools)
+        il.resetToolButtonsRequested.connect(self.reset_tool_buttons)
+        il.toolSizeChanged.connect(self._on_tool_size_changed)
+
+        # Navigation / info
+        il.zoomInRequested.connect(self.zoom_in)
+        il.zoomOutRequested.connect(self.zoom_out)
+        il.imageInfoChanged.connect(self.update_image_info)
+
+    def _on_tool_size_changed(self, tool: str, size: int) -> None:
+        if tool == "paint":
+            self.paint_brush_size = size
+        elif tool == "eraser":
+            self.eraser_size = size
+
+    def _on_annotations_batch_saved(self) -> None:
+        self.annotation_controller.save_current_annotations()
+        self.class_controller.update_slice_list_colors()
 
     def setup_ui(self):
         # Initialize the main layout

--- a/src/digitalsreeni_image_annotator/annotator_window.py
+++ b/src/digitalsreeni_image_annotator/annotator_window.py
@@ -243,7 +243,7 @@ class ImageAnnotator(QMainWindow):
         il.samPredictionRequested.connect(sc.schedule_sam_prediction)
         il.samPredictionApplyRequested.connect(sc.apply_sam_prediction)
         il.samPredictionAccepted.connect(sc.accept_sam_prediction)
-        il.samPointsCleared.connect(sc.cancel_sam_prediction)
+        il.samPointsCleared.connect(sc.cancel_sam_debounce)
 
         # Tool / UI state
         il.enableToolsRequested.connect(self.enable_tools)

--- a/src/digitalsreeni_image_annotator/controllers/annotation_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/annotation_controller.py
@@ -152,6 +152,16 @@ class AnnotationController(QObject):
 
         self.mw.update_slice_list_colors()
 
+    def replace_annotations(self, image_key: str, annotations: dict) -> None:
+        """Replace the full per-class annotation dict for one image.
+        Used by the eraser path which has already cut polygons in
+        ImageLabel.annotations. Triggers list refresh, save, and slice
+        colour update atomically."""
+        self.mw.all_annotations[image_key] = annotations
+        self.update_annotation_list()
+        self.save_current_annotations()
+        self.mw.class_controller.update_slice_list_colors()
+
     # --- Sorting ---
 
     def sort_annotations_by_class(self):

--- a/src/digitalsreeni_image_annotator/controllers/sam_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/sam_controller.py
@@ -111,9 +111,11 @@ class SAMController(QObject):
         self.mw.sam_inference_timer.stop()
         self.mw.sam_inference_timer.start(1000)
 
-    def cancel_sam_prediction(self):
-        """Cancel a pending SAM points prediction. Triggered by Escape
-        in ImageLabel while sam_points mode is active."""
+    def cancel_sam_debounce(self):
+        """Stop the SAM debounce timer so a queued inference doesn't
+        fire. Does NOT abort an in-flight inference; that case is
+        handled by the _sam_inference_in_flight guard (ADR-013).
+        Triggered by Escape in ImageLabel while sam_points is active."""
         self.mw.sam_inference_timer.stop()
 
     def apply_sam_prediction(self):

--- a/src/digitalsreeni_image_annotator/controllers/sam_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/sam_controller.py
@@ -111,6 +111,11 @@ class SAMController(QObject):
         self.mw.sam_inference_timer.stop()
         self.mw.sam_inference_timer.start(1000)
 
+    def cancel_sam_prediction(self):
+        """Cancel a pending SAM points prediction. Triggered by Escape
+        in ImageLabel while sam_points mode is active."""
+        self.mw.sam_inference_timer.stop()
+
     def apply_sam_prediction(self):
         # Re-entry guard (ADR-013): the event-loop pump inside _run_sync
         # can deliver this timer fire before the first call returns.

--- a/src/digitalsreeni_image_annotator/widgets/canvas_context.py
+++ b/src/digitalsreeni_image_annotator/widgets/canvas_context.py
@@ -1,0 +1,48 @@
+"""
+CanvasContext — narrow read-only view of main-window state used by
+ImageLabel during rendering and event handling.
+
+The orchestrator (ImageAnnotator) constructs one CanvasContext and
+passes it to ImageLabel via set_context(). ImageLabel reads state
+through the accessors here; writes go out as Qt signals connected to
+controllers in ImageAnnotator.__init__.
+
+All accessors are methods (not attributes) so the source of truth
+stays on ImageAnnotator and future refactors that move state to a
+controller can re-route the accessor without changing ImageLabel.
+"""
+
+
+class CanvasContext:
+    def __init__(self, main_window):
+        self._mw = main_window
+
+    def paint_brush_size(self) -> int:
+        return self._mw.paint_brush_size
+
+    def eraser_size(self) -> int:
+        return self._mw.eraser_size
+
+    def current_class(self):
+        return self._mw.current_class
+
+    def class_id(self, name: str) -> int:
+        return self._mw.class_mapping[name]
+
+    def class_mapping(self) -> dict:
+        return self._mw.class_mapping
+
+    def is_class_visible(self, name: str) -> bool:
+        return self._mw.class_controller.is_class_visible(name)
+
+    def current_image_key(self):
+        return self._mw.current_slice or self._mw.image_file_name
+
+    def all_annotations(self) -> dict:
+        return self._mw.all_annotations
+
+    def scroll_area(self):
+        return self._mw.scroll_area
+
+    def dialog_parent(self):
+        return self._mw

--- a/src/digitalsreeni_image_annotator/widgets/image_label.py
+++ b/src/digitalsreeni_image_annotator/widgets/image_label.py
@@ -222,7 +222,6 @@ class ImageLabel(QLabel):
             contours, _ = cv2.findContours(
                 self.temp_paint_mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
             )
-            committed = False
             for contour in contours:
                 if cv2.contourArea(contour) > 10:  # Minimum area threshold
                     segmentation = contour.flatten().tolist()
@@ -233,10 +232,8 @@ class ImageLabel(QLabel):
                     }
                     self.annotations.setdefault(class_name, []).append(new_annotation)
                     self.annotationCommitted.emit(new_annotation)
-                    committed = True
             self.temp_paint_mask = None
-            if committed:
-                self.annotationsBatchSaved.emit()
+            self.annotationsBatchSaved.emit()
             self.update()
 
     def discard_paint_annotation(self):
@@ -412,7 +409,6 @@ class ImageLabel(QLabel):
         painter.restore()
 
     def accept_temp_annotations(self):
-        had_annotations = bool(self.temp_annotations)
         for annotation in self.temp_annotations:
             class_name = annotation["category_name"]
 
@@ -431,8 +427,7 @@ class ImageLabel(QLabel):
             self.annotationCommitted.emit(annotation)
 
         self.temp_annotations.clear()
-        if had_annotations:
-            self.annotationsBatchSaved.emit()
+        self.annotationsBatchSaved.emit()
         self.update()
 
     def discard_temp_annotations(self):

--- a/src/digitalsreeni_image_annotator/widgets/image_label.py
+++ b/src/digitalsreeni_image_annotator/widgets/image_label.py
@@ -14,7 +14,7 @@ import warnings
 import cv2
 import numpy as np
 from PIL import Image
-from PyQt6.QtCore import QPoint, QPointF, QRectF, QSize, Qt
+from PyQt6.QtCore import QPoint, QPointF, QRectF, QSize, Qt, pyqtSignal
 from PyQt6.QtGui import (
     QBrush,
     QColor,
@@ -39,6 +39,36 @@ class ImageLabel(QLabel):
     A custom QLabel for displaying images and handling annotations.
     """
 
+    # Annotation lifecycle
+    annotationCommitted = pyqtSignal(dict)              # paint / accept-temp per-annotation add
+    annotationsBatchSaved = pyqtSignal()                # batch finalizer: save + slice-color refresh
+    annotationsReplaced = pyqtSignal(str, dict)         # eraser path: (image_key, per-class dict)
+    annotationListUpdateRequested = pyqtSignal()        # editing-mode exit refresh
+    annotationSelected = pyqtSignal(object)             # double-click selection
+    deleteSelectionRequested = pyqtSignal()
+    finishPolygonRequested = pyqtSignal()
+    finishRectangleRequested = pyqtSignal()
+
+    # Class
+    classRequested = pyqtSignal(str)                    # accept-temp path needs a new class
+
+    # SAM
+    samPredictionRequested = pyqtSignal()               # debounced (mouse press)
+    samPredictionApplyRequested = pyqtSignal()          # post-debounce (mouse release)
+    samPredictionAccepted = pyqtSignal()                # Enter on temp prediction
+    samPointsCleared = pyqtSignal()                     # Escape during sam_points: stop timer
+
+    # Tool / UI state
+    enableToolsRequested = pyqtSignal()
+    disableToolsRequested = pyqtSignal()
+    resetToolButtonsRequested = pyqtSignal()
+    toolSizeChanged = pyqtSignal(str, int)              # ("paint" | "eraser", new_size)
+
+    # Navigation / info
+    zoomInRequested = pyqtSignal()
+    zoomOutRequested = pyqtSignal()
+    imageInfoChanged = pyqtSignal()
+
     def __init__(self, parent=None):
         super().__init__(parent)
         self.annotations = {}
@@ -56,7 +86,7 @@ class ImageLabel(QLabel):
         self.original_pixmap = None
         self.scaled_pixmap = None
         self.pan_start_pos = None
-        self.main_window = None
+        self._ctx = None
         self.offset_x = 0
         self.offset_y = 0
         self.drawing_polygon = False
@@ -91,8 +121,8 @@ class ImageLabel(QLabel):
         self.sam_positive_points = []
         self.sam_negative_points = []
 
-    def set_main_window(self, main_window):
-        self.main_window = main_window
+    def set_context(self, ctx):
+        self._ctx = ctx
 
     def set_dark_mode(self, is_dark):
         self.dark_mode = is_dark
@@ -122,8 +152,7 @@ class ImageLabel(QLabel):
                 else:
                     self.bit_depth = img.bits
 
-                if self.main_window:
-                    self.main_window.update_image_info()
+                self.imageInfoChanged.emit()
 
     def update_scaled_pixmap(self):
         if self.original_pixmap and not self.original_pixmap.isNull():
@@ -175,7 +204,7 @@ class ImageLabel(QLabel):
     def continue_painting(self, pos):
         if not self.is_painting:
             return
-        brush_size = self.main_window.paint_brush_size
+        brush_size = self._ctx.paint_brush_size()
         cv2.circle(
             self.temp_paint_mask, (int(pos[0]), int(pos[1])), brush_size, 255, -1
         )
@@ -188,24 +217,26 @@ class ImageLabel(QLabel):
         # Don't commit the annotation yet, just keep the temp_paint_mask
 
     def commit_paint_annotation(self):
-        if self.temp_paint_mask is not None and self.main_window.current_class:
-            class_name = self.main_window.current_class
+        if self.temp_paint_mask is not None and self._ctx.current_class():
+            class_name = self._ctx.current_class()
             contours, _ = cv2.findContours(
                 self.temp_paint_mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
             )
+            committed = False
             for contour in contours:
                 if cv2.contourArea(contour) > 10:  # Minimum area threshold
                     segmentation = contour.flatten().tolist()
                     new_annotation = {
                         "segmentation": segmentation,
-                        "category_id": self.main_window.class_mapping[class_name],
+                        "category_id": self._ctx.class_id(class_name),
                         "category_name": class_name,
                     }
                     self.annotations.setdefault(class_name, []).append(new_annotation)
-                    self.main_window.add_annotation_to_list(new_annotation)
+                    self.annotationCommitted.emit(new_annotation)
+                    committed = True
             self.temp_paint_mask = None
-            self.main_window.save_current_annotations()
-            self.main_window.update_slice_list_colors()
+            if committed:
+                self.annotationsBatchSaved.emit()
             self.update()
 
     def discard_paint_annotation(self):
@@ -224,7 +255,7 @@ class ImageLabel(QLabel):
     def continue_erasing(self, pos):
         if not self.is_erasing:
             return
-        eraser_size = self.main_window.eraser_size
+        eraser_size = self._ctx.eraser_size()
         cv2.circle(
             self.temp_eraser_mask, (int(pos[0]), int(pos[1])), eraser_size, 255, -1
         )
@@ -239,9 +270,7 @@ class ImageLabel(QLabel):
     def commit_eraser_changes(self):
         if self.temp_eraser_mask is not None:
             eraser_mask = self.temp_eraser_mask.astype(bool)
-            current_name = (
-                self.main_window.current_slice or self.main_window.image_file_name
-            )
+            current_name = self._ctx.current_image_key()
             annotations_changed = False
 
             for class_name, annotations in self.annotations.items():
@@ -284,14 +313,11 @@ class ImageLabel(QLabel):
 
             self.temp_eraser_mask = None
 
-            # Update the all_annotations dictionary in the main window
-            self.main_window.all_annotations[current_name] = self.annotations
-
-            # Call update_annotation_list directly
-            self.main_window.update_annotation_list()
-
-            self.main_window.save_current_annotations()
-            self.main_window.update_slice_list_colors()
+            # Emit one signal carrying the full per-class annotations
+            # dict; AnnotationController.replace_annotations writes it
+            # into all_annotations and triggers save + slice-color
+            # refresh atomically.
+            self.annotationsReplaced.emit(current_name, self.annotations)
             self.update()
 
             # print(f"Eraser changes committed. Annotations changed: {annotations_changed}")
@@ -386,12 +412,13 @@ class ImageLabel(QLabel):
         painter.restore()
 
     def accept_temp_annotations(self):
+        had_annotations = bool(self.temp_annotations)
         for annotation in self.temp_annotations:
             class_name = annotation["category_name"]
 
             # Check if the class exists, if not, add it
-            if class_name not in self.main_window.class_mapping:
-                self.main_window.add_class(class_name)
+            if class_name not in self._ctx.class_mapping():
+                self.classRequested.emit(class_name)
 
             if class_name not in self.annotations:
                 self.annotations[class_name] = []
@@ -401,11 +428,11 @@ class ImageLabel(QLabel):
                 "score"
             ]  # Remove the score as it's not needed in the final annotation
             self.annotations[class_name].append(annotation)
-            self.main_window.add_annotation_to_list(annotation)
+            self.annotationCommitted.emit(annotation)
 
         self.temp_annotations.clear()
-        self.main_window.save_current_annotations()
-        self.main_window.update_slice_list_colors()
+        if had_annotations:
+            self.annotationsBatchSaved.emit()
         self.update()
 
     def discard_temp_annotations(self):
@@ -461,10 +488,10 @@ class ImageLabel(QLabel):
             painter.scale(self.zoom_factor, self.zoom_factor)
 
             if self.current_tool == "paint_brush":
-                size = self.main_window.paint_brush_size
+                size = self._ctx.paint_brush_size()
                 color = QColor(255, 0, 0, 128)  # Semi-transparent red
             else:  # eraser
-                size = self.main_window.eraser_size
+                size = self._ctx.eraser_size()
                 color = QColor(0, 0, 255, 128)  # Semi-transparent blue
 
             # Draw filled circle with lower opacity
@@ -560,7 +587,7 @@ class ImageLabel(QLabel):
     def check_unsaved_changes(self):
         if self.temp_paint_mask is not None or self.temp_eraser_mask is not None:
             reply = QMessageBox.question(
-                self.main_window,
+                self._ctx.dialog_parent(),
                 "Unsaved Changes",
                 "You have unsaved changes. Do you want to save them?",
                 QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No | QMessageBox.StandardButton.Cancel,
@@ -611,7 +638,7 @@ class ImageLabel(QLabel):
         painter.scale(self.zoom_factor, self.zoom_factor)
 
         for class_name, class_annotations in self.annotations.items():
-            if not self.main_window.is_class_visible(class_name):
+            if not self._ctx.is_class_visible(class_name):
                 continue
 
             color = self.class_colors.get(class_name, QColor(Qt.GlobalColor.white))
@@ -716,7 +743,7 @@ class ImageLabel(QLabel):
         painter.scale(self.zoom_factor, self.zoom_factor)
 
         x1, y1, x2, y2 = self.current_rectangle
-        color = self.class_colors.get(self.main_window.current_class, QColor(Qt.GlobalColor.red))
+        color = self.class_colors.get(self._ctx.current_class(), QColor(Qt.GlobalColor.red))
         painter.setPen(QPen(color, 2 / self.zoom_factor, Qt.PenStyle.SolidLine))
         painter.drawRect(QRectF(float(x1), float(y1), float(x2 - x1), float(y2 - y1)))
 
@@ -789,16 +816,17 @@ class ImageLabel(QLabel):
             img_x = (cursor_widget_pos.x() - self.offset_x) / self.zoom_factor
             img_y = (cursor_widget_pos.y() - self.offset_y) / self.zoom_factor
 
-            scrollbar_h = self.main_window.scroll_area.horizontalScrollBar()
-            scrollbar_v = self.main_window.scroll_area.verticalScrollBar()
+            scroll_area = self._ctx.scroll_area()
+            scrollbar_h = scroll_area.horizontalScrollBar()
+            scrollbar_v = scroll_area.verticalScrollBar()
             old_scroll_h = scrollbar_h.value()
             old_scroll_v = scrollbar_v.value()
 
             delta = event.angleDelta().y()
             if delta > 0:
-                self.main_window.zoom_in()
+                self.zoomInRequested.emit()
             else:
-                self.main_window.zoom_out()
+                self.zoomOutRequested.emit()
 
             # Compute the post-zoom offset analytically from the
             # viewport size and the new scaled-pixmap size. Reading
@@ -807,7 +835,7 @@ class ImageLabel(QLabel):
             # widget hasn't shrunk yet when update_offset ran. self.width()
             # is stale → offset_x is wrong → cursor drifts. The viewport
             # width is always current.
-            viewport = self.main_window.scroll_area.viewport()
+            viewport = scroll_area.viewport()
             new_scaled_w = self.scaled_pixmap.width()
             new_scaled_h = self.scaled_pixmap.height()
             new_offset_x = max(0, (viewport.width() - new_scaled_w) / 2)
@@ -839,12 +867,12 @@ class ImageLabel(QLabel):
             if event.button() == Qt.MouseButton.LeftButton:
                 self.sam_positive_points.append(pos)
                 self.update()
-                self.main_window.schedule_sam_prediction()
+                self.samPredictionRequested.emit()
                 return
             elif event.button() == Qt.MouseButton.RightButton:
                 self.sam_negative_points.append(pos)
                 self.update()
-                self.main_window.schedule_sam_prediction()
+                self.samPredictionRequested.emit()
                 return
 
         if event.button() == Qt.MouseButton.LeftButton:
@@ -880,8 +908,9 @@ class ImageLabel(QLabel):
             if self.pan_start_pos:
                 cur = event.globalPosition()
                 delta = cur - self.pan_start_pos
-                scrollbar_h = self.main_window.scroll_area.horizontalScrollBar()
-                scrollbar_v = self.main_window.scroll_area.verticalScrollBar()
+                scroll_area = self._ctx.scroll_area()
+                scrollbar_h = scroll_area.horizontalScrollBar()
+                scrollbar_v = scroll_area.verticalScrollBar()
                 scrollbar_h.setValue(scrollbar_h.value() - int(delta.x()))
                 scrollbar_v.setValue(scrollbar_v.value() - int(delta.y()))
                 self.pan_start_pos = cur
@@ -935,7 +964,7 @@ class ImageLabel(QLabel):
                     self.sam_bbox[2] = pos[0]
                     self.sam_bbox[3] = pos[1]
                     self.drawing_sam_bbox = False
-                    self.main_window.apply_sam_prediction()
+                    self.samPredictionApplyRequested.emit()
                 elif (
                     self.sam_magic_wand_active
                     and self.drawing_sam_bbox
@@ -944,13 +973,13 @@ class ImageLabel(QLabel):
                     self.sam_bbox[2] = pos[0]
                     self.sam_bbox[3] = pos[1]
                     self.drawing_sam_bbox = False
-                    self.main_window.apply_sam_prediction()
+                    self.samPredictionApplyRequested.emit()
                 elif self.editing_polygon:
                     self.editing_point_index = None
                 elif self.current_tool == "rectangle" and self.drawing_rectangle:
                     self.drawing_rectangle = False
                     if self.current_rectangle:
-                        self.main_window.finish_rectangle()
+                        self.finishRectangleRequested.emit()
                 elif self.current_tool == "paint_brush":
                     self.finish_painting()
                 elif self.current_tool == "eraser":
@@ -968,7 +997,7 @@ class ImageLabel(QLabel):
                 self.clear_current_annotation()
                 annotation = self.start_polygon_edit(pos)
                 if annotation:
-                    self.main_window.select_annotation_in_list(annotation)
+                    self.annotationSelected.emit(annotation)
         self.update()
 
     def get_image_coordinates(self, pos):
@@ -987,13 +1016,13 @@ class ImageLabel(QLabel):
             if self.temp_annotations:
                 self.accept_temp_annotations()
             elif self.temp_sam_prediction:
-                self.main_window.accept_sam_prediction()
+                self.samPredictionAccepted.emit()
             elif self.editing_polygon:
                 self.editing_polygon = None
                 self.editing_point_index = None
                 self.hover_point_index = None
-                self.main_window.enable_tools()
-                self.main_window.update_annotation_list()
+                self.enableToolsRequested.emit()
+                self.annotationListUpdateRequested.emit()
             elif self.current_tool == "polygon" and self.drawing_polygon:
                 self.finish_polygon()
             elif self.current_tool == "paint_brush":
@@ -1004,7 +1033,7 @@ class ImageLabel(QLabel):
                 self.finish_current_annotation()
         elif event.key() == Qt.Key.Key_Escape:
             if self.sam_points_active:
-                self.main_window.sam_inference_timer.stop()
+                self.samPointsCleared.emit()
                 self.sam_positive_points = []
                 self.sam_negative_points = []
                 self.clear_temp_sam_prediction()
@@ -1021,7 +1050,7 @@ class ImageLabel(QLabel):
                 self.editing_polygon = None
                 self.editing_point_index = None
                 self.hover_point_index = None
-                self.main_window.enable_tools()
+                self.enableToolsRequested.emit()
             elif self.current_tool == "paint_brush":
                 self.discard_paint_annotation()
             elif self.current_tool == "eraser":
@@ -1030,28 +1059,30 @@ class ImageLabel(QLabel):
                 self.cancel_current_annotation()
         elif event.key() == Qt.Key.Key_Delete:
             if self.editing_polygon:
-                self.main_window.delete_selected_annotations()
+                self.deleteSelectionRequested.emit()
                 self.editing_polygon = None
                 self.editing_point_index = None
                 self.hover_point_index = None
-                self.main_window.enable_tools()
+                self.enableToolsRequested.emit()
                 self.update()
         elif event.key() == Qt.Key.Key_Minus:
             if self.current_tool == "paint_brush":
-                self.main_window.paint_brush_size = max(
-                    1, self.main_window.paint_brush_size - 1
-                )
-                print(f"Paint brush size: {self.main_window.paint_brush_size}")
+                new_size = max(1, self._ctx.paint_brush_size() - 1)
+                self.toolSizeChanged.emit("paint", new_size)
+                print(f"Paint brush size: {new_size}")
             elif self.current_tool == "eraser":
-                self.main_window.eraser_size = max(1, self.main_window.eraser_size - 1)
-                print(f"Eraser size: {self.main_window.eraser_size}")
+                new_size = max(1, self._ctx.eraser_size() - 1)
+                self.toolSizeChanged.emit("eraser", new_size)
+                print(f"Eraser size: {new_size}")
         elif event.key() == Qt.Key.Key_Equal:
             if self.current_tool == "paint_brush":
-                self.main_window.paint_brush_size += 1
-                print(f"Paint brush size: {self.main_window.paint_brush_size}")
+                new_size = self._ctx.paint_brush_size() + 1
+                self.toolSizeChanged.emit("paint", new_size)
+                print(f"Paint brush size: {new_size}")
             elif self.current_tool == "eraser":
-                self.main_window.eraser_size += 1
-                print(f"Eraser size: {self.main_window.eraser_size}")
+                new_size = self._ctx.eraser_size() + 1
+                self.toolSizeChanged.emit("eraser", new_size)
+                print(f"Eraser size: {new_size}")
         self.update()
 
     def cancel_current_annotation(self):
@@ -1065,15 +1096,13 @@ class ImageLabel(QLabel):
     def finish_current_annotation(self):
         """Finish the current annotation being created."""
         if self.current_tool == "polygon" and len(self.current_annotation) > 2:
-            if self.main_window:
-                self.main_window.finish_polygon()
+            self.finishPolygonRequested.emit()
 
     def finish_polygon(self):
         """Finish the current polygon annotation."""
         if self.drawing_polygon and len(self.current_annotation) > 2:
             self.drawing_polygon = False
-            if self.main_window:
-                self.main_window.finish_polygon()
+            self.finishPolygonRequested.emit()
 
     def start_polygon_edit(self, pos):
         for class_name, annotations in self.annotations.items():
@@ -1089,8 +1118,8 @@ class ImageLabel(QLabel):
                     if self.point_in_polygon(pos, points):
                         self.editing_polygon = annotation
                         self.current_tool = None
-                        self.main_window.disable_tools()
-                        self.main_window.reset_tool_buttons()
+                        self.disableToolsRequested.emit()
+                        self.resetToolButtonsRequested.emit()
                         return annotation
         return None
 


### PR DESCRIPTION
## Summary

Phase 6 of the modular refactor. Removes `ImageLabel.main_window` entirely — every direct call/state-read is replaced with either a `pyqtSignal` emission (writes) or a read through a narrow `CanvasContext` accessor (reads). The orchestrator wires every signal to a controller slot in `ImageAnnotator._connect_image_label_signals()`.

This is the "ambitious signal-driven" approach picked at the start of the refactor (vs. a protocol or deferred fix), and it's the prerequisite for Phase 7 (per-tool handler split inside `ImageLabel`).

## What changed

- **New** `widgets/canvas_context.py` — narrow read-only view of main-window state (10 method-style accessors: `paint_brush_size`, `eraser_size`, `current_class`, `class_id`, `class_mapping`, `is_class_visible`, `current_image_key`, `all_annotations`, `scroll_area`, `dialog_parent`).
- **`widgets/image_label.py`** — `self.main_window` field and `set_main_window()` removed. Added ~20 `pyqtSignal`s covering annotation lifecycle (committed / batch-saved / replaced / list-update / selected / delete / finish-polygon / finish-rectangle), class (`classRequested`), SAM (requested / apply / accepted / debounce-cleared), tool/UI state (enable / disable / reset / tool-size), navigation (zoom-in / zoom-out), and image-info changes. All ~50 prior `self.main_window.*` sites replaced.
- **`annotator_window.py`** — drops the old `set_main_window` call, constructs `CanvasContext(self)` after every controller is instantiated, and wires every ImageLabel signal in `_connect_image_label_signals()`. Two new thin slots: `_on_tool_size_changed` (brush/eraser size RMW) and `_on_annotations_batch_saved` (paint/accept-temp batch finalizer).
- **`controllers/annotation_controller.py`** — new `replace_annotations(image_key, dict)` for the eraser path (atomic replace + list update + save + slice-colour refresh).
- **`controllers/sam_controller.py`** — new `cancel_sam_debounce()` for the Escape-during-sam_points path.

## Invariants preserved

- **ADR-013** SAM re-entrancy guard (`_sam_inference_in_flight`) — untouched.
- **v0.9.0** pan/zoom invariants — `event.globalPosition()` for pan, `viewport().width()` for post-zoom offset.
- **DINO temp_annotations** single-field re-sync via `DINOController._refresh_dino_temp_for_current` — untouched.
- **`is_loading_project`** autosave guard — untouched.

## Documentation

- New ADR-016 in `docs/09_architecture_decisions.md` (rationale, rules for new traffic in either direction, synchronous-emit ordering, batch-save invariant).
- New "Canvas Decoupling" section in `docs/08_crosscutting_concepts.md`.
- `docs/11_risks_and_technical_debt.md`: "Tight Coupling Between ImageAnnotator and ImageLabel" marked Resolved.
- `docs/05_building_block_view.md`: dependency diagram updated.
- `CLAUDE.md`: "Adding a New Annotation Tool" — step 5 updated post-signal-refactor.

## Senior review

Ran the senior-reviewer agent: 0 P0s. 3 P1s (all doc updates per CLAUDE.md's in-PR rule) addressed in commit `b415c61`. 2 cleanup P2s addressed (drop the `committed`/`had_annotations` guards for literal semantic equivalence; rename `cancel_sam_prediction` → `cancel_sam_debounce`). Remaining nits skipped as scope creep / pre-existing.

## Test plan

- [x] `python -m pytest tests/ -x -q` — 94 / 94 pass
- [x] App boots; `image_label._ctx` is set; `image_label.main_window` no longer exists
- [ ] Manual: paint stroke commit → annotation appears + saved
- [ ] Manual: eraser stroke across polygon → cuts persist
- [ ] Manual: polygon draw + Enter, polygon edit (double-click) + Enter/Escape, rectangle draw
- [ ] Manual: SAM bbox + Enter; SAM points (rapid clicks → debounce + ADR-013 guard) + Enter; SAM Escape during sam_points
- [ ] Manual: DINO accept-temp creating a new class
- [ ] Manual: Brush size `-` / `=` updates sidebar; Ctrl+Wheel zoom-to-cursor still pixel-accurate
- [ ] Manual: Delete key on selected polygon; Dark mode toggle

## Diff size

| File | Δ |
|---|---:|
| `widgets/image_label.py` | +101 / −66 |
| `widgets/canvas_context.py` | +50 (new) |
| `annotator_window.py` | +57 / −2 |
| `controllers/annotation_controller.py` | +10 |
| `controllers/sam_controller.py` | +6 |
| Docs (5 files) | +144 / −16 |

https://claude.ai/code/session_01QxGci8QYbXHtV6BpoBLfAU

---
_Generated by [Claude Code](https://claude.ai/code/session_01QxGci8QYbXHtV6BpoBLfAU)_