### PR TITLE
docs(phase9): Refresh CLAUDE.md + arc42 to reflect the post-refactor architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ src/digitalsreeni_image_annotator/
 ├── io/                           # export_formats.py, import_formats.py
 ├── ui/                           # menu_bar, sidebar, shortcuts, theme, stylesheets
 └── dialogs/                      # Standalone tool dialogs (statistics,
-                                  #   splitter, augmenter, … 14 files)
+                                  #   splitter, augmenter, … 16 files)
 ```
 
 ## Key Classes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ python -m src.digitalsreeni_image_annotator.main
 
 Python 3.10+ | PyQt6 6.7+ | Ultralytics 8.3.27 (SAM 2) | NumPy | OpenCV | Shapely
 
-**Test suite**: `tests/` (pytest + pytest-qt). 65 tests pass on PyQt6.
+**Test suite**: `tests/` (pytest + pytest-qt). 94 tests pass on PyQt6.
 
 ## Documentation
 
@@ -40,23 +40,43 @@ See [docs/README.md](docs/README.md) for full documentation index.
 
 ```
 src/digitalsreeni_image_annotator/
-├── main.py                    # Entry point
-├── annotator_window.py        # ImageAnnotator - main window, project state
-├── image_label.py             # ImageLabel - display, mouse events, rendering
-├── sam_utils.py               # SAMUtils - SAM model management
-├── utils.py                   # Utility functions
-├── export_formats.py          # COCO, YOLO, Pascal VOC exporters
-├── import_formats.py          # COCO, YOLO importers
-└── [tool dialogs]             # Standalone utility windows
+├── main.py                       # Entry point
+├── annotator_window.py           # ImageAnnotator - thin orchestrator
+├── utils.py                      # Utility functions (calculate_area, …)
+├── __init__.py                   # Public API re-exports
+│
+├── core/                         # constants, annotation_utils, image_utils
+├── controllers/                  # 7 controllers (project, image, sam, dino,
+│                                 #   yolo, annotation, class) + io_controller
+├── widgets/
+│   ├── image_label.py            # ImageLabel canvas widget (dispatcher)
+│   ├── canvas_context.py         # CanvasContext read accessor (ADR-016)
+│   └── tools/                    # Per-tool handlers (ADR-017): rectangle,
+│                                 #   polygon, paint, eraser
+├── inference/                    # sam_utils.py, dino_utils.py
+├── io/                           # export_formats.py, import_formats.py
+├── ui/                           # menu_bar, sidebar, shortcuts, theme, stylesheets
+└── dialogs/                      # Standalone tool dialogs (statistics,
+                                  #   splitter, augmenter, … 14 files)
 ```
 
 ## Key Classes
 
 | Class | File | Responsibility |
 |-------|------|----------------|
-| `ImageAnnotator` | annotator_window.py | Main window, state (`all_annotations`, `class_mapping`, etc.) |
-| `ImageLabel` | image_label.py | Image display, zoom/pan, annotation interaction |
-| `SAMUtils` | sam_utils.py | Load SAM models, run inference |
+| `ImageAnnotator` | annotator_window.py | Thin orchestrator — holds controllers, wires signals, delegates almost everything |
+| `ImageLabel` | widgets/image_label.py | Canvas display, zoom/pan, event dispatch to tool handlers |
+| `CanvasContext` | widgets/canvas_context.py | Narrow read view of main-window state for ImageLabel (ADR-016) |
+| `ToolHandler` (+ 4 subclasses) | widgets/tools/ | Per-tool mouse/key handling (rectangle, polygon, paint, eraser) (ADR-017) |
+| `ProjectController` | controllers/project_controller.py | `.iap` save/load, auto-save, `is_loading_project` guard |
+| `ImageController` | controllers/image_controller.py | TIFF/CZI loading, multi-dim slicing, image/slice switching |
+| `AnnotationController` | controllers/annotation_controller.py | Annotation CRUD, sort, edit-mode, finish_polygon/rectangle |
+| `ClassController` | controllers/class_controller.py | Class add/delete/rename/colour/visibility |
+| `SAMController` | controllers/sam_controller.py | SAM model picker, debounce, in-flight guard (ADR-013) |
+| `DINOController` | controllers/dino_controller.py | DINO single/batch detection, batch review, temp-class workflow |
+| `YOLOController` | controllers/yolo_controller.py | YOLO training menu + prediction wiring |
+| `SAMUtils` | inference/sam_utils.py | Load SAM models, run inference |
+| `DINOUtils` | inference/dino_utils.py | Grounding-DINO model load + inference |
 
 See [Building Block View](docs/05_building_block_view.md) for detailed class documentation.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,8 +50,8 @@ src/digitalsreeni_image_annotator/
 │                                 #   yolo, annotation, class) + io_controller
 ├── widgets/
 │   ├── image_label.py            # ImageLabel canvas widget (dispatcher)
-│   ├── canvas_context.py         # CanvasContext read accessor (ADR-016)
-│   └── tools/                    # Per-tool handlers (ADR-017): rectangle,
+│   ├── canvas_context.py         # CanvasContext read accessor (ADR-018)
+│   └── tools/                    # Per-tool handlers (ADR-019): rectangle,
 │                                 #   polygon, paint, eraser
 ├── inference/                    # sam_utils.py, dino_utils.py
 ├── io/                           # export_formats.py, import_formats.py
@@ -66,8 +66,8 @@ src/digitalsreeni_image_annotator/
 |-------|------|----------------|
 | `ImageAnnotator` | annotator_window.py | Thin orchestrator — holds controllers, wires signals, delegates almost everything |
 | `ImageLabel` | widgets/image_label.py | Canvas display, zoom/pan, event dispatch to tool handlers |
-| `CanvasContext` | widgets/canvas_context.py | Narrow read view of main-window state for ImageLabel (ADR-016) |
-| `ToolHandler` (+ 4 subclasses) | widgets/tools/ | Per-tool mouse/key handling (rectangle, polygon, paint, eraser) (ADR-017) |
+| `CanvasContext` | widgets/canvas_context.py | Narrow read view of main-window state for ImageLabel (ADR-018) |
+| `ToolHandler` (+ 4 subclasses) | widgets/tools/ | Per-tool mouse/key handling (rectangle, polygon, paint, eraser) (ADR-019) |
 | `ProjectController` | controllers/project_controller.py | `.iap` save/load, auto-save, `is_loading_project` guard |
 | `ImageController` | controllers/image_controller.py | TIFF/CZI loading, multi-dim slicing, image/slice switching |
 | `AnnotationController` | controllers/annotation_controller.py | Annotation CRUD, sort, edit-mode, finish_polygon/rectangle |
@@ -90,7 +90,7 @@ See [Building Block View](docs/05_building_block_view.md) for detailed class doc
 4. Render in `ImageLabel.paintEvent()`
 5. Commit via `self.annotationCommitted.emit(annotation_dict)` — the
    orchestrator routes it to `AnnotationController.add_annotation_to_list`
-   (see ADR-016)
+   (see ADR-018)
 
 ### Working with Annotations
 
@@ -163,7 +163,7 @@ See [Runtime View](docs/06_runtime_view.md#multi-dimensional-image-loading) for 
 | Dark mode contrast | No hardcoded `background:` / `color:` in widget `setStyleSheet(...)` | Hardcoded greys override `soft_dark_stylesheet.py` and punch bright boxes into the sidebar. Add a global rule first, then write the widget. See [No Hardcoded Colors Rule](docs/08_crosscutting_concepts.md#dark-mode--no-hardcoded-colors-rule). |
 | DINO review state | `image_label.temp_annotations` is a single field, **not** per-image — must be re-synced from `dino_batch_results` on every image/slice switch via `_refresh_dino_temp_for_current` | Otherwise the first image's masks bleed onto every subsequent slice during navigation. See [DINO Temp Annotations](docs/08_crosscutting_concepts.md#dino-temp-annotations--single-field-many-images). |
 | DINO batch over stacks | Use `_collect_dino_batch_work_items()` to flatten regular images + every loaded slice; don't iterate `self.all_images` directly | Multi-dim images appear in `all_images` as a single entry — slices live in `self.image_slices[base_name]` and were silently skipped. |
-| DINO Enter/Escape during review | Application-wide `_DINOReviewEventFilter`, gated on pending temp_annotations + no modal + no text input | `QListWidget` consumes Enter for `itemActivated` before `ImageLabel.keyPressEvent` sees it. See [ADR-015](docs/09_architecture_decisions.md#adr-015-application-wide-event-filter-for-dino-review-shortcuts). |
+| DINO Enter/Escape during review | Application-wide `DINOReviewEventFilter`, gated on pending temp_annotations + no modal + no text input | `QListWidget` consumes Enter for `itemActivated` before `ImageLabel.keyPressEvent` sees it. See [ADR-015](docs/09_architecture_decisions.md#adr-015-application-wide-event-filter-for-dino-review-shortcuts). |
 | Auto-accept dropdown | Honored by **both** `run_dino_detection_single` and `run_dino_detection_batch` | Easy to forget in the single path because the combo is labeled "batch". |
 | GPU model unload | `model.cpu()` → `gc.collect()` → `torch.cuda.empty_cache()` + `ipc_collect()` + `synchronize()` — full reclaim requires app restart due to per-process CUDA context | Setting refs to None alone leaves circular refs pinned and shows zero Task Manager drop. See [Releasing Model GPU Memory](docs/08_crosscutting_concepts.md#releasing-model-gpu-memory). |
 | Export image-path lookup | Exact-key match first, substring fallback only | `"bee.jpg" in "honeybee.jpg"` is True — substring-only matching writes the wrong file. See [Export Format Filename Matching](docs/08_crosscutting_concepts.md#export-format-filename-matching). |

--- a/README.md
+++ b/README.md
@@ -128,9 +128,8 @@ You should see `True` and your GPU name. For other platforms or driver combinati
    - To use SAM2-assisted annotation:
      - Select a model from the "Pick a SAM Model" dropdown. It's recommended to use smaller models like SAM2 tiny or SAM2 small. SAM2 large is not recommended as it may crash the application on systems with limited resources.
      - Note: When you select a model for the first time, the application needs to download it. This process may take a few seconds to a minute, depending on your internet connection speed. Subsequent uses of the same model will be faster as it will already be cached locally, in your working directory.
-     - Click the "SAM-Assisted" button to activate the tool.
-     - Draw a rectangle around objects of interest to allow SAM2 to automatically detect objects.
-     - Note that SAM2 provides various outputs with different scores, and only the top-scoring region will be displayed. If the desired result isn't achieved on the first try, draw again.
+     - Click the "SAM-box" button and draw a rectangle around an object of interest, or click the "SAM-points" button and left-click points inside the object (right-click adds negative points to exclude regions).
+     - SAM2 displays the top-scoring mask as a temporary prediction — press Enter to accept it or Esc to discard it. If the desired result isn't achieved on the first try, draw the box again or adjust the points.
      - For low-quality images where SAM2 may not auto-detect objects, manual tools may be necessary.
      - When SAM2 auto-detect partial objects, use polygon or paint brush tools to manually define the remaining region and use the Merge tool to combine both annotations into one.
      - When SAM2 over-annotates objects, extending the annotation beyond object's boundaries, use the Eraser tool to clean up the edges.

--- a/docs/05_building_block_view.md
+++ b/docs/05_building_block_view.md
@@ -184,6 +184,30 @@ DINO's xyxy boxes feed directly into `SAMUtils.apply_sam_predictions_batch()`,
 which returns segmentation polygons (xywh bbox is derived from the polygon at
 export time — see [Cross-cutting Concepts](08_crosscutting_concepts.md)).
 
+## Level 3: Controllers
+
+The seven `controllers/*` modules carve `ImageAnnotator` into
+single-responsibility owners that the orchestrator delegates to.
+Pattern: each controller is a `QObject` subclass holding `self.mw =
+main_window`. The orchestrator keeps thin pass-through methods so
+external call sites (menus, signal wiring, the test harness) don't
+need to reach into the controller graph.
+
+| Controller | Responsibility |
+|------------|----------------|
+| `ProjectController` | `.iap` save/load, auto-save, backup/restore, missing-image prompts, window-title sync. Owns the `is_loading_project` autosave guard (load/save round-trip safety, v0.8.12). |
+| `ImageController` | Open / load / switch images and slices. TIFF + CZI loaders, the multi-dim `DimensionDialog`, the `[-ndim:]` axis-slice bug fix from the v0.9.0 era. |
+| `AnnotationController` | Annotation CRUD, list sorting, highlight, edit-mode entry/exit, `finish_polygon`, `finish_rectangle`, `replace_annotations` (eraser path). Validates writes before mutating `all_annotations`. |
+| `ClassController` | Class add / delete / rename / colour / visibility. `update_slice_list_colors`, `is_class_visible`. |
+| `SAMController` | Magic-wand activation, debounce timer, `_sam_inference_in_flight` re-entrancy guard (ADR-013), model picker. |
+| `DINOController` | Single + batch detection, batch review navigation, temp-annotation accept/reject, custom-model browse, `DINOReviewEventFilter` ownership (ADR-015). |
+| `YOLOController` | Training menu, `TrainingThread`, prediction dialog, result processing. |
+| `io_controller` *(module-level functions, not a class)* | Thin UI wrappers around the pure `io/export_formats.py` and `io/import_formats.py` modules. |
+
+Communication: `ImageLabel` does not import controllers directly —
+it emits Qt signals (ADR-016) that the orchestrator connects to
+controller slots in `_connect_image_label_signals()`.
+
 ## Level 3: Export/Import Subsystem
 
 ### Export Formats (export_formats.py)

--- a/docs/05_building_block_view.md
+++ b/docs/05_building_block_view.md
@@ -82,7 +82,7 @@ current_slice: str                  # Currently displayed slice
 **Responsibility**: Canvas widget — image display, navigation
 (zoom/pan), committed-annotation rendering, SAM bbox/points overlays,
 DINO temp-annotation rendering, polygon edit mode (modal). Per-tool
-mouse/key handling lives in `widgets/tools/*` (see ADR-017); ImageLabel
+mouse/key handling lives in `widgets/tools/*` (see ADR-019); ImageLabel
 dispatches events to the active handler.
 
 **Key Attributes**:
@@ -99,7 +99,7 @@ sam_positive_points: list           # SAM positive points
 sam_negative_points: list           # SAM negative points
 editing_polygon: dict | None        # Polygon being edited (modal sub-state)
 _tools: dict[str, ToolHandler]      # Per-tool handlers
-_ctx: CanvasContext                 # Narrow read view of main-window state (ADR-016)
+_ctx: CanvasContext                 # Narrow read view of main-window state (ADR-018)
 ```
 
 **Key Methods**:
@@ -120,7 +120,7 @@ _ctx: CanvasContext                 # Narrow read view of main-window state (ADR
   and prompts the user.
 
 **Communication**: emits ~20 Qt signals connected to controller slots
-in `ImageAnnotator._connect_image_label_signals` (ADR-016). Reads
+in `ImageAnnotator._connect_image_label_signals` (ADR-018). Reads
 main-window state through `CanvasContext`.
 
 ### SAMUtils (sam_utils.py)
@@ -216,7 +216,7 @@ the controller graph.
 | `io_controller` *(module-level functions, not a class)* | Thin UI wrappers around the pure `io/export_formats.py` and `io/import_formats.py` modules. |
 
 Communication: `ImageLabel` does not import controllers directly —
-it emits Qt signals (ADR-016) that the orchestrator connects to
+it emits Qt signals (ADR-018) that the orchestrator connects to
 controller slots in `_connect_image_label_signals()`.
 
 ## Level 3: Export/Import Subsystem
@@ -342,7 +342,7 @@ ImageAnnotator (main window)
     └── launches ──> Tool Dialogs (utilities)
 
 ImageLabel
-    ├── emits signals to ──> ImageAnnotator (writes; see ADR-016)
+    ├── emits signals to ──> ImageAnnotator (writes; see ADR-018)
     ├── reads via ──> CanvasContext (paint/eraser size, current class,
     │                  class_mapping, is_class_visible, scroll_area, …)
     └── uses ──> utils (area, bbox calculations)

--- a/docs/05_building_block_view.md
+++ b/docs/05_building_block_view.md
@@ -41,6 +41,7 @@ src/digitalsreeni_image_annotator/
 │       ├── paint_tool.py
 │       └── eraser_tool.py
 ├── controllers/                   # Project/Image/SAM/DINO/YOLO/Annotation/Class
+│                                  # + io_controller helpers
 ├── inference/                     # sam_utils.py, dino_utils.py
 ├── io/                            # export_formats.py, import_formats.py
 ├── ui/                            # menu_bar, sidebar, shortcuts, theme, stylesheets
@@ -186,12 +187,15 @@ export time — see [Cross-cutting Concepts](08_crosscutting_concepts.md)).
 
 ## Level 3: Controllers
 
-The seven `controllers/*` modules carve `ImageAnnotator` into
-single-responsibility owners that the orchestrator delegates to.
-Pattern: each controller is a `QObject` subclass holding `self.mw =
-main_window`. The orchestrator keeps thin pass-through methods so
-external call sites (menus, signal wiring, the test harness) don't
-need to reach into the controller graph.
+Seven `QObject` controllers plus an `io_controller` helper module
+carve `ImageAnnotator` into single-responsibility owners that the
+orchestrator delegates to. Each `QObject` controller holds `self.mw
+= main_window` and owns one slice of behaviour; the
+`io_controller` is a thin module of UI-wrapper functions around the
+pure `io/` formatters and does not need to hold state. The
+orchestrator keeps pass-through methods so external call sites
+(menus, signal wiring, the test harness) don't need to reach into
+the controller graph.
 
 | Controller | Responsibility |
 |------------|----------------|

--- a/docs/05_building_block_view.md
+++ b/docs/05_building_block_view.md
@@ -108,7 +108,7 @@ _ctx: CanvasContext                 # Narrow read view of main-window state (ADR
   then SAM/edit-mode branches, then dispatch to
   `active_tool_handler.on_mouse_X()`.
 - `keyPressEvent()`: Enter / Escape / Delete / brush-size keys. Modal
-  branches (DINO temp, sam_points, editing_polygon, sam_magic_wand)
+  branches (DINO temp, sam_points, sam_box, editing_polygon)
   consume first; otherwise routed to `handler.on_enter()` /
   `on_escape()`.
 - `paintEvent()`: image → committed annotations → editing polygon →
@@ -210,7 +210,7 @@ the controller graph.
 | `ImageController` | Open / load / switch images and slices. TIFF + CZI loaders, the multi-dim `DimensionDialog`, the `[-ndim:]` axis-slice bug fix from the v0.9.0 era. |
 | `AnnotationController` | Annotation CRUD, list sorting, highlight, edit-mode entry/exit, `finish_polygon`, `finish_rectangle`, `replace_annotations` (eraser path). Validates writes before mutating `all_annotations`. |
 | `ClassController` | Class add / delete / rename / colour / visibility. `update_slice_list_colors`, `is_class_visible`. |
-| `SAMController` | Magic-wand activation, debounce timer, `_sam_inference_in_flight` re-entrancy guard (ADR-013), model picker. |
+| `SAMController` | SAM box/points tool lifecycle, debounce timer, `_sam_inference_in_flight` re-entrancy guard (ADR-013), model picker. |
 | `DINOController` | Single + batch detection, batch review navigation, temp-annotation accept/reject, custom-model browse, `DINOReviewEventFilter` ownership (ADR-015). |
 | `YOLOController` | Training menu, `TrainingThread`, prediction dialog, result processing. |
 | `io_controller` *(module-level functions, not a class)* | Thin UI wrappers around the pure `io/export_formats.py` and `io/import_formats.py` modules. |

--- a/docs/06_runtime_view.md
+++ b/docs/06_runtime_view.md
@@ -66,7 +66,7 @@ User presses Enter
     └─> update() to show final annotation
 ```
 
-## SAM-Assisted Annotation
+## SAM-Assisted Annotation (SAM-box / SAM-points)
 
 ```
 User selects SAM model

--- a/docs/08_crosscutting_concepts.md
+++ b/docs/08_crosscutting_concepts.md
@@ -491,7 +491,7 @@ before the subsequent class lookup.
 `annotationCommitted` per annotation but `annotationsBatchSaved` only
 once at the end. The single batch save preserves O(1) `.iap` writes
 per user action; replacing it with a per-annotation save would turn
-paint commits into O(N). See ADR-016.
+paint commits into O(N). See ADR-018.
 
-See ADR-016 in `09_architecture_decisions.md` for the rationale and
+See ADR-018 in `09_architecture_decisions.md` for the rationale and
 the full pattern.

--- a/docs/09_architecture_decisions.md
+++ b/docs/09_architecture_decisions.md
@@ -535,8 +535,8 @@ the architectural-smell note below.
 **What stays on `ImageLabel` (intentional non-extraction)**:
 
 - Navigation (zoom, pan, offset, scaled pixmap) — cross-cutting.
-- SAM bbox / points / magic-wand state — activates from any tool via
-  the magic-wand toggle, cuts across the main tools.
+- SAM bbox / points state — activates from any tool via the SAM-box /
+  SAM-points toggles, cuts across the main tools.
 - Polygon edit mode (`editing_polygon`, `handle_editing_click`,
   `handle_editing_move`, `draw_editing_polygon`) — modal state
   orthogonal to tool selection; sets `current_tool = None` while

--- a/docs/11_risks_and_technical_debt.md
+++ b/docs/11_risks_and_technical_debt.md
@@ -85,26 +85,34 @@
 
 ## Technical Debt
 
-### No Automated Tests
+### Low Test Coverage of Interactive Paths
 
-**Debt Level**: High
+**Debt Level**: Medium
 
-**Description**: Zero unit tests, integration tests, or UI tests
+**Description**: A pytest + pytest-qt suite of 94 tests now exists
+(boot smoke, coordinate conversions, export-format round-trips,
+utility functions). Coverage is ~15% by line — the gap is the
+canvas event flow (mouse events → tool handler → signal emission →
+controller slot) and the SAM/DINO/YOLO inference paths.
 
 **Impact**:
-- High risk of regressions
-- Refactoring is dangerous
-- Manual testing burden
-- Slow development velocity
+- Phase 6/7/8 refactors had to lean on manual QA checklists for the
+  canvas flow because no automated test exercises it end-to-end.
+- Inference paths are exercised only via the smoke boot, not under
+  real model loads (those would slow CI prohibitively).
 
-**Effort to Resolve**: High (months)
+**Effort to Resolve**: Medium
 
 **Priority**: Medium
 
 **Plan**:
-1. Add unit tests for utility functions first (low-hanging fruit)
-2. Add integration tests for export/import
-3. Consider pytest-qt for critical UI flows
+1. Per-tool unit tests under `widgets/tools/` — each handler can be
+   tested by instantiating with a stub `label` carrying signals
+   and a fake `CanvasContext`, then feeding `QMouseEvent`s.
+2. Integration test that loads a tiny project, draws a polygon,
+   asserts the `.iap` round-trip restores state.
+3. Mock SAMUtils / DINOUtils inference returns to exercise the
+   controller signal paths without needing model weights.
 
 ---
 

--- a/docs/11_risks_and_technical_debt.md
+++ b/docs/11_risks_and_technical_debt.md
@@ -196,7 +196,7 @@ read goes through a narrow `CanvasContext` accessor.
 signals (annotation lifecycle, SAM, class, tool/UI state, navigation);
 the orchestrator wires each to the matching controller slot.
 
-**ADR**: see ADR-016 in `09_architecture_decisions.md`.
+**ADR**: see ADR-018 in `09_architecture_decisions.md`.
 
 ---
 

--- a/docs/12_glossary.md
+++ b/docs/12_glossary.md
@@ -69,13 +69,13 @@ You Only Look Once - object detection format. Uses `.txt` files with normalized 
 A series of 2D images taken at different focal depths (Z positions), used in microscopy to capture 3D structure.
 
 ### CanvasContext
-Narrow read-only view of main-window state exposed to `ImageLabel`. Introduced in Phase 6 (ADR-016) to replace the old `image_label.main_window` back-reference. Method-style accessors (`paint_brush_size()`, `current_class()`, `is_class_visible(name)`, `scroll_area()`, …) so future state migrations can re-route reads without touching the widget. Constructed once in `ImageAnnotator.__init__` and passed via `image_label.set_context(ctx)`.
+Narrow read-only view of main-window state exposed to `ImageLabel`. Introduced in Phase 6 (ADR-018) to replace the old `image_label.main_window` back-reference. Method-style accessors (`paint_brush_size()`, `current_class()`, `is_class_visible(name)`, `scroll_area()`, …) so future state migrations can re-route reads without touching the widget. Constructed once in `ImageAnnotator.__init__` and passed via `image_label.set_context(ctx)`.
 
 ### Controller
 Architectural pattern used across `controllers/*`. A controller is a `QObject` subclass holding `self.mw = main_window` that owns a single responsibility cluster carved out of the old monolithic `ImageAnnotator` — project I/O, image loading, annotations, classes, SAM, DINO, or YOLO. The orchestrator delegates to the controllers via thin pass-through methods, keeping external entry points (menu actions, signal connections) stable across refactors. Seven controllers exist as of Phase 8.
 
 ### ToolHandler
-Base class for per-tool mouse / key / paint behaviour inside `ImageLabel`. Plain Python object (not a `QObject`); holds a back-reference to the widget for signal emission and `CanvasContext` reads. Subclasses (`RectangleTool`, `PolygonTool`, `PaintBrushTool`, `EraserTool`) live in `widgets/tools/` and are dispatched to by `ImageLabel.active_tool_handler`. Introduced in Phase 7 (ADR-017).
+Base class for per-tool mouse / key / paint behaviour inside `ImageLabel`. Plain Python object (not a `QObject`); holds a back-reference to the widget for signal emission and `CanvasContext` reads. Subclasses (`RectangleTool`, `PolygonTool`, `PaintBrushTool`, `EraserTool`) live in `widgets/tools/` and are dispatched to by `ImageLabel.active_tool_handler`. Introduced in Phase 7 (ADR-019).
 
 ### Tool subclasses (`RectangleTool`, `PolygonTool`, `PaintBrushTool`, `EraserTool`)
 Concrete `ToolHandler` implementations, one per mouse-driven annotation tool. Each overrides the event hooks defined on the base class (`on_mouse_press`, `on_mouse_move`, `on_mouse_release`, `on_double_click`, `on_enter`, `on_escape`, `paint_overlay`, `deactivate`) and participates in the `has_unsaved_state()` / `commit()` / `discard()` contract used by the `check_unsaved_changes` dialog.
@@ -127,8 +127,8 @@ Functions under `ui/` that construct widget trees at startup. Each takes the `Im
 |-------|--------|-------------|
 | `ImageAnnotator` | annotator_window.py | Thin orchestrator (QMainWindow). Holds controllers, wires signals, delegates almost everything. |
 | `ImageLabel` | widgets/image_label.py | Canvas widget — display, zoom/pan, event dispatch to tool handlers. |
-| `CanvasContext` | widgets/canvas_context.py | Narrow read view of main-window state for ImageLabel (ADR-016). |
-| `ToolHandler` | widgets/tools/base.py | Base class for per-tool mouse/key handlers (ADR-017). |
+| `CanvasContext` | widgets/canvas_context.py | Narrow read view of main-window state for ImageLabel (ADR-018). |
+| `ToolHandler` | widgets/tools/base.py | Base class for per-tool mouse/key handlers (ADR-019). |
 | `RectangleTool` / `PolygonTool` / `PaintBrushTool` / `EraserTool` | widgets/tools/ | Per-tool handler subclasses. |
 | `ProjectController` | controllers/project_controller.py | `.iap` save/load, auto-save, `is_loading_project` guard. |
 | `ImageController` | controllers/image_controller.py | TIFF/CZI loading, multi-dim slicing, image/slice switching. |

--- a/docs/12_glossary.md
+++ b/docs/12_glossary.md
@@ -78,7 +78,7 @@ Architectural pattern used across `controllers/*`. A controller is a `QObject` s
 Base class for per-tool mouse / key / paint behaviour inside `ImageLabel`. Plain Python object (not a `QObject`); holds a back-reference to the widget for signal emission and `CanvasContext` reads. Subclasses (`RectangleTool`, `PolygonTool`, `PaintBrushTool`, `EraserTool`) live in `widgets/tools/` and are dispatched to by `ImageLabel.active_tool_handler`. Introduced in Phase 7 (ADR-017).
 
 ### Tool subclasses (`RectangleTool`, `PolygonTool`, `PaintBrushTool`, `EraserTool`)
-Concrete `ToolHandler` implementations, one per mouse-driven annotation tool. Each owns its event hooks (`on_mouse_press`, `on_mouse_move`, `on_mouse_release`, `on_enter`, `on_escape`, `paint_overlay`) and an `has_unsaved_state()` / `commit()` / `discard()` contract for the `check_unsaved_changes` dialog.
+Concrete `ToolHandler` implementations, one per mouse-driven annotation tool. Each overrides the event hooks defined on the base class (`on_mouse_press`, `on_mouse_move`, `on_mouse_release`, `on_double_click`, `on_enter`, `on_escape`, `paint_overlay`, `deactivate`) and participates in the `has_unsaved_state()` / `commit()` / `discard()` contract used by the `check_unsaved_changes` dialog.
 
 ### UI builders (`build_menu_bar`, `build_sidebar`, `build_image_area`, `build_image_list`)
 Functions under `ui/` that construct widget trees at startup. Each takes the `ImageAnnotator` instance as `window`, attaches widgets as `window.X = QWidget(...)` so other modules can read them, and wires signals to `window.<method>` delegate methods. Replaced the equivalent `setup_*` methods on `ImageAnnotator` in Phase 8.

--- a/docs/12_glossary.md
+++ b/docs/12_glossary.md
@@ -68,6 +68,21 @@ You Only Look Once - object detection format. Uses `.txt` files with normalized 
 ### Z-Stack
 A series of 2D images taken at different focal depths (Z positions), used in microscopy to capture 3D structure.
 
+### CanvasContext
+Narrow read-only view of main-window state exposed to `ImageLabel`. Introduced in Phase 6 (ADR-016) to replace the old `image_label.main_window` back-reference. Method-style accessors (`paint_brush_size()`, `current_class()`, `is_class_visible(name)`, `scroll_area()`, …) so future state migrations can re-route reads without touching the widget. Constructed once in `ImageAnnotator.__init__` and passed via `image_label.set_context(ctx)`.
+
+### Controller
+Architectural pattern used across `controllers/*`. A controller is a `QObject` subclass holding `self.mw = main_window` that owns a single responsibility cluster carved out of the old monolithic `ImageAnnotator` — project I/O, image loading, annotations, classes, SAM, DINO, or YOLO. The orchestrator delegates to the controllers via thin pass-through methods, keeping external entry points (menu actions, signal connections) stable across refactors. Seven controllers exist as of Phase 8.
+
+### ToolHandler
+Base class for per-tool mouse / key / paint behaviour inside `ImageLabel`. Plain Python object (not a `QObject`); holds a back-reference to the widget for signal emission and `CanvasContext` reads. Subclasses (`RectangleTool`, `PolygonTool`, `PaintBrushTool`, `EraserTool`) live in `widgets/tools/` and are dispatched to by `ImageLabel.active_tool_handler`. Introduced in Phase 7 (ADR-017).
+
+### Tool subclasses (`RectangleTool`, `PolygonTool`, `PaintBrushTool`, `EraserTool`)
+Concrete `ToolHandler` implementations, one per mouse-driven annotation tool. Each owns its event hooks (`on_mouse_press`, `on_mouse_move`, `on_mouse_release`, `on_enter`, `on_escape`, `paint_overlay`) and an `has_unsaved_state()` / `commit()` / `discard()` contract for the `check_unsaved_changes` dialog.
+
+### UI builders (`build_menu_bar`, `build_sidebar`, `build_image_area`, `build_image_list`)
+Functions under `ui/` that construct widget trees at startup. Each takes the `ImageAnnotator` instance as `window`, attaches widgets as `window.X = QWidget(...)` so other modules can read them, and wires signals to `window.<method>` delegate methods. Replaced the equivalent `setup_*` methods on `ImageAnnotator` in Phase 8.
+
 ## Acronyms
 
 | Acronym | Full Term |
@@ -110,12 +125,24 @@ A series of 2D images taken at different focal depths (Z positions), used in mic
 
 | Class | Module | Description |
 |-------|--------|-------------|
-| `ImageAnnotator` | annotator_window.py | Main application window (QMainWindow) |
-| `ImageLabel` | image_label.py | Custom QLabel for image display and interaction |
-| `SAMUtils` | sam_utils.py | SAM model loading and inference |
-| `DimensionDialog` | annotator_window.py | Dialog for assigning dimensions to stacks |
-| `TrainingThread` | annotator_window.py | Background thread for YOLO training |
-| `YOLOTrainer` | yolo_trainer.py | YOLO model training and prediction |
+| `ImageAnnotator` | annotator_window.py | Thin orchestrator (QMainWindow). Holds controllers, wires signals, delegates almost everything. |
+| `ImageLabel` | widgets/image_label.py | Canvas widget — display, zoom/pan, event dispatch to tool handlers. |
+| `CanvasContext` | widgets/canvas_context.py | Narrow read view of main-window state for ImageLabel (ADR-016). |
+| `ToolHandler` | widgets/tools/base.py | Base class for per-tool mouse/key handlers (ADR-017). |
+| `RectangleTool` / `PolygonTool` / `PaintBrushTool` / `EraserTool` | widgets/tools/ | Per-tool handler subclasses. |
+| `ProjectController` | controllers/project_controller.py | `.iap` save/load, auto-save, `is_loading_project` guard. |
+| `ImageController` | controllers/image_controller.py | TIFF/CZI loading, multi-dim slicing, image/slice switching. |
+| `AnnotationController` | controllers/annotation_controller.py | Annotation CRUD, sort, edit-mode, finish_polygon/rectangle. |
+| `ClassController` | controllers/class_controller.py | Class add/delete/rename/colour/visibility. |
+| `SAMController` | controllers/sam_controller.py | SAM model picker + debounce + ADR-013 re-entrancy guard. |
+| `DINOController` | controllers/dino_controller.py | DINO single + batch detection, batch review, temp-class workflow. |
+| `YOLOController` | controllers/yolo_controller.py | YOLO training menu + prediction wiring. |
+| `SAMUtils` | inference/sam_utils.py | SAM model loading and inference. |
+| `DINOUtils` | inference/dino_utils.py | Grounding-DINO model loading and inference. |
+| `DimensionDialog` | controllers/image_controller.py | Dialog for assigning dimensions to multi-dim stacks. |
+| `TrainingThread` | controllers/yolo_controller.py | Background thread for YOLO training. |
+| `YOLOTrainer` | dialogs/yolo_trainer.py | YOLO model training and prediction dialog. |
+| `DINOReviewEventFilter` | controllers/dino_controller.py | App-wide Enter/Escape filter during DINO review (ADR-015). |
 
 ## Data Structure Keys
 

--- a/src/digitalsreeni_image_annotator/annotator_window.py
+++ b/src/digitalsreeni_image_annotator/annotator_window.py
@@ -323,17 +323,8 @@ class ImageAnnotator(QMainWindow):
     def load_multi_slice_image(self, image_path, dimensions=None, shape=None):
         return self.image_controller.load_multi_slice_image(image_path, dimensions, shape)
 
-    def activate_sam_magic_wand(self):
-        return self.sam_controller.activate_sam_magic_wand()
-
-    def deactivate_sam_magic_wand(self):
-        return self.sam_controller.deactivate_sam_magic_wand()
-
-    def toggle_sam_assisted(self):
-        return self.sam_controller.toggle_sam_assisted()
-
-    def toggle_sam_magic_wand(self):
-        return self.sam_controller.toggle_sam_magic_wand()
+    def deactivate_sam_tools(self):
+        return self.sam_controller.deactivate_sam_tools()
 
     def schedule_sam_prediction(self):
         return self.sam_controller.schedule_sam_prediction()
@@ -776,9 +767,6 @@ class ImageAnnotator(QMainWindow):
         self.image_label.set_active_tool(None)
         self.polygon_button.setChecked(False)
         self.rectangle_button.setChecked(False)
-        self.sam_magic_wand_button.setChecked(False)
-        self.sam_magic_wand_button.setEnabled(False)  # Disable the SAM-Assisted button
-        self.image_label.sam_magic_wand_active = False  # Deactivate SAM magic wand
 
         # Reset SAM-related attributes
         self.image_label.sam_bbox = None
@@ -919,7 +907,7 @@ class ImageAnnotator(QMainWindow):
 
         sender = self.sender()
         if sender is None:
-            sender = self.sam_magic_wand_button
+            return
 
         if not self.current_class:
             QMessageBox.warning(
@@ -941,13 +929,6 @@ class ImageAnnotator(QMainWindow):
 
         other_buttons = [btn for btn in self.tool_group.buttons() if btn != sender]
 
-        # Deactivate SAM if we're switching to a different tool
-        if (
-            sender != self.sam_magic_wand_button
-            and self.image_label.sam_magic_wand_active
-        ):
-            self.deactivate_sam_magic_wand()
-
         if sender.isChecked():
             # Uncheck all other buttons
             for btn in other_buttons:
@@ -958,9 +939,6 @@ class ImageAnnotator(QMainWindow):
                 self.image_label.set_active_tool("polygon")
             elif sender == self.rectangle_button:
                 self.image_label.set_active_tool("rectangle")
-            elif sender == self.sam_magic_wand_button:
-                self.image_label.set_active_tool("sam_magic_wand")
-                self.activate_sam_magic_wand()
             elif sender == self.paint_brush_button:
                 self.image_label.set_active_tool("paint_brush")
                 self.image_label.setFocus()  # Set focus on the image label
@@ -969,8 +947,6 @@ class ImageAnnotator(QMainWindow):
                 self.image_label.setFocus()  # Set focus on the image label
         else:
             self.image_label.set_active_tool(None)
-            if sender == self.sam_magic_wand_button:
-                self.deactivate_sam_magic_wand()
 
         # Update UI based on the current tool
         self.update_ui_for_current_tool()
@@ -997,12 +973,6 @@ class ImageAnnotator(QMainWindow):
         # Update button states
         self.polygon_button.setChecked(self.image_label.current_tool == "polygon")
         self.rectangle_button.setChecked(self.image_label.current_tool == "rectangle")
-        self.sam_magic_wand_button.setChecked(
-            self.image_label.current_tool == "sam_magic_wand"
-        )
-
-        # Enable/disable SAM button based on model availability
-        self.sam_magic_wand_button.setEnabled(self.current_sam_model is not None)
 
         # Disable all tools if no class is selected
         tools_enabled = (
@@ -1013,10 +983,7 @@ class ImageAnnotator(QMainWindow):
             button.setEnabled(tools_enabled)
 
         # Update cursor based on the current tool
-        if (
-            self.image_label.current_tool == "sam_magic_wand"
-            and self.sam_magic_wand_button.isEnabled()
-        ):
+        if self.image_label.current_tool in ("sam_box", "sam_points"):
             self.image_label.setCursor(Qt.CursorShape.CrossCursor)
         else:
             self.image_label.setCursor(Qt.CursorShape.ArrowCursor)

--- a/src/digitalsreeni_image_annotator/annotator_window.py
+++ b/src/digitalsreeni_image_annotator/annotator_window.py
@@ -1049,9 +1049,6 @@ class ImageAnnotator(QMainWindow):
     def finish_polygon(self):
         return self.annotation_controller.finish_polygon()
 
-    def highlight_annotation(self, item):
-        return self.annotation_controller.highlight_annotation(item)
-
     def delete_annotation(self):
         return self.annotation_controller.delete_annotation()
 

--- a/src/digitalsreeni_image_annotator/controllers/annotation_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/annotation_controller.py
@@ -380,7 +380,7 @@ class AnnotationController(QObject):
             self.mw.annotation_list.takeItem(
                 self.mw.annotation_list.row(current_item)
             )
-            self.mw.image_label.highlighted_annotation = None
+            self.mw.image_label.highlighted_annotations.clear()
             self.mw.image_label.update()
 
     def delete_selected_annotations(self):

--- a/src/digitalsreeni_image_annotator/controllers/annotation_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/annotation_controller.py
@@ -330,7 +330,7 @@ class AnnotationController(QObject):
     # --- Highlighting / selection ---
 
     def clear_highlighted_annotation(self):
-        self.mw.image_label.highlighted_annotation = None
+        self.mw.image_label.highlighted_annotations.clear()
         self.mw.image_label.update()
 
     def update_highlighted_annotations(self):
@@ -342,10 +342,6 @@ class AnnotationController(QObject):
 
         self.mw.merge_button.setEnabled(len(selected_items) >= 2)
         self.mw.change_class_button.setEnabled(len(selected_items) > 0)
-
-    def highlight_annotation(self, item):
-        self.mw.image_label.highlighted_annotation = item.data(Qt.ItemDataRole.UserRole)
-        self.mw.image_label.update()
 
     def highlight_annotation_in_list(self, annotation):
         for i in range(self.mw.annotation_list.count()):

--- a/src/digitalsreeni_image_annotator/controllers/dino_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/dino_controller.py
@@ -361,7 +361,7 @@ class DINOController(QObject):
             return
 
         # Prevent stale temp annotations from a prior single-image review from
-        # confusing the batch results handler or the _DINOReviewEventFilter.
+        # confusing the batch results handler or the DINOReviewEventFilter.
         self.mw.image_label.temp_annotations = []
 
         if not self._ensure_dino_model_downloaded(model_name):

--- a/src/digitalsreeni_image_annotator/controllers/image_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/image_controller.py
@@ -192,7 +192,6 @@ class ImageController(QObject):
                 self.mw.load_image_annotations()
                 self.mw.update_annotation_list()
                 self.mw.clear_highlighted_annotation()
-                self.mw.image_label.highlighted_annotations.clear()
                 self.mw.image_label.reset_annotation_state()
                 self.mw.image_label.clear_current_annotation()
                 self.mw.update_image_info()
@@ -261,8 +260,6 @@ class ImageController(QObject):
                 self.mw.load_image_annotations()
                 self.mw.update_annotation_list()
                 self.mw.clear_highlighted_annotation()
-
-                self.mw.image_label.highlighted_annotations.clear()
                 self.mw.image_label.update()
                 self.mw.image_label.reset_annotation_state()
                 self.mw.image_label.clear_current_annotation()

--- a/src/digitalsreeni_image_annotator/controllers/sam_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/sam_controller.py
@@ -1,8 +1,8 @@
 """SAM (Segment Anything) coordination controller.
 
-Extracted from `ImageAnnotator`. Owns the SAM tool lifecycle (magic
-wand, box, points), the debounce timer state machine, ADR-013's
-in-flight re-entrancy guard, and the model picker dropdown plumbing.
+Extracted from `ImageAnnotator`. Owns the SAM tool lifecycle (box,
+points), the debounce timer state machine, ADR-013's in-flight
+re-entrancy guard, and the model picker dropdown plumbing.
 
 State (`sam_utils`, `sam_inference_timer`, `_sam_inference_in_flight`,
 `current_sam_model`) stays on the main window in this phase for the
@@ -34,77 +34,29 @@ class SAMController(QObject):
         super().__init__(main_window)
         self.mw = main_window
 
-    def activate_sam_magic_wand(self):
-        for button in self.mw.tool_group.buttons():
-            if button != self.mw.sam_magic_wand_button:
-                button.setChecked(False)
+    def deactivate_sam_tools(self):
+        """Turn off SAM box / points and clear any pending SAM state.
 
-        self.mw.image_label.current_tool = "sam_magic_wand"
-        self.mw.image_label.sam_magic_wand_active = True
-        self.mw.image_label.setCursor(Qt.CursorShape.CrossCursor)
+        Called before YOLO predictions overlay their own temp results
+        and when the SAM model is unset, so a stale bbox / point set /
+        temp prediction can't linger into the next workflow."""
+        self.mw.sam_inference_timer.stop()
+        self.mw.sam_box_button.setChecked(False)
+        self.mw.sam_points_button.setChecked(False)
 
-        self.mw.update_ui_for_current_tool()
-
-        if self.mw.current_class is None and self.mw.class_list.count() > 0:
-            self.mw.class_list.setCurrentRow(0)
-            self.mw.current_class = self.mw.class_list.currentItem().text()
-        elif self.mw.class_list.count() == 0:
-            QMessageBox.warning(
-                self.mw,
-                "No Class Selected",
-                "Please add a class before using annotation tools.",
-            )
-            self.mw.sam_magic_wand_button.setChecked(False)
-            self.deactivate_sam_magic_wand()
-
-    def deactivate_sam_magic_wand(self):
-        self.mw.image_label.current_tool = None
-        self.mw.image_label.sam_magic_wand_active = False
-        self.mw.sam_magic_wand_button.setChecked(False)
-        self.mw.sam_magic_wand_button.setEnabled(False)
-        self.mw.image_label.setCursor(Qt.CursorShape.ArrowCursor)
-
-        self.mw.image_label.sam_bbox = None
-        self.mw.image_label.drawing_sam_bbox = False
-        self.mw.image_label.temp_sam_prediction = None
+        image_label = self.mw.image_label
+        if image_label.current_tool in ("sam_box", "sam_points"):
+            image_label.current_tool = None
+        image_label.sam_box_active = False
+        image_label.sam_points_active = False
+        image_label.sam_bbox = None
+        image_label.drawing_sam_bbox = False
+        image_label.sam_positive_points = []
+        image_label.sam_negative_points = []
+        image_label.temp_sam_prediction = None
+        image_label.setCursor(Qt.CursorShape.ArrowCursor)
 
         self.mw.update_ui_for_current_tool()
-
-    def toggle_sam_assisted(self):
-        if not self.mw.current_sam_model:
-            QMessageBox.warning(
-                self.mw,
-                "No SAM Model Selected",
-                "Please pick a SAM model before using the SAM-Assisted tool.",
-            )
-            self.mw.sam_magic_wand_button.setChecked(False)
-            return
-
-        if self.mw.sam_magic_wand_button.isChecked():
-            self.activate_sam_magic_wand()
-        else:
-            self.deactivate_sam_magic_wand()
-
-        self.mw.image_label.clear_temp_sam_prediction()
-
-    def toggle_sam_magic_wand(self):
-        if self.mw.sam_magic_wand_button.isChecked():
-            if self.mw.current_class is None:
-                QMessageBox.warning(
-                    self.mw,
-                    "No Class Selected",
-                    "Please select a class before using SAM2 Magic Wand.",
-                )
-                self.mw.sam_magic_wand_button.setChecked(False)
-                return
-            self.mw.image_label.setCursor(Qt.CursorShape.CrossCursor)
-            self.mw.image_label.sam_magic_wand_active = True
-        else:
-            self.mw.image_label.setCursor(Qt.CursorShape.ArrowCursor)
-            self.mw.image_label.sam_magic_wand_active = False
-            self.mw.image_label.sam_bbox = None
-
-        self.mw.image_label.clear_temp_sam_prediction()
 
     def schedule_sam_prediction(self):
         """Restart the debounce timer; inference fires 1s after last click."""
@@ -261,14 +213,7 @@ class SAMController(QObject):
         self.mw.current_sam_model = self.mw.sam_utils.current_sam_model
 
         if model_name != "Pick a SAM Model":
-            self.mw.sam_magic_wand_button.setEnabled(True)
-
-            self.mw.sam_magic_wand_button.setChecked(True)
-            self.activate_sam_magic_wand()
-
             print(f"Changed SAM model to: {model_name}")
         else:
-            self.mw.sam_magic_wand_button.setEnabled(False)
-            self.mw.sam_magic_wand_button.setChecked(False)
-            self.deactivate_sam_magic_wand()
+            self.deactivate_sam_tools()
             print("SAM model unset")

--- a/src/digitalsreeni_image_annotator/controllers/yolo_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/yolo_controller.py
@@ -420,7 +420,7 @@ class YOLOController(QObject):
             )
             return
 
-        self.mw.deactivate_sam_magic_wand()
+        self.mw.deactivate_sam_tools()
 
         image_path = self.mw.image_paths[file_name]
         try:
@@ -536,4 +536,4 @@ class YOLOController(QObject):
                 "No predictions were found for this image.",
             )
 
-        self.mw.deactivate_sam_magic_wand()
+        self.mw.deactivate_sam_tools()

--- a/src/digitalsreeni_image_annotator/dialogs/dataset_splitter.py
+++ b/src/digitalsreeni_image_annotator/dialogs/dataset_splitter.py
@@ -130,10 +130,13 @@ class DatasetSplitterTool(QDialog):
             QMessageBox.warning(self, "Error", "Percentages must add up to 100%.")
             return
 
-        if self.images_only_radio.isChecked():
-            self.split_images_only()
-        else:
-            self.split_images_and_annotations()
+        try:
+            if self.images_only_radio.isChecked():
+                self.split_images_only()
+            else:
+                self.split_images_and_annotations()
+        except Exception as e:
+            QMessageBox.critical(self, "Error", f"Dataset split failed:\n{e}")
 
     def split_images_only(self):
         image_files = [f for f in os.listdir(self.input_directory) if f.lower().endswith(('.png', '.jpg', '.jpeg', '.tif', '.tiff'))]
@@ -161,6 +164,25 @@ class DatasetSplitterTool(QDialog):
             coco_data = json.load(f)
 
         image_files = [img['file_name'] for img in coco_data['images']]
+
+        # The JSON lists filenames; nothing guarantees they exist in the
+        # chosen input directory. A partial split would silently produce a
+        # broken dataset, so refuse to start if anything is missing.
+        missing = [f for f in image_files
+                   if not os.path.exists(os.path.join(self.input_directory, f))]
+        if missing:
+            preview = "\n".join(missing[:10])
+            if len(missing) > 10:
+                preview += f"\n... and {len(missing) - 10} more"
+            QMessageBox.warning(
+                self, "Images Not Found",
+                f"{len(missing)} of {len(image_files)} image(s) listed in the "
+                f"COCO JSON were not found in the selected input directory:\n\n"
+                f"{preview}\n\n"
+                "Please select the directory that contains these images."
+            )
+            return
+
         random.shuffle(image_files)
 
         train_split = int(len(image_files) * self.train_percent.value() / 100)

--- a/src/digitalsreeni_image_annotator/dialogs/help_window.py
+++ b/src/digitalsreeni_image_annotator/dialogs/help_window.py
@@ -87,19 +87,18 @@ class HelpWindow(QDialog):
         <h2>Annotation Process</h2>
         <ol>
             <li><strong>Select a Class:</strong> Choose the class you want to annotate from the class list.</li>
-            <li><strong>Choose a Tool:</strong> Select either the Polygon Tool, Rectangle Tool, or SAM-Assisted tool.</li>
+            <li><strong>Choose a Tool:</strong> Select the Polygon Tool, Rectangle Tool, or one of the SAM-assisted tools (SAM-box / SAM-points).</li>
             <li><strong>Create Annotation:</strong>
                 <ul>
                     <li>For Polygon Tool: Click around the object to define its boundary. Press Enter or click "Finish Polygon" when done.</li>
                     <li>For Rectangle Tool: Click and drag to create a bounding box.</li>
-                    <li>For SAM-Assisted tool: 
+                    <li>For SAM-assisted tools (SAM-box / SAM-points):
                         <ol>
                             <li>Select a SAM model from the "Pick a SAM Model" dropdown. It's recommended to use smaller models like SAM2 tiny or SAM2 small for better performance.</li>
                             <li>Note: When you select a model for the first time, the application needs to download it. This process may take a few seconds to a minute, depending on your internet connection speed. Subsequent uses of the same model will be faster as it will already be cached locally, in your working directory.</li>
-                            <li>Click the "SAM-Assisted" button to activate the tool.</li>
-                            <li>Draw a rectangle around objects of interest to allow SAM2 to automatically detect objects.</li>
-                            <li>SAM2 will provide various outputs with different scores, and only the top-scoring region will be displayed.</li>
-                            <li>If the desired result isn't achieved on the first try, draw again.</li>
+                            <li>Click the "SAM-box" button and draw a rectangle around an object of interest, or click the "SAM-points" button and left-click points inside the object (right-click adds negative points to exclude regions).</li>
+                            <li>SAM2 will display the top-scoring mask as a temporary prediction. Press Enter to accept it or Esc to discard it.</li>
+                            <li>If the desired result isn't achieved on the first try, draw the box again or adjust the points.</li>
                             <li>For low-quality images where SAM2 may not auto-detect objects, manual tools may be necessary.</li>
                         </ol>
                     </li>

--- a/src/digitalsreeni_image_annotator/ui/sidebar.py
+++ b/src/digitalsreeni_image_annotator/ui/sidebar.py
@@ -119,14 +119,6 @@ def build_sidebar(window):
     sam_buttons_layout.addWidget(window.sam_points_button)
     sam_layout.addLayout(sam_buttons_layout)
 
-    # Magic-wand button is constructed inside the sidebar so the
-    # tool_group can reference it without an early-init step in
-    # ImageAnnotator.__init__.
-    window.sam_magic_wand_button = QPushButton("Magic Wand")
-    window.sam_magic_wand_button.setCheckable(True)
-    window.sam_magic_wand_button.setEnabled(False)
-    sam_layout.addWidget(window.sam_magic_wand_button)
-
     # SAM model selector
     window.sam_model_selector = QComboBox()
     window.sam_model_selector.addItem("Pick a SAM Model")
@@ -210,9 +202,9 @@ def build_sidebar(window):
     annotation_layout.addWidget(dino_widget)
     # --- END DINO section ---
 
-    # Tool group — must include all checkable tool buttons (incl. the
-    # magic-wand) so update_ui_for_current_tool / enable_tools /
-    # disable_tools can iterate.
+    # Tool group — must include all checkable tool buttons so
+    # update_ui_for_current_tool / enable_tools / disable_tools can
+    # iterate.
     window.tool_group = QButtonGroup(window)
     window.tool_group.setExclusive(False)
     window.tool_group.addButton(window.polygon_button)
@@ -221,13 +213,11 @@ def build_sidebar(window):
     window.tool_group.addButton(window.eraser_button)
     window.tool_group.addButton(window.sam_box_button)
     window.tool_group.addButton(window.sam_points_button)
-    window.tool_group.addButton(window.sam_magic_wand_button)
 
     window.polygon_button.clicked.connect(window.toggle_tool)
     window.rectangle_button.clicked.connect(window.toggle_tool)
     window.paint_brush_button.clicked.connect(window.toggle_tool)
     window.eraser_button.clicked.connect(window.toggle_tool)
-    window.sam_magic_wand_button.clicked.connect(window.toggle_tool)
 
     # Annotations list subsection
     annotation_layout.addWidget(QLabel("Annotations"))

--- a/src/digitalsreeni_image_annotator/widgets/image_label.py
+++ b/src/digitalsreeni_image_annotator/widgets/image_label.py
@@ -106,7 +106,6 @@ class ImageLabel(QLabel):
         self.cursor_pos = None
 
         # SAM
-        self.sam_magic_wand_active = False
         self.sam_bbox = None
         self.drawing_sam_bbox = False
         self.temp_sam_prediction = None
@@ -234,8 +233,6 @@ class ImageLabel(QLabel):
             if self.editing_polygon:
                 self.draw_editing_polygon(painter)
             # SAM overlays (cross-cutting; not part of the tool handlers)
-            if self.sam_magic_wand_active and self.sam_bbox:
-                self.draw_sam_bbox(painter)
             if self.sam_box_active and self.sam_bbox:
                 self.draw_sam_bbox(painter)
             if self.sam_points_active:
@@ -662,9 +659,6 @@ class ImageLabel(QLabel):
             if self.current_tool == "sam_box" and self.sam_box_active:
                 self.sam_bbox = [pos[0], pos[1], pos[0], pos[1]]
                 self.drawing_sam_bbox = True
-            elif self.sam_magic_wand_active:
-                self.sam_bbox = [pos[0], pos[1], pos[0], pos[1]]
-                self.drawing_sam_bbox = True
             elif self.editing_polygon:
                 self.handle_editing_click(pos, event)
             else:
@@ -699,13 +693,6 @@ class ImageLabel(QLabel):
         ):
             self.sam_bbox[2] = pos[0]
             self.sam_bbox[3] = pos[1]
-        elif (
-            self.sam_magic_wand_active
-            and self.drawing_sam_bbox
-            and self.sam_bbox is not None
-        ):
-            self.sam_bbox[2] = pos[0]
-            self.sam_bbox[3] = pos[1]
         elif self.editing_polygon:
             self.handle_editing_move(pos)
         else:
@@ -726,15 +713,6 @@ class ImageLabel(QLabel):
             if event.button() == Qt.MouseButton.LeftButton:
                 if (
                     self.sam_box_active
-                    and self.drawing_sam_bbox
-                    and self.sam_bbox is not None
-                ):
-                    self.sam_bbox[2] = pos[0]
-                    self.sam_bbox[3] = pos[1]
-                    self.drawing_sam_bbox = False
-                    self.samPredictionApplyRequested.emit()
-                elif (
-                    self.sam_magic_wand_active
                     and self.drawing_sam_bbox
                     and self.sam_bbox is not None
                 ):
@@ -808,7 +786,7 @@ class ImageLabel(QLabel):
             # non-DINO temp state only.
             elif self.temp_annotations:
                 self.discard_temp_annotations()
-            elif self.sam_magic_wand_active:
+            elif self.sam_box_active:
                 self.sam_bbox = None
                 self.clear_temp_sam_prediction()
             elif self.editing_polygon:

--- a/src/digitalsreeni_image_annotator/widgets/tools/base.py
+++ b/src/digitalsreeni_image_annotator/widgets/tools/base.py
@@ -3,7 +3,7 @@ Base class for per-tool mouse / key event handlers in ImageLabel.
 
 Each handler owns its tool-specific temp state. ImageLabel keeps a
 dispatcher that routes events to the active handler. Handlers emit
-back through the ImageLabel's Phase 6 signals (see ADR-016) — they
+back through the ImageLabel's Phase 6 signals (see ADR-018) — they
 never call into the orchestrator directly.
 
 Plain Python objects, not QObjects: no need for their own signals,

--- a/src/digitalsreeni_image_annotator/widgets/tools/base.py
+++ b/src/digitalsreeni_image_annotator/widgets/tools/base.py
@@ -36,8 +36,8 @@ class ToolHandler:
         return False
 
     # --- Key hooks. ImageLabel routes Enter/Escape here only after the
-    # higher-priority modal branches (DINO temp, sam_points, editing
-    # polygon, magic wand) have had their turn. ---
+    # higher-priority modal branches (DINO temp, sam_points, sam_box,
+    # editing polygon) have had their turn. ---
 
     def on_enter(self) -> bool:
         return False

--- a/src/digitalsreeni_image_annotator/widgets/tools/eraser_tool.py
+++ b/src/digitalsreeni_image_annotator/widgets/tools/eraser_tool.py
@@ -58,11 +58,12 @@ class EraserTool(ToolHandler):
         painter.translate(self.label.offset_x, self.label.offset_y)
         painter.scale(self.label.zoom_factor, self.label.zoom_factor)
 
+        mask_copy = mask.copy()
         mask_image = QImage(
-            mask.data,
-            mask.shape[1],
-            mask.shape[0],
-            mask.shape[1],
+            mask_copy.data,
+            mask_copy.shape[1],
+            mask_copy.shape[0],
+            mask_copy.shape[1],
             QImage.Format.Format_Grayscale8,
         )
         mask_pixmap = QPixmap.fromImage(mask_image)

--- a/src/digitalsreeni_image_annotator/widgets/tools/paint_tool.py
+++ b/src/digitalsreeni_image_annotator/widgets/tools/paint_tool.py
@@ -57,11 +57,12 @@ class PaintBrushTool(ToolHandler):
         painter.translate(self.label.offset_x, self.label.offset_y)
         painter.scale(self.label.zoom_factor, self.label.zoom_factor)
 
+        mask_copy = mask.copy()
         mask_image = QImage(
-            mask.data,
-            mask.shape[1],
-            mask.shape[0],
-            mask.shape[1],
+            mask_copy.data,
+            mask_copy.shape[1],
+            mask_copy.shape[0],
+            mask_copy.shape[1],
             QImage.Format.Format_Grayscale8,
         )
         mask_pixmap = QPixmap.fromImage(mask_image)


### PR DESCRIPTION
## Summary

Phase 9 — the **final phase** of the 9-phase modular refactor. Docs-only. Brings `CLAUDE.md` and the arc42 docs back in sync with what the code actually looks like after Phases 1–8.

> **Stacked on #14 / #15 / #16.** GitHub will show the combined diff until those land; Phase 9's own commits are `80c2afb` + `418814f`.

## What changed

- **`CLAUDE.md`** — project-structure tree replaced with the post-refactor subpackage layout (`core/`, `controllers/`, `widgets/`, `widgets/tools/`, `inference/`, `io/`, `ui/`, `dialogs/`). "Key Classes" table grew from 3 rows to 14 (added `CanvasContext`, all 4 tool subclasses, all 7 controllers, `DINOUtils`). Test count corrected `65` → `94`.
- **`docs/05_building_block_view.md`** — new "Level 3: Controllers" section with a one-line responsibility per controller, mirroring the existing "Level 3: Export/Import Subsystem" structure. Cross-references ADR-013 (SAM re-entrancy), ADR-015 (DINO event filter), ADR-016 (signal decoupling).
- **`docs/12_glossary.md`** — new entries for `CanvasContext`, `Controller` (pattern), `ToolHandler`, the four tool subclasses, and the UI builders. "Key Classes (Code)" table grew from 6 rows to 18 with the same controller set covered in CLAUDE.md.
- **`docs/11_risks_and_technical_debt.md`** — rewrote the "No Automated Tests" entry. Old text claimed zero tests; the test suite now reports 94 with ~15% line coverage. The remaining gap (canvas event flow, inference paths) is named with a concrete plan that leans on the Phase 7 ToolHandler isolation.

## Senior-reviewer P2s addressed (commit `418814f`)

- `CLAUDE.md`: dialogs/ count `14 files` → `16 files`.
- `docs/05_building_block_view.md`: "The seven controllers/* modules" + "each controller is a QObject subclass" intro contradicted the table beneath (which includes the `io_controller` module-helpers row). Reworded to "Seven QObject controllers plus an io_controller helper module".
- `docs/05_building_block_view.md`: top-level tree mentioned controllers without listing `io_controller` while the Level 3 section did — same document, two stories. Added `+ io_controller helpers` to the tree comment.
- `docs/12_glossary.md`: "Tool subclasses" hook list missed `on_double_click` and `deactivate` from `widgets/tools/base.py`. Listed all 8 hooks to match the base class.

## Verified

- No `src/` changes. Code untouched.
- `python -m pytest tests/ -x -q` → 94/94 pass.
- `python -c "from src.digitalsreeni_image_annotator import ImageAnnotator, ImageLabel, SAMUtils, calculate_area, calculate_bbox"` resolves — public API freeze intact.
- Every class named in the new tables exists at the file/path cited.

## End state of the 9-phase refactor

| Metric | Before | After |
|---|---:|---:|
| `annotator_window.py` | 5,900 LOC | 1,164 LOC (−80%) |
| `image_label.py` | 1,193 LOC | ~960 LOC, no `main_window` reference |
| Controllers | 0 | 7 (+ `io_controller` helpers) |
| Tool handlers | 0 | 4 (`Rectangle`, `Polygon`, `PaintBrush`, `Eraser`) |
| UI builders | 0 | `menu_bar`, `sidebar`, `shortcuts` modules |
| `CanvasContext` | — | added (ADR-016) |
| ADRs added | — | 016 (signal decoupling), 017 (tool dispatcher) |
| Tests | 65 | 94 |
| Public API surface | `ImageAnnotator`, `ImageLabel`, `SAMUtils`, `calculate_area`, `calculate_bbox` | **unchanged** |

## Test plan

- [x] `python -m pytest tests/ -x -q` — 94 / 94 pass
- [x] Public API import resolves
- [ ] Manual: render-check the four updated docs (no broken Markdown / tables / links)

## Diff size

| File | Δ |
|---|---:|
| `CLAUDE.md` | +33 / −12 |
| `docs/05_building_block_view.md` | +33 / −5 |
| `docs/12_glossary.md` | +37 / −5 |
| `docs/11_risks_and_technical_debt.md` | +15 / −12 |

Total: 4 files, +118 / −34. No `src/` changes.

The refactor is done.

https://claude.ai/code/session_01QxGci8QYbXHtV6BpoBLfAU

---
_Generated by [Claude Code](https://claude.ai/code/session_01QxGci8QYbXHtV6BpoBLfAU)_