### PR TITLE
feat: Low-vision mode - continuous UI font zoom with persistence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ See [docs/README.md](docs/README.md) for full documentation index.
 src/digitalsreeni_image_annotator/
 ├── main.py                       # Entry point
 ├── annotator_window.py           # ImageAnnotator - thin orchestrator
+├── app_settings.py               # QSettings UI prefs: ui_font_pt, dark_mode (ADR-020)
 ├── utils.py                      # Utility functions (calculate_area, …)
 ├── __init__.py                   # Public API re-exports
 │
@@ -236,6 +237,8 @@ See [Risks and Technical Debt](docs/11_risks_and_technical_debt.md) for full lis
 | Global | Action |
 |--------|--------|
 | Ctrl+N/O/S | New/Open/Save Project |
+| Ctrl+Shift+= / Ctrl+Shift+- | UI font bigger/smaller (8-24pt, persisted via QSettings) |
+| Ctrl+Shift+0 | Reset UI font size |
 | F1 | Help |
 
 | Canvas | Action |

--- a/docs/05_building_block_view.md
+++ b/docs/05_building_block_view.md
@@ -29,6 +29,7 @@
 src/digitalsreeni_image_annotator/
 ├── main.py                        # Entry point, initializes QApplication
 	├── annotator_window.py            # ImageAnnotator - main window orchestrator
+	├── app_settings.py                # QSettings-backed UI prefs (font size, dark mode) — ADR-020
 	├── utils.py                       # Cross-cutting utilities
 	├── core/                          # Constants, annotation utils, image utils
 	│   ├── constants.py

--- a/docs/08_crosscutting_concepts.md
+++ b/docs/08_crosscutting_concepts.md
@@ -240,8 +240,12 @@ strings. `apply_theme_and_font` appends scaled rules *after* the
 static sheet — later rules of equal specificity win in QSS — for the
 body font, `.section-header` and checkbox/radio indicator sizes. The
 overrides scale the legacy px values (14px header, 14px indicators,
-8px radio radius) by `ui_font_pt / 10` and stay in **px**, so at the
-default 10pt they reproduce the static sheets exactly. Do not
+8px radio radius, 11px/10px compact DINO panel) by `ui_font_pt / 10`
+and stay in **px**, so at the default 10pt they reproduce the legacy
+look exactly. Widgets that want smaller-than-body text (e.g. the DINO
+threshold table / phrase panel) must not set their own `font-size` —
+they get a type- or objectName-targeted rule in the appended block
+instead, so "compact" still scales. Do not
 hardcode `font-size` in widget `setStyleSheet(...)` calls: it overrides
 the global rule and the widget stops scaling (same failure mode as the
 No Hardcoded Colors rule below; the DINO sidebar captions hit this).

--- a/docs/08_crosscutting_concepts.md
+++ b/docs/08_crosscutting_concepts.md
@@ -221,6 +221,53 @@ which on Windows means barely-visible radio-button indicators and
 white-on-white headers (the dataset splitter radio buttons hit this
 before they were styled).
 
+## UI Font Zoom (Low-Vision Mode)
+
+### Single Source of Truth: `ui_font_pt`
+
+All UI text size flows from one integer, `ImageAnnotator.ui_font_pt`
+(8–24pt, default 10, clamped by `app_settings.clamp_font_pt`). The
+Settings → Font Size presets (Small…XXL) jump to fixed values;
+Ctrl+Shift+= / Ctrl+Shift+- step ±1pt; Ctrl+Shift+0 resets. Every
+change goes through `theme.set_font_pt`, which clamps, re-applies the
+theme, persists via QSettings and syncs the preset menu checkmarks
+(no preset is checked at an in-between size).
+
+### Appended QSS Overrides, Not Templated Stylesheets
+
+`soft_dark_stylesheet.py` / `default_stylesheet.py` stay static
+strings. `apply_theme_and_font` appends scaled rules *after* the
+static sheet — later rules of equal specificity win in QSS — for the
+body font, `.section-header` and checkbox/radio indicator sizes. The
+overrides scale the legacy px values (14px header, 14px indicators,
+8px radio radius) by `ui_font_pt / 10` and stay in **px**, so at the
+default 10pt they reproduce the static sheets exactly. Do not
+hardcode `font-size` in widget `setStyleSheet(...)` calls: it overrides
+the global rule and the widget stops scaling (same failure mode as the
+No Hardcoded Colors rule below; the DINO sidebar captions hit this).
+
+### Canvas Overlay Scaling: `ui_scale`
+
+`apply_theme_and_font` pushes `ui_font_pt / 10.0` to
+`ImageLabel.set_ui_scale`. Overlay sizes (annotation label fonts, SAM
+point radii, pen widths, edit-point handles, hit-test tolerances) use
+the helpers `ImageLabel._pen_w(base)` / `_overlay_font(base)`, which
+multiply by `ui_scale` and divide by `zoom_factor` — UI zoom and image
+zoom stay orthogonal: overlays grow with the font setting but remain
+constant-size on screen across image zoom. At the default 10pt,
+`ui_scale == 1.0` and rendering is pixel-identical to the legacy code.
+Exception: the SAM point-marker radii are drawn under
+`painter.scale(zoom)` without zoom compensation (pre-existing
+behaviour) and only multiply by `ui_scale`.
+
+### Persistence via QSettings
+
+`app_settings.py` stores `ui/font_pt` and `ui/dark_mode` in
+`QSettings("DigitalSreeni", "ImageAnnotator")` (registry under HKCU on
+Windows). These are per-user preferences, deliberately *not* part of
+the `.iap` project file. All functions take an optional `QSettings`
+instance so tests inject an INI-backed temp file.
+
 ## Thread Safety for YOLO Training
 
 ### Training Thread
@@ -313,7 +360,11 @@ def generate_slice_name(filename, t, z, c, s):
 | Ctrl+O | Open Project |
 | Ctrl+S | Save Project |
 | Ctrl+W | Close Project |
-| Ctrl+Shift+S | Annotation Statistics |
+| Ctrl+Shift+S | Save Project As |
+| Ctrl+Alt+S | Annotation Statistics |
+| Ctrl+Shift+= (or Ctrl++) | Increase UI font size |
+| Ctrl+Shift+- (or Ctrl+-) | Decrease UI font size |
+| Ctrl+Shift+0 | Reset UI font size |
 | F1 | Help Window |
 
 ### Canvas Shortcuts

--- a/docs/09_architecture_decisions.md
+++ b/docs/09_architecture_decisions.md
@@ -727,11 +727,15 @@ persistence mechanism in the app.
   `_overlay_font` or the appended-override block in
   `theme.apply_theme_and_font` — hardcoded px values won't follow the
   setting (see "UI Font Zoom" in `08_crosscutting_concepts.md`).
-- ⚠️ Known debt: standalone dialogs still carry hardcoded
-  `font-size:Npx` tokens (`dino_phrase_editor.py`,
-  `dino_merge_dialog.py` — the latter also a `color:#444` dark-mode
-  contrast issue) and therefore don't scale. Tracked, not an
-  oversight; fix when those dialogs are next touched.
+- ⚠️ Deliberately-compact widgets (DINO threshold table / phrase
+  panel) don't hardcode their small font inline; the appended block
+  owns it via type/objectName selectors (`ClassThresholdTable`,
+  `PhraseEditorPanel …`, `#dino_phrase_hint`) so compact ≠ unscaled.
+  Follow that pattern for new compact widgets.
+- ⚠️ Known debt: `dino_merge_dialog.py` still carries hardcoded
+  `font-size:Npx` tokens and a `color:#444` dark-mode contrast issue,
+  so it doesn't scale. Tracked, not an oversight; fix when that
+  dialog is next touched.
 
 ---
 

--- a/docs/09_architecture_decisions.md
+++ b/docs/09_architecture_decisions.md
@@ -685,7 +685,53 @@ Real-world testing with `torch 2.11.0+cu126 + PyQt6 6.10.2 + Python 3.14.2` on W
 - Implementation: `src/digitalsreeni_image_annotator/main.py`.
 - Gate: `tools/check_pyqt6_torch_coexistence.py`.
 
+## ADR-020: App-Global UI Preferences via QSettings; Canvas Overlays Scale with `ui_font_pt`
 
+**Status**: Accepted
+
+**Context**: The low-vision accessibility feature (continuous UI font
+zoom, 8–24pt) needed (a) the chosen size to survive app restarts and
+(b) canvas overlay elements — annotation labels, SAM point markers,
+pen widths — to grow with the setting. UI preferences were previously
+reset on every launch, and the `.iap` project file was the only
+persistence mechanism in the app.
+
+**Decision**:
+1. Introduce the app's first QSettings usage
+   (`QSettings("DigitalSreeni", "ImageAnnotator")`, module
+   `app_settings.py`) for `ui/font_pt` and `ui/dark_mode`. These are
+   per-user preferences, so they do **not** go into the `.iap` file —
+   a project opened by a different user must not impose a font size.
+2. A single integer `ImageAnnotator.ui_font_pt` is the source of
+   truth; the named presets and the step shortcuts both funnel
+   through `theme.set_font_pt` (clamp → apply → persist → menu sync).
+3. Canvas overlay sizes derive from `ui_scale = ui_font_pt / 10.0`
+   (10 = the legacy default, so the default renders pixel-identical
+   to the pre-feature code). `ImageLabel` receives the value via a
+   plain setter from `apply_theme_and_font`, not via CanvasContext —
+   consistent with the existing direct `image_label.setFont` call,
+   and avoids a paint-before-context-set window.
+
+**Alternatives considered**:
+- Storing prefs in the `.iap` file — rejected: project files are
+  shared artifacts; accessibility settings are personal.
+- Templating the static stylesheets per font size — rejected:
+  appended QSS override rules (later rules win at equal specificity)
+  achieve the same with zero churn in the two stylesheet strings.
+
+**Consequences**:
+- ✅ Font size and dark mode persist across restarts.
+- ✅ Tests stay hermetic: every `app_settings` function accepts an
+  injectable `QSettings` (INI temp file) instance.
+- ⚠️ Any new scalable UI metric should use `ImageLabel._pen_w` /
+  `_overlay_font` or the appended-override block in
+  `theme.apply_theme_and_font` — hardcoded px values won't follow the
+  setting (see "UI Font Zoom" in `08_crosscutting_concepts.md`).
+- ⚠️ Known debt: standalone dialogs still carry hardcoded
+  `font-size:Npx` tokens (`dino_phrase_editor.py`,
+  `dino_merge_dialog.py` — the latter also a `color:#444` dark-mode
+  contrast issue) and therefore don't scale. Tracked, not an
+  oversight; fix when those dialogs are next touched.
 
 ---
 

--- a/src/digitalsreeni_image_annotator/annotator_window.py
+++ b/src/digitalsreeni_image_annotator/annotator_window.py
@@ -16,6 +16,7 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
+from .app_settings import load_ui_prefs
 from .controllers import io_controller
 from .controllers.annotation_controller import AnnotationController
 from .controllers.class_controller import ClassController
@@ -127,7 +128,9 @@ class ImageAnnotator(QMainWindow):
         self.image_label.set_context(CanvasContext(self))
         self._connect_image_label_signals()
 
-        # Font size control
+        # Font size control. Presets are named entry points into the
+        # continuous 8-24pt range; `ui_font_pt` (int) is the single
+        # source of truth — see theme.set_font_pt.
         self.font_sizes = {
             "Small": 8,
             "Medium": 10,
@@ -135,12 +138,12 @@ class ImageAnnotator(QMainWindow):
             "XL": 14,
             "XXL": 16,
         }  # When adding a new option here, also add it to the Font Size submenu in ui/menu_bar.build_menu_bar.
-        self.current_font_size = "Medium"
 
-        # Dark mode control. Default on — matches the look most users
-        # expect from a 2025-era desktop annotation tool; toggle with
-        # Settings → Toggle Dark Mode (Ctrl+D).
-        self.dark_mode = True
+        # UI prefs persist app-globally via QSettings (not in the .iap
+        # project file). Dark mode defaults on — matches the look most
+        # users expect from a 2025-era desktop annotation tool; toggle
+        # with Settings → Toggle Dark Mode (Ctrl+D).
+        self.ui_font_pt, self.dark_mode = load_ui_prefs()
 
         # Default annotations sorting
         self.current_sort_method = "class"  # Default sorting method
@@ -522,6 +525,12 @@ class ImageAnnotator(QMainWindow):
     def change_font_size(self, size):
         theme.change_font_size(self, size)
 
+    def step_font_size(self, delta):
+        theme.step_font_pt(self, delta)
+
+    def reset_font_size(self):
+        theme.reset_font_pt(self)
+
     def unload_ai_models(self):
         """Drop cached SAM/DINO model objects to free GPU/CPU memory.
 
@@ -620,12 +629,6 @@ class ImageAnnotator(QMainWindow):
     def reject_dino_results(self):
         return self.dino_controller.reject_dino_results()
 
-    def setup_font_size_selector(self):
-        theme.setup_font_size_selector(self)
-
-    def on_font_size_changed(self, size):
-        theme.on_font_size_changed(self, size)
-
     def apply_theme_and_font(self):
         theme.apply_theme_and_font(self)
 
@@ -693,7 +696,7 @@ class ImageAnnotator(QMainWindow):
     # update the show_help method:
     def show_help(self):
         self.help_window = HelpWindow(
-            dark_mode=self.dark_mode, font_size=self.font_sizes[self.current_font_size]
+            dark_mode=self.dark_mode, font_size=self.ui_font_pt
         )
         self.help_window.show_centered(self)
 

--- a/src/digitalsreeni_image_annotator/app_settings.py
+++ b/src/digitalsreeni_image_annotator/app_settings.py
@@ -1,0 +1,54 @@
+"""App-global UI preferences persisted via QSettings.
+
+First (and so far only) QSettings usage in the app — see ADR in
+docs/09_architecture_decisions.md. UI preferences (font size, dark
+mode) are per-user, not per-project, so they live here rather than in
+the .iap project file. On Windows this writes to the registry under
+HKCU\\Software\\DigitalSreeni\\ImageAnnotator.
+
+All functions accept an optional QSettings instance so tests can pass
+an INI-backed temp file instead of touching the real registry.
+"""
+
+from PyQt6.QtCore import QSettings
+
+FONT_PT_MIN = 8
+FONT_PT_MAX = 24
+FONT_PT_DEFAULT = 10
+
+_KEY_FONT_PT = "ui/font_pt"
+_KEY_DARK_MODE = "ui/dark_mode"
+
+
+def clamp_font_pt(pt) -> int:
+    """Coerce any stored/passed value to a usable point size.
+
+    QSettings round-trips values as strings on some backends, and a
+    hand-edited registry/INI can contain garbage — fall back to the
+    default rather than crash at startup.
+    """
+    try:
+        pt = int(pt)
+    except (TypeError, ValueError):
+        return FONT_PT_DEFAULT
+    return max(FONT_PT_MIN, min(FONT_PT_MAX, pt))
+
+
+def _settings() -> QSettings:
+    return QSettings("DigitalSreeni", "ImageAnnotator")
+
+
+def load_ui_prefs(settings=None) -> tuple[int, bool]:
+    """Return (font_pt, dark_mode), with defaults (10, True)."""
+    if settings is None:
+        settings = _settings()
+    font_pt = clamp_font_pt(settings.value(_KEY_FONT_PT, FONT_PT_DEFAULT))
+    dark_mode = settings.value(_KEY_DARK_MODE, True, type=bool)
+    return font_pt, dark_mode
+
+
+def save_ui_prefs(font_pt, dark_mode, settings=None) -> None:
+    if settings is None:
+        settings = _settings()
+    settings.setValue(_KEY_FONT_PT, clamp_font_pt(font_pt))
+    settings.setValue(_KEY_DARK_MODE, bool(dark_mode))

--- a/src/digitalsreeni_image_annotator/dialogs/dino_phrase_editor.py
+++ b/src/digitalsreeni_image_annotator/dialogs/dino_phrase_editor.py
@@ -60,14 +60,19 @@ class ClassThresholdTable(QTableWidget):
         self.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
         self.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
         self.verticalHeader().setVisible(False)
+        # Rows track their content height so cell text isn't clipped
+        # when the UI font zoom enlarges the compact panel font.
+        self.verticalHeader().setSectionResizeMode(
+            QHeaderView.ResizeMode.ResizeToContents)
         self.setMaximumHeight(160)
         # No hardcoded background colors — pick them up from the active
         # stylesheet so the table integrates with both light and dark
         # mode. The earlier "background: #e0e0e0" produced a bright bar
         # across the top of the panel in dark mode.
+        # No font-size either: the compact size is set (and scaled with
+        # ui_font_pt) by the appended overrides in ui/theme.py.
         self.setStyleSheet(
-            "QTableWidget { font-size: 11px; }"
-            "QHeaderView::section { font-size: 11px; font-weight: bold; "
+            "QHeaderView::section { font-weight: bold; "
             "  padding: 2px; background-color: palette(mid); color: palette(text); }"
         )
 
@@ -78,7 +83,6 @@ class ClassThresholdTable(QTableWidget):
         sp.setDecimals(2)
         sp.setValue(value)
         sp.setFrame(True)
-        sp.setStyleSheet("font-size: 11px;")
         return sp
 
     def add_class(self, name: str) -> bool:
@@ -93,7 +97,6 @@ class ClassThresholdTable(QTableWidget):
         self.setCellWidget(row, _COL_BOX, self._make_spin(DEFAULT_BOX_THR))
         self.setCellWidget(row, _COL_TXT, self._make_spin(DEFAULT_TXT_THR))
         self.setCellWidget(row, _COL_NMS, self._make_spin(DEFAULT_NMS_THR))
-        self.setRowHeight(row, 26)
         return True
 
     def remove_class(self, name: str) -> bool:
@@ -173,34 +176,36 @@ class PhraseEditorPanel(QWidget):
         layout.setContentsMargins(0, 4, 0, 0)
         layout.setSpacing(3)
 
+        # Compact font sizes for this panel come from the appended
+        # overrides in ui/theme.py so they scale with the UI font zoom.
+        # Note: *every* QLabel/QListWidget/QPushButton in this panel is
+        # compact by design — theme.py targets them by type. A new
+        # label added here will get the compact size, not body size.
         self.lbl_title = QLabel("Phrases for: ---")
-        self.lbl_title.setStyleSheet(
-            "font-size: 11px; font-weight: bold;")
+        self.lbl_title.setStyleSheet("font-weight: bold;")
         layout.addWidget(self.lbl_title)
 
         hint = QLabel(
             "DINO uses all phrases below for this class.\n"
             "First phrase (class name) cannot be removed.")
         hint.setWordWrap(True)
-        hint.setStyleSheet("font-size: 10px; font-style: italic;")
+        hint.setObjectName("dino_phrase_hint")  # theme.py font-size rule
+        hint.setStyleSheet("font-style: italic;")
         layout.addWidget(hint)
 
         self.phrase_list = QListWidget()
         self.phrase_list.setMaximumHeight(90)
-        self.phrase_list.setStyleSheet("font-size: 11px;")
         self.phrase_list.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.phrase_list.customContextMenuRequested.connect(self._show_phrase_context_menu)
         layout.addWidget(self.phrase_list)
 
         btn_row = QHBoxLayout()
         self.btn_add_phrase = QPushButton("Add Phrase")
-        self.btn_add_phrase.setStyleSheet(
-            "QPushButton{font-size:11px;padding:3px 6px;}")
+        self.btn_add_phrase.setStyleSheet("QPushButton{padding:3px 6px;}")
         self.btn_add_phrase.clicked.connect(self._add_phrase)
 
         self.btn_rem_phrase = QPushButton("Remove Selected")
-        self.btn_rem_phrase.setStyleSheet(
-            "QPushButton{font-size:11px;padding:3px 6px;}")
+        self.btn_rem_phrase.setStyleSheet("QPushButton{padding:3px 6px;}")
         self.btn_rem_phrase.clicked.connect(self._remove_phrase)
 
         btn_row.addWidget(self.btn_add_phrase)

--- a/src/digitalsreeni_image_annotator/dialogs/help_window.py
+++ b/src/digitalsreeni_image_annotator/dialogs/help_window.py
@@ -15,11 +15,8 @@ class HelpWindow(QDialog):
         layout.addWidget(self.text_browser)
         self.setLayout(layout)
         
-        if dark_mode:
-            self.setStyleSheet(soft_dark_stylesheet)
-        else:
-            self.setStyleSheet(default_stylesheet)
-        
+        self._base_stylesheet = soft_dark_stylesheet if dark_mode else default_stylesheet
+
         self.font_size = font_size
         self.apply_font_size()
         self.load_help_content()
@@ -30,7 +27,11 @@ class HelpWindow(QDialog):
         self.show()
     
     def apply_font_size(self):
-        self.setStyleSheet(f"QWidget {{ font-size: {self.font_size}pt; }}")
+        # Append the font rule to the theme stylesheet — replacing the
+        # whole sheet here used to wipe the dark/light theme.
+        self.setStyleSheet(
+            f"{self._base_stylesheet}\nQWidget {{ font-size: {self.font_size}pt; }}"
+        )
         font = self.text_browser.font()
         font.setPointSize(self.font_size)
         self.text_browser.setFont(font)
@@ -144,6 +145,9 @@ class HelpWindow(QDialog):
             <li><strong>Ctrl + Shift + S:</strong> Open Annotation Statistics</li>
             <li><strong>F1:</strong> Open this help window</li>
             <li><strong>Ctrl + Wheel:</strong> Zoom in/out</li>
+            <li><strong>Ctrl + Shift + = (or Ctrl + +):</strong> Increase application font size</li>
+            <li><strong>Ctrl + Shift + - (or Ctrl + -):</strong> Decrease application font size</li>
+            <li><strong>Ctrl + Shift + 0:</strong> Reset application font size</li>
             <li><strong>Esc:</strong> Cancel current annotation, exit edit mode, or exit SAM-assisted annotation</li>
             <li><strong>Enter:</strong> Finish current annotation, exit edit mode, or accept SAM-generated mask</li>
             <li><strong>Up/Down Arrow Keys:</strong> Navigate through slices in multi-dimensional images</li>

--- a/src/digitalsreeni_image_annotator/ui/menu_bar.py
+++ b/src/digitalsreeni_image_annotator/ui/menu_bar.py
@@ -8,6 +8,8 @@ controllers, but the menu doesn't need to know that.
 
 from PyQt6.QtGui import QAction, QKeySequence
 
+from . import theme
+
 
 def build_menu_bar(window):
     menu_bar = window.menuBar()
@@ -54,10 +56,40 @@ def build_menu_bar(window):
     settings_menu = menu_bar.addMenu("&Settings")
 
     font_size_menu = settings_menu.addMenu("&Font Size")
+    window._font_preset_actions = {}
     for size in ["Small", "Medium", "Large", "XL", "XXL"]:
         action = QAction(size, window)
+        action.setCheckable(True)
         action.triggered.connect(lambda checked, s=size: window.change_font_size(s))
         font_size_menu.addAction(action)
+        window._font_preset_actions[size] = action
+    # Show the persisted size as checked from the first frame (no
+    # preset is checked when ui_font_pt sits between preset values).
+    theme.sync_font_menu(window)
+
+    font_size_menu.addSeparator()
+
+    # Continuous UI zoom for low-vision users — steps ui_font_pt ±1pt
+    # within 8-24. Secondary Ctrl++ / Ctrl+- sequences cover keypads
+    # and layouts where Ctrl+Shift+= is awkward.
+    increase_font_action = QAction("&Increase Font Size", window)
+    increase_font_action.setShortcuts(
+        [QKeySequence("Ctrl+Shift+="), QKeySequence("Ctrl++")]
+    )
+    increase_font_action.triggered.connect(lambda: window.step_font_size(1))
+    font_size_menu.addAction(increase_font_action)
+
+    decrease_font_action = QAction("&Decrease Font Size", window)
+    decrease_font_action.setShortcuts(
+        [QKeySequence("Ctrl+Shift+-"), QKeySequence("Ctrl+-")]
+    )
+    decrease_font_action.triggered.connect(lambda: window.step_font_size(-1))
+    font_size_menu.addAction(decrease_font_action)
+
+    reset_font_action = QAction("&Reset Font Size", window)
+    reset_font_action.setShortcut(QKeySequence("Ctrl+Shift+0"))
+    reset_font_action.triggered.connect(window.reset_font_size)
+    font_size_menu.addAction(reset_font_action)
 
     toggle_dark_mode_action = QAction("Toggle &Dark Mode", window)
     toggle_dark_mode_action.setShortcut(QKeySequence("Ctrl+D"))

--- a/src/digitalsreeni_image_annotator/ui/sidebar.py
+++ b/src/digitalsreeni_image_annotator/ui/sidebar.py
@@ -149,9 +149,11 @@ def build_sidebar(window):
     # Use palette(text) so the colour follows the active stylesheet
     # (light or dark) — hardcoded #555 used to render unreadable on
     # dark mode. See "No Hardcoded Colors Rule" in CLAUDE.md.
-    window.lbl_dino_custom.setStyleSheet("font-size:10px;color:palette(text);")
+    # No font-size here — the caption follows the global ui_font_pt rule.
+    window.lbl_dino_custom.setStyleSheet("color:palette(text);")
     btn_dino_browse = QPushButton("Browse")
-    btn_dino_browse.setFixedWidth(60)
+    # No fixed width — a 60px cap clipped the caption at large UI font
+    # sizes (low-vision zoom); sizeHint tracks the active font.
     btn_dino_browse.clicked.connect(window.browse_dino_model)
     dino_browse_layout.addWidget(window.lbl_dino_custom, 1)
     dino_browse_layout.addWidget(btn_dino_browse)
@@ -164,7 +166,7 @@ def build_sidebar(window):
     # dark) provide it via QLabel rules. Hardcoded #f5f5f5 used to
     # punch a bright rectangle into the dark sidebar.
     window.lbl_dino_status.setStyleSheet(
-        "font-size:11px;padding:4px;border-radius:3px;"
+        "padding:4px;border-radius:3px;"
         "border:1px solid palette(mid);"
     )
     dino_layout.addWidget(window.lbl_dino_status)

--- a/src/digitalsreeni_image_annotator/ui/theme.py
+++ b/src/digitalsreeni_image_annotator/ui/theme.py
@@ -1,22 +1,51 @@
 """Theme + font size application, extracted from `ImageAnnotator`.
 
 The functions here take the main window as their first argument; they
-read state directly off it (`dark_mode`, `current_font_size`, etc.) and
-write to its widgets. Kept as plain functions rather than a controller
-class because they are stateless and the call sites are sparse.
+read state directly off it (`dark_mode`, `ui_font_pt`, etc.) and write
+to its widgets. Kept as plain functions rather than a controller class
+because they are stateless and the call sites are sparse.
+
+`mw.ui_font_pt` (int, 8-24, default 10) is the single source of truth
+for UI text size. The Settings → Font Size presets jump to fixed
+values; Ctrl+Shift+= / Ctrl+Shift+- step it ±1pt. Every change goes
+through `set_font_pt`, which clamps, re-applies the theme, persists
+via QSettings and syncs the preset menu checkmarks.
 """
 
 from PyQt6.QtGui import QFont
-from PyQt6.QtWidgets import QComboBox, QLabel, QWidget
+from PyQt6.QtWidgets import QWidget
 
+from ..app_settings import FONT_PT_DEFAULT, clamp_font_pt, save_ui_prefs
 from .default_stylesheet import default_stylesheet
 from .soft_dark_stylesheet import soft_dark_stylesheet
 
+# Legacy px values from the static stylesheets at the 10pt default.
+# The overrides scale these by ui_font_pt / 10 and stay in px so the
+# default renders pixel-identical to the pre-zoom stylesheets.
+_HEADER_PX_AT_DEFAULT = 14      # QLabel.section-header font-size
+_INDICATOR_PX_AT_DEFAULT = 14   # checkbox / radio indicator width+height
+_RADIO_RADIUS_PX_AT_DEFAULT = 8  # radio indicator border-radius
+
 
 def apply_theme_and_font(mw):
-    font_size = mw.font_sizes[mw.current_font_size]
+    font_size = mw.ui_font_pt
     style = soft_dark_stylesheet if mw.dark_mode else default_stylesheet
-    combined_style = f"{style}\nQWidget {{ font-size: {font_size}pt; }}"
+    # Appended rules win over the static sheet (same specificity,
+    # later in cascade) — this is how the hardcoded px sizes in the
+    # stylesheets are made to follow ui_font_pt without templating
+    # the static strings.
+    scale = font_size / FONT_PT_DEFAULT
+    header_px = round(_HEADER_PX_AT_DEFAULT * scale)
+    indicator_px = round(_INDICATOR_PX_AT_DEFAULT * scale)
+    radio_radius_px = round(_RADIO_RADIUS_PX_AT_DEFAULT * scale)
+    combined_style = (
+        f"{style}\n"
+        f"QWidget {{ font-size: {font_size}pt; }}\n"
+        f"QLabel.section-header {{ font-size: {header_px}px; }}\n"
+        f"QCheckBox::indicator, QRadioButton::indicator {{"
+        f" width: {indicator_px}px; height: {indicator_px}px; }}\n"
+        f"QRadioButton::indicator {{ border-radius: {radio_radius_px}px; }}"
+    )
     mw.setStyleSheet(combined_style)
 
     for widget in mw.findChildren(QWidget):
@@ -25,12 +54,46 @@ def apply_theme_and_font(mw):
         widget.setFont(font)
 
     mw.image_label.setFont(QFont("Arial", font_size))
+    mw.image_label.set_ui_scale(font_size / FONT_PT_DEFAULT)
     mw.update()
+
+
+def set_font_pt(mw, pt):
+    mw.ui_font_pt = clamp_font_pt(pt)
+    apply_theme_and_font(mw)
+    save_ui_prefs(mw.ui_font_pt, mw.dark_mode)
+    sync_font_menu(mw)
+
+
+def step_font_pt(mw, delta):
+    set_font_pt(mw, mw.ui_font_pt + delta)
+
+
+def reset_font_pt(mw):
+    set_font_pt(mw, FONT_PT_DEFAULT)
+
+
+def change_font_size(mw, size):
+    """Preset entry point — `size` is a name from `mw.font_sizes`."""
+    set_font_pt(mw, mw.font_sizes[size])
+
+
+def sync_font_menu(mw):
+    """Check the preset action matching ui_font_pt, uncheck the rest.
+
+    No preset is checked when the user stepped to an in-between size.
+    """
+    actions = getattr(mw, "_font_preset_actions", None)
+    if not actions:
+        return
+    for name, action in actions.items():
+        action.setChecked(mw.font_sizes[name] == mw.ui_font_pt)
 
 
 def toggle_dark_mode(mw):
     mw.dark_mode = not mw.dark_mode
     apply_theme_and_font(mw)
+    save_ui_prefs(mw.ui_font_pt, mw.dark_mode)
     mw.update_slice_list_colors()
     mw.update_class_list()
     mw.update_annotation_list()
@@ -45,24 +108,3 @@ def update_ui_colors(mw):
     mw.update_annotation_list_colors()
     mw.update_slice_list_colors()
     mw.image_label.update()
-
-
-def setup_font_size_selector(mw):
-    font_size_label = QLabel("Font Size:")
-    mw.font_size_selector = QComboBox()
-    mw.font_size_selector.addItems(["Small", "Medium", "Large"])
-    mw.font_size_selector.setCurrentText("Medium")
-    mw.font_size_selector.currentTextChanged.connect(lambda size: on_font_size_changed(mw, size))
-
-    mw.sidebar_layout.addWidget(font_size_label)
-    mw.sidebar_layout.addWidget(mw.font_size_selector)
-
-
-def on_font_size_changed(mw, size):
-    mw.current_font_size = size
-    apply_theme_and_font(mw)
-
-
-def change_font_size(mw, size):
-    mw.current_font_size = size
-    apply_theme_and_font(mw)

--- a/src/digitalsreeni_image_annotator/ui/theme.py
+++ b/src/digitalsreeni_image_annotator/ui/theme.py
@@ -25,6 +25,11 @@ from .soft_dark_stylesheet import soft_dark_stylesheet
 _HEADER_PX_AT_DEFAULT = 14      # QLabel.section-header font-size
 _INDICATOR_PX_AT_DEFAULT = 14   # checkbox / radio indicator width+height
 _RADIO_RADIUS_PX_AT_DEFAULT = 8  # radio indicator border-radius
+# DINO sidebar panel uses deliberately compact text (smaller than body).
+# The widgets carry no inline font-size — these rules own it so the
+# compact look is preserved but still scales with ui_font_pt.
+_DINO_COMPACT_PX_AT_DEFAULT = 11  # threshold table, phrase list, buttons
+_DINO_HINT_PX_AT_DEFAULT = 10     # italic hint under "Phrases for:"
 
 
 def apply_theme_and_font(mw):
@@ -38,13 +43,20 @@ def apply_theme_and_font(mw):
     header_px = round(_HEADER_PX_AT_DEFAULT * scale)
     indicator_px = round(_INDICATOR_PX_AT_DEFAULT * scale)
     radio_radius_px = round(_RADIO_RADIUS_PX_AT_DEFAULT * scale)
+    dino_px = round(_DINO_COMPACT_PX_AT_DEFAULT * scale)
+    dino_hint_px = round(_DINO_HINT_PX_AT_DEFAULT * scale)
     combined_style = (
         f"{style}\n"
         f"QWidget {{ font-size: {font_size}pt; }}\n"
         f"QLabel.section-header {{ font-size: {header_px}px; }}\n"
         f"QCheckBox::indicator, QRadioButton::indicator {{"
         f" width: {indicator_px}px; height: {indicator_px}px; }}\n"
-        f"QRadioButton::indicator {{ border-radius: {radio_radius_px}px; }}"
+        f"QRadioButton::indicator {{ border-radius: {radio_radius_px}px; }}\n"
+        f"ClassThresholdTable, ClassThresholdTable QDoubleSpinBox,"
+        f" ClassThresholdTable QHeaderView::section,"
+        f" PhraseEditorPanel QLabel, PhraseEditorPanel QListWidget,"
+        f" PhraseEditorPanel QPushButton {{ font-size: {dino_px}px; }}\n"
+        f"QLabel#dino_phrase_hint {{ font-size: {dino_hint_px}px; }}"
     )
     mw.setStyleSheet(combined_style)
 

--- a/src/digitalsreeni_image_annotator/widgets/image_label.py
+++ b/src/digitalsreeni_image_annotator/widgets/image_label.py
@@ -75,6 +75,11 @@ class ImageLabel(QLabel):
         self.temp_point = None
         self.current_tool = None
         self.zoom_factor = 1.0
+        # Low-vision UI zoom: ui_font_pt / 10 (legacy default), set by
+        # theme.apply_theme_and_font. Multiplies overlay sizes (label
+        # fonts, marker radii, pen widths) — orthogonal to zoom_factor,
+        # which keeps them constant-size on screen across image zoom.
+        self.ui_scale = 1.0
         self.class_colors = {}
         self.class_visibility = {}
         self.start_point = None
@@ -129,6 +134,18 @@ class ImageLabel(QLabel):
 
     def set_context(self, ctx):
         self._ctx = ctx
+
+    def set_ui_scale(self, scale):
+        self.ui_scale = scale
+        self.update()
+
+    def _pen_w(self, base):
+        """Overlay pen width: ui-scaled, zoom-compensated (constant on screen)."""
+        return base * self.ui_scale / self.zoom_factor
+
+    def _overlay_font(self, base=12):
+        """Overlay label font: ui-scaled, zoom-compensated (constant on screen)."""
+        return QFont("Arial", max(1, int(base * self.ui_scale / self.zoom_factor)))
 
     @property
     def active_tool_handler(self):
@@ -239,14 +256,17 @@ class ImageLabel(QLabel):
                 painter.save()
                 painter.translate(self.offset_x, self.offset_y)
                 painter.scale(self.zoom_factor, self.zoom_factor)
+                # Radii intentionally NOT zoom-compensated — the dots
+                # grow with image zoom (pre-existing behaviour).
+                dot_r = 4 * self.ui_scale
                 for pt in self.sam_positive_points:
-                    painter.setPen(QPen(Qt.GlobalColor.green, 6 / self.zoom_factor, Qt.PenStyle.SolidLine))
+                    painter.setPen(QPen(Qt.GlobalColor.green, self._pen_w(6), Qt.PenStyle.SolidLine))
                     painter.setBrush(QBrush(Qt.GlobalColor.green))
-                    painter.drawEllipse(QPointF(pt[0], pt[1]), 4, 4)
+                    painter.drawEllipse(QPointF(pt[0], pt[1]), dot_r, dot_r)
                 for pt in self.sam_negative_points:
-                    painter.setPen(QPen(Qt.GlobalColor.red, 6 / self.zoom_factor, Qt.PenStyle.SolidLine))
+                    painter.setPen(QPen(Qt.GlobalColor.red, self._pen_w(6), Qt.PenStyle.SolidLine))
                     painter.setBrush(QBrush(Qt.GlobalColor.red))
-                    painter.drawEllipse(QPointF(pt[0], pt[1]), 4, 4)
+                    painter.drawEllipse(QPointF(pt[0], pt[1]), dot_r, dot_r)
                 painter.restore()
             # In-progress overlays from every tool that has state to
             # render (paint mask, eraser mask, polygon-in-progress,
@@ -268,7 +288,7 @@ class ImageLabel(QLabel):
 
         for annotation in self.temp_annotations:
             color = QColor(255, 165, 0, 128)  # Semi-transparent orange
-            painter.setPen(QPen(color, 2 / self.zoom_factor, Qt.PenStyle.DashLine))
+            painter.setPen(QPen(color, self._pen_w(2), Qt.PenStyle.DashLine))
             painter.setBrush(QBrush(color))
 
             # Prefer segmentation polygon over bbox when both are present
@@ -288,7 +308,7 @@ class ImageLabel(QLabel):
                 painter.drawRect(QRectF(x, y, w, h))
 
             # Draw label and score
-            painter.setFont(QFont("Arial", int(12 / self.zoom_factor)))
+            painter.setFont(self._overlay_font())
             label = f"{annotation['category_name']} {annotation['score']:.2f}"
             if points is not None:
                 centroid = self.calculate_centroid(points)
@@ -351,7 +371,7 @@ class ImageLabel(QLabel):
 
             # Draw circle outline with full opacity
             painter.setOpacity(1.0)
-            painter.setPen(QPen(color.darker(150), 1 / self.zoom_factor, Qt.PenStyle.SolidLine))
+            painter.setPen(QPen(color.darker(150), self._pen_w(1), Qt.PenStyle.SolidLine))
             painter.setBrush(Qt.BrushStyle.NoBrush)
             painter.drawEllipse(
                 QPointF(self.cursor_pos[0], self.cursor_pos[1]), size, size
@@ -361,7 +381,9 @@ class ImageLabel(QLabel):
             # Reset the transform to ensure text is drawn at screen coordinates
             painter.resetTransform()
             font = QFont()
-            font.setPointSize(10)
+            # Screen-space text (transform was reset above): scale with
+            # the UI font setting only, not with image zoom.
+            font.setPointSize(max(1, int(10 * self.ui_scale)))
             painter.setFont(font)
             painter.setPen(QPen(Qt.GlobalColor.black))  # Use black color for better visibility
 
@@ -386,7 +408,7 @@ class ImageLabel(QLabel):
         painter.save()
         painter.translate(self.offset_x, self.offset_y)
         painter.scale(self.zoom_factor, self.zoom_factor)
-        painter.setPen(QPen(Qt.GlobalColor.red, 2 / self.zoom_factor, Qt.PenStyle.SolidLine))
+        painter.setPen(QPen(Qt.GlobalColor.red, self._pen_w(2), Qt.PenStyle.SolidLine))
         x1, y1, x2, y2 = self.sam_bbox
         painter.drawRect(QRectF(min(x1, x2), min(y1, y2), abs(x2 - x1), abs(y2 - y1)))
         painter.restore()
@@ -464,7 +486,7 @@ class ImageLabel(QLabel):
                 fill_color.setAlphaF(self.fill_opacity)
 
                 text_color = Qt.GlobalColor.white if self.dark_mode else Qt.GlobalColor.black
-                painter.setPen(QPen(border_color, 2 / self.zoom_factor, Qt.PenStyle.SolidLine))
+                painter.setPen(QPen(border_color, self._pen_w(2), Qt.PenStyle.SolidLine))
                 painter.setBrush(QBrush(fill_color))
 
                 if "segmentation" in annotation:
@@ -490,11 +512,9 @@ class ImageLabel(QLabel):
                         if points:
                             centroid = self.calculate_centroid(points)
                             if centroid:
-                                painter.setFont(
-                                    QFont("Arial", int(12 / self.zoom_factor))
-                                )
+                                painter.setFont(self._overlay_font())
                                 painter.setPen(
-                                    QPen(text_color, 2 / self.zoom_factor, Qt.PenStyle.SolidLine)
+                                    QPen(text_color, self._pen_w(2), Qt.PenStyle.SolidLine)
                                 )
                                 painter.drawText(
                                     centroid,
@@ -504,7 +524,7 @@ class ImageLabel(QLabel):
                 elif "bbox" in annotation:
                     x, y, width, height = annotation["bbox"]
                     painter.drawRect(QRectF(x, y, width, height))
-                    painter.setPen(QPen(text_color, 2 / self.zoom_factor, Qt.PenStyle.SolidLine))
+                    painter.setPen(QPen(text_color, self._pen_w(2), Qt.PenStyle.SolidLine))
                     painter.drawText(
                         QPointF(x, y), f"{class_name} {annotation.get('number', '')}"
                     )
@@ -515,7 +535,7 @@ class ImageLabel(QLabel):
         # Draw temporary SAM prediction
         if self.temp_sam_prediction:
             temp_color = QColor(255, 165, 0, 128)  # Semi-transparent orange
-            painter.setPen(QPen(temp_color, 2 / self.zoom_factor, Qt.PenStyle.DashLine))
+            painter.setPen(QPen(temp_color, self._pen_w(2), Qt.PenStyle.DashLine))
             painter.setBrush(QBrush(temp_color))
 
             segmentation = self.temp_sam_prediction["segmentation"]
@@ -527,7 +547,7 @@ class ImageLabel(QLabel):
                 painter.drawPolygon(QPolygonF(points))
                 centroid = self.calculate_centroid(points)
                 if centroid:
-                    painter.setFont(QFont("Arial", int(12 / self.zoom_factor)))
+                    painter.setFont(self._overlay_font())
                     painter.drawText(
                         centroid, f"SAM: {self.temp_sam_prediction['score']:.2f}"
                     )
@@ -553,7 +573,7 @@ class ImageLabel(QLabel):
         fill_color = QColor(color)
         fill_color.setAlphaF(self.fill_opacity)
 
-        painter.setPen(QPen(color, 2 / self.zoom_factor, Qt.PenStyle.SolidLine))
+        painter.setPen(QPen(color, self._pen_w(2), Qt.PenStyle.SolidLine))
         painter.setBrush(QBrush(fill_color))
         painter.drawPolygon(QPolygonF(points))  # Changed QPolygon to QPolygonF - Sreeni
 
@@ -562,7 +582,8 @@ class ImageLabel(QLabel):
                 painter.setBrush(QColor(255, 0, 0))
             else:
                 painter.setBrush(QColor(0, 255, 0))
-            painter.drawEllipse(point, 5 / self.zoom_factor, 5 / self.zoom_factor)
+            r = 5 * self.ui_scale / self.zoom_factor
+            painter.drawEllipse(point, r, r)
 
         painter.restore()
 
@@ -855,7 +876,7 @@ class ImageLabel(QLabel):
             )
         ]
         for i, point in enumerate(points):
-            if self.distance(pos, point) < 10 / self.zoom_factor:
+            if self.distance(pos, point) < 10 * self.ui_scale / self.zoom_factor:
                 if event.modifiers() & Qt.KeyboardModifier.ShiftModifier:
                     # Delete point
                     del self.editing_polygon["segmentation"][i * 2 : i * 2 + 2]
@@ -884,7 +905,7 @@ class ImageLabel(QLabel):
         ]
         self.hover_point_index = None
         for i, point in enumerate(points):
-            if self.distance(pos, point) < 10 / self.zoom_factor:
+            if self.distance(pos, point) < 10 * self.ui_scale / self.zoom_factor:
                 self.hover_point_index = i
                 break
         if self.editing_point_index is not None:

--- a/tests/ui/test_font_zoom.py
+++ b/tests/ui/test_font_zoom.py
@@ -1,0 +1,123 @@
+"""Tests for the continuous UI font zoom (low-vision mode).
+
+Uses a minimal QMainWindow stub carrying exactly the state
+theme.set_font_pt touches, instead of constructing the full
+ImageAnnotator (which would dominate suite runtime). save_ui_prefs is
+patched out so tests never write the real per-user settings.
+"""
+
+import pytest
+from PyQt6.QtGui import QAction
+from PyQt6.QtWidgets import QMainWindow
+
+from digitalsreeni_image_annotator.app_settings import (
+    FONT_PT_DEFAULT,
+    FONT_PT_MAX,
+    FONT_PT_MIN,
+)
+from digitalsreeni_image_annotator.ui import theme
+from digitalsreeni_image_annotator.widgets.image_label import ImageLabel
+
+
+class _StubWindow(QMainWindow):
+    """Just enough ImageAnnotator surface for theme.set_font_pt."""
+
+    def __init__(self):
+        super().__init__()
+        self.font_sizes = {"Small": 8, "Medium": 10, "Large": 12, "XL": 14, "XXL": 16}
+        self.ui_font_pt = FONT_PT_DEFAULT
+        self.dark_mode = True
+        self.image_label = ImageLabel()
+        self._font_preset_actions = {}
+        for name in self.font_sizes:
+            action = QAction(name, self)
+            action.setCheckable(True)
+            self._font_preset_actions[name] = action
+
+
+@pytest.fixture
+def window(qt_application, monkeypatch):
+    saved = []
+    monkeypatch.setattr(
+        theme, "save_ui_prefs", lambda pt, dark, settings=None: saved.append((pt, dark))
+    )
+    w = _StubWindow()
+    w._saved_prefs = saved
+    yield w
+    w.image_label.deleteLater()
+    w.deleteLater()
+
+
+def test_step_up_increments_and_scales_canvas(window):
+    theme.step_font_pt(window, 1)
+    assert window.ui_font_pt == FONT_PT_DEFAULT + 1
+    assert window.image_label.ui_scale == pytest.approx(
+        (FONT_PT_DEFAULT + 1) / FONT_PT_DEFAULT
+    )
+
+
+def test_step_clamps_at_bounds(window):
+    theme.set_font_pt(window, FONT_PT_MAX)
+    theme.step_font_pt(window, 1)
+    assert window.ui_font_pt == FONT_PT_MAX
+
+    theme.set_font_pt(window, FONT_PT_MIN)
+    theme.step_font_pt(window, -1)
+    assert window.ui_font_pt == FONT_PT_MIN
+
+
+def test_reset_returns_to_default(window):
+    theme.set_font_pt(window, 20)
+    theme.reset_font_pt(window)
+    assert window.ui_font_pt == FONT_PT_DEFAULT
+    assert window.image_label.ui_scale == pytest.approx(1.0)
+
+
+def test_preset_entry_point_sets_value(window):
+    theme.change_font_size(window, "XXL")
+    assert window.ui_font_pt == 16
+
+
+def test_preset_checkmark_follows_value(window):
+    theme.change_font_size(window, "Large")
+    assert window._font_preset_actions["Large"].isChecked()
+    assert not window._font_preset_actions["Medium"].isChecked()
+
+    # Stepping to an in-between size unchecks every preset.
+    theme.step_font_pt(window, 1)  # 13pt — between Large and XL
+    assert not any(a.isChecked() for a in window._font_preset_actions.values())
+
+
+def test_every_change_is_persisted(window):
+    theme.set_font_pt(window, 12)
+    theme.step_font_pt(window, 1)
+    assert window._saved_prefs == [(12, True), (13, True)]
+
+
+def test_default_scale_renders_identical_to_legacy(window):
+    """At the default 10pt, ui_scale is exactly 1.0 — overlay rendering
+    must be pixel-identical to the pre-feature code paths."""
+    theme.set_font_pt(window, FONT_PT_DEFAULT)
+    assert window.image_label.ui_scale == 1.0
+    assert window.image_label._pen_w(2) == pytest.approx(2.0)
+
+
+def test_stylesheet_contains_scaled_overrides(window):
+    theme.set_font_pt(window, 20)
+    sheet = window.styleSheet()
+    assert "QWidget { font-size: 20pt; }" in sheet
+    # Header/indicator overrides scale the legacy px values by 2x at 20pt.
+    assert "QLabel.section-header { font-size: 28px; }" in sheet
+    assert "width: 28px; height: 28px;" in sheet
+    assert "QRadioButton::indicator { border-radius: 16px; }" in sheet
+
+
+def test_default_stylesheet_overrides_match_legacy_px(window):
+    """At the 10pt default the appended overrides must reproduce the
+    static stylesheets' values exactly (14px header, 14px indicators,
+    8px radio radius) — the zoom feature must be invisible until used."""
+    theme.set_font_pt(window, FONT_PT_DEFAULT)
+    sheet = window.styleSheet()
+    assert "QLabel.section-header { font-size: 14px; }" in sheet
+    assert "width: 14px; height: 14px;" in sheet
+    assert "QRadioButton::indicator { border-radius: 8px; }" in sheet

--- a/tests/ui/test_font_zoom.py
+++ b/tests/ui/test_font_zoom.py
@@ -110,6 +110,32 @@ def test_stylesheet_contains_scaled_overrides(window):
     assert "QLabel.section-header { font-size: 28px; }" in sheet
     assert "width: 28px; height: 28px;" in sheet
     assert "QRadioButton::indicator { border-radius: 16px; }" in sheet
+    # Compact DINO panel scales too (11px / 10px legacy at default).
+    assert "PhraseEditorPanel QPushButton { font-size: 22px; }" in sheet
+    assert "QLabel#dino_phrase_hint { font-size: 20px; }" in sheet
+
+
+def test_dino_panel_resolves_compact_scaled_font(window, qt_application):
+    """The compact DINO-panel rules must win at the *rendered-font*
+    level — i.e. the QSS px rules beat the findChildren setFont(pt)
+    loop in apply_theme_and_font. String presence in the stylesheet
+    (tested above) is not enough; this guards the precedence."""
+    from PyQt6.QtWidgets import QLabel
+
+    from digitalsreeni_image_annotator.dialogs.dino_phrase_editor import (
+        PhraseEditorPanel,
+    )
+
+    panel = PhraseEditorPanel()
+    window.setCentralWidget(panel)
+    theme.set_font_pt(window, 20)  # scale 2.0 -> compact 22px, hint 20px
+    qt_application.processEvents()
+
+    panel.btn_add_phrase.ensurePolished()
+    assert panel.btn_add_phrase.font().pixelSize() == 22
+    hint = panel.findChild(QLabel, "dino_phrase_hint")
+    hint.ensurePolished()
+    assert hint.font().pixelSize() == 20
 
 
 def test_default_stylesheet_overrides_match_legacy_px(window):
@@ -121,3 +147,5 @@ def test_default_stylesheet_overrides_match_legacy_px(window):
     assert "QLabel.section-header { font-size: 14px; }" in sheet
     assert "width: 14px; height: 14px;" in sheet
     assert "QRadioButton::indicator { border-radius: 8px; }" in sheet
+    assert "PhraseEditorPanel QPushButton { font-size: 11px; }" in sheet
+    assert "QLabel#dino_phrase_hint { font-size: 10px; }" in sheet

--- a/tests/unit/test_app_settings.py
+++ b/tests/unit/test_app_settings.py
@@ -1,0 +1,61 @@
+"""Unit tests for app_settings (UI preference persistence).
+
+QSettings is exercised against an INI file in tmp_path so the tests
+never touch the real per-user registry/config.
+"""
+
+import pytest
+from PyQt6.QtCore import QSettings
+
+from digitalsreeni_image_annotator.app_settings import (
+    FONT_PT_DEFAULT,
+    FONT_PT_MAX,
+    FONT_PT_MIN,
+    clamp_font_pt,
+    load_ui_prefs,
+    save_ui_prefs,
+)
+
+
+class TestClampFontPt:
+    def test_in_range_passes_through(self):
+        assert clamp_font_pt(12) == 12
+
+    def test_below_min_clamps(self):
+        assert clamp_font_pt(3) == FONT_PT_MIN
+
+    def test_above_max_clamps(self):
+        assert clamp_font_pt(99) == FONT_PT_MAX
+
+    def test_numeric_string_is_coerced(self):
+        # QSettings INI backend round-trips ints as strings.
+        assert clamp_font_pt("14") == 14
+
+    def test_garbage_falls_back_to_default(self):
+        assert clamp_font_pt("huge") == FONT_PT_DEFAULT
+
+    def test_none_falls_back_to_default(self):
+        assert clamp_font_pt(None) == FONT_PT_DEFAULT
+
+
+@pytest.fixture
+def ini_settings(tmp_path):
+    return QSettings(str(tmp_path / "prefs.ini"), QSettings.Format.IniFormat)
+
+
+class TestUiPrefsRoundtrip:
+    def test_defaults_from_empty_settings(self, ini_settings):
+        assert load_ui_prefs(ini_settings) == (FONT_PT_DEFAULT, True)
+
+    def test_roundtrip(self, ini_settings):
+        save_ui_prefs(18, False, ini_settings)
+        ini_settings.sync()
+        assert load_ui_prefs(ini_settings) == (18, False)
+
+    def test_save_clamps_out_of_range(self, ini_settings):
+        save_ui_prefs(100, True, ini_settings)
+        assert load_ui_prefs(ini_settings) == (FONT_PT_MAX, True)
+
+    def test_load_clamps_corrupt_value(self, ini_settings):
+        ini_settings.setValue("ui/font_pt", "not-a-number")
+        assert load_ui_prefs(ini_settings)[0] == FONT_PT_DEFAULT


### PR DESCRIPTION
## Summary

Accessibility feature for users with decreased eyesight: the application font now scales **continuously from 8 to 24pt**, persisted across restarts — without breaking the dark/light design.

- **Shortcuts**: `Ctrl+Shift+=` / `Ctrl+Shift+-` step ±1pt (`Ctrl++` / `Ctrl+-` also work), `Ctrl+Shift+0` resets. All three live as entries in Settings → Font Size, so they're discoverable.
- **Presets stay**: Small…XXL are now checkable and act as named entry points into the same range; the checkmark tracks the current value (none is checked at an in-between size).
- **Canvas visuals scale too**: annotation label fonts, SAM point markers, pen widths, polygon edit handles and click-target tolerances grow with the setting via `ui_scale = ui_font_pt / 10`. They remain zoom-compensated, so they stay constant-size on screen across image zoom. At the default 10pt, rendering is pixel-identical to before (pinned by test).
- **Persistence**: first QSettings usage (`app_settings.py`) — `ui/font_pt` and `ui/dark_mode` survive restarts. Per-user preference, deliberately not in the `.iap` project file (ADR-020).
- **Design intact**: stylesheets stay static strings; appended QSS overrides scale the hardcoded px values (section headers, checkbox/radio indicators incl. radio roundness) by exactly the legacy proportions.

## Fixes along the way

- `HelpWindow.apply_font_size` used to **replace** the theme stylesheet with a bare font rule — help window lost dark/light theming. Now appends to the stored base sheet.
- DINO "Browse" button had `setFixedWidth(60)` and clipped its caption at large fonts.
- Two sidebar captions hardcoded `font-size:10px/11px` and ignored the font setting.
- Removed dead `theme.setup_font_size_selector` / `on_font_size_changed` (no call sites).
- Doc fix: arc42 shortcut table claimed Ctrl+Shift+S = Annotation Statistics (it's Save As; stats is Ctrl+Alt+S).

## Verification

- 113 tests pass (18 new: clamp/INI-roundtrip for `app_settings`, stepping/clamping/preset-sync/stylesheet-pinning for `theme`); suite runs in ~1s.
- Offscreen full-`ImageAnnotator` run: stepping 8→24, clamps, preset checkmarks, dark-mode toggles at both extremes, help window themed+sized, programmatic clip audit at 24pt finds no clipped buttons.
- Senior reviewer gate run; the P1 (px/pt unit mismatch in the header override that would have enlarged section headers at the default size) and P2s fixed; known debt (hardcoded font sizes in standalone DINO dialogs) recorded in ADR-020.

## Docs

arc42 updated in the same PR: new "UI Font Zoom (Low-Vision Mode)" concept in `08_crosscutting_concepts.md`, ADR-020 in `09_architecture_decisions.md`, structure tree in `05_building_block_view.md`, CLAUDE.md structure + shortcut tables, in-app help (F1) shortcut list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
