### PR TITLE
Five upstream quick wins: #30, #44, #33, #60, #56

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,11 +48,6 @@ Issue numbers refer to https://github.com/bnsreenu/digitalsreeni-image-annotator
 
 | Issue | Size | Task |
 |-------|------|------|
-| #30 | quick win | `yolo_trainer.py` `save_model()`: `self.model.export(save_path)` → `self.model.save(save_path)` (reporter-verified fix) |
-| #44 | quick win | Add `encoding='utf-8'` to all YAML `open()` calls (Windows `'charmap' codec` crash) — yolo_trainer.py, import_formats.py, export_formats.py, dataset_splitter.py |
-| #33 | quick win | `start_polygon_edit` in image_label.py: select smallest-area containing polygon so annotations nested inside others become editable (reuse shoelace `calculate_area`) |
-| #60 | quick win | Sort image list alphabetically. Insert sorted in list population — do **NOT** use `setSortingEnabled(True)`: `currentRowChanged` is wired to `switch_image` and re-sorts would fire spurious switches |
-| #56 | quick win | LZW-compressed TIFF crashes app: add `imagecodecs` to install_requires, or catch `ValueError` in `load_tiff` with an actionable message |
 | #32 + #36 | medium | Annotations can extend outside image bounds (manual edit + Image Augmenter) → clamp coords on commit; clip augmented polygons to image rect (shapely intersection). Silently poisons training data |
 | #40 | medium | True bbox editing (move whole box, drag edges, keep rectangularity). Currently bbox annotations aren't editable at all — `start_polygon_edit` only matches `"segmentation"` |
 | #63 | blocked | SAM 3 support — blocked on Ultralytics shipping SAM 3; re-check their releases before attempting |

--- a/docs/05_building_block_view.md
+++ b/docs/05_building_block_view.md
@@ -209,7 +209,7 @@ the controller graph.
 | Controller | Responsibility |
 |------------|----------------|
 | `ProjectController` | `.iap` save/load, auto-save, backup/restore, missing-image prompts, window-title sync. Owns the `is_loading_project` autosave guard (load/save round-trip safety, v0.8.12). |
-| `ImageController` | Open / load / switch images and slices. TIFF + CZI loaders, the multi-dim `DimensionDialog`, the `[-ndim:]` axis-slice bug fix from the v0.9.0 era. Image-list annotation-status filter (`image_has_annotations`, `apply_image_filter` — upstream #27). |
+| `ImageController` | Open / load / switch images and slices. TIFF + CZI loaders (with `imagecodecs` codec-error handling — #56), the multi-dim `DimensionDialog`, the `[-ndim:]` axis-slice bug fix from the v0.9.0 era. Image-list annotation-status filter (`image_has_annotations`, `apply_image_filter` — #27) and alphabetical sort (`sort_image_list` — #60). |
 | `AnnotationController` | Annotation CRUD, list sorting, highlight, edit-mode entry/exit, `finish_polygon`, `finish_rectangle`, `replace_annotations` (eraser path). Validates writes before mutating `all_annotations`. |
 | `ClassController` | Class add / delete / rename / colour / visibility. `update_slice_list_colors`, `is_class_visible`. |
 | `SAMController` | SAM box/points tool lifecycle, debounce timer, `_sam_inference_in_flight` re-entrancy guard (ADR-013), model picker. |

--- a/docs/08_crosscutting_concepts.md
+++ b/docs/08_crosscutting_concepts.md
@@ -558,6 +558,37 @@ emitters follow up with `annotationsBatchSaved`
 New mutation paths must keep one of those two routes — don't add
 bespoke `apply_image_filter()` call sites.
 
+## Image List Sorting — Rebuild, Don't `setSortingEnabled`
+
+The image list is kept alphabetical (upstream issue #60,
+`ImageController.sort_image_list`). Two constraints shape the
+implementation:
+
+- `currentRowChanged` is wired to `switch_image`, so `setSortingEnabled(True)`
+  is forbidden — a live re-sort would reorder rows and fire spurious
+  image switches.
+- COCO import (and other positional lookups) assume `all_images[i]`
+  matches `image_list.item(i)`. So the model and the view are sorted
+  **together**: `all_images` is sorted, then the list is cleared and
+  repopulated from it with `blockSignals(True)` around the rebuild, and
+  the prior (or newly added) selection is restored explicitly. The #27
+  filter is re-applied at the end of the rebuild.
+
+`update_image_list` routes through `sort_image_list`; `add_images_to_list`
+calls it with the first added file selected. It is skipped per-image
+during project load (the list is rebuilt once via `update_ui`) to avoid
+an O(n²) re-sort.
+
+## TIFF Compression Codecs
+
+Reading an LZW- (or otherwise) compressed TIFF requires the optional
+`imagecodecs` package; without it `tifffile` raises `ValueError` mid-read
+(upstream issue #56). `imagecodecs` is now a hard dependency, but
+`ImageController.add_images_to_list` also catches the codec `ValueError`
+(`_is_missing_codec_error`) and shows an actionable "pip install
+imagecodecs" dialog, skipping the file instead of crashing or leaving a
+half-added entry. Non-codec `ValueError`s still propagate.
+
 ## Canvas Decoupling — Signals + CanvasContext
 
 `ImageLabel` (the canvas widget) does **not** hold a reference to

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         "numpy>=2.0.0",  # pip resolves 2.4+ on Py3.14, 2.2.x on Py3.10 (last 3.10-compatible)
         "Pillow>=10.0.0",
         "tifffile>=2023.0.0",
+        "imagecodecs>=2023.1.23",  # tifffile needs it for LZW/compressed TIFF (#56)
         "czifile>=2019.7.2",
         "opencv-python>=4.8.0",
         "pyyaml>=6.0.0",

--- a/src/digitalsreeni_image_annotator/controllers/annotation_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/annotation_controller.py
@@ -540,7 +540,7 @@ class AnnotationController(QObject):
         msg_box.setText("Do you want to keep the original annotations?")
         msg_box.setIcon(QMessageBox.Icon.Question)
 
-        keep_button = msg_box.addButton("Keep", QMessageBox.ButtonRole.YesRole)
+        msg_box.addButton("Keep", QMessageBox.ButtonRole.YesRole)
         delete_button = msg_box.addButton("Delete", QMessageBox.ButtonRole.NoRole)
         cancel_button = msg_box.addButton("Cancel", QMessageBox.ButtonRole.RejectRole)
 

--- a/src/digitalsreeni_image_annotator/controllers/annotation_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/annotation_controller.py
@@ -217,7 +217,7 @@ class AnnotationController(QObject):
         if not file_name:
             return
 
-        with open(file_name, "r") as f:
+        with open(file_name, "r", encoding='utf-8') as f:
             self.mw.loaded_json = json.load(f)
 
         self.mw.class_list.clear()

--- a/src/digitalsreeni_image_annotator/controllers/annotation_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/annotation_controller.py
@@ -259,9 +259,11 @@ class AnnotationController(QObject):
 
         for img in json_images.values():
             updated_all_images.append(img)
-            self.mw.image_list.addItem(img["file_name"])
 
         self.mw.all_images = updated_all_images
+        # Rebuild the list in sorted order (issue #60). The reconciliation
+        # loop above already consumed the pre-sort row/index alignment.
+        self.mw.update_image_list()
 
         self.mw.all_annotations.clear()
         for annotation in self.mw.loaded_json["annotations"]:

--- a/src/digitalsreeni_image_annotator/controllers/image_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/image_controller.py
@@ -110,7 +110,10 @@ class ImageController(QObject):
             current = self.mw.image_list.currentItem().text()
 
         self.mw.all_images.sort(
-            key=lambda info: (info["file_name"].casefold(), info["file_name"])
+            key=lambda info: (
+                info.get("file_name", "").casefold(),
+                info.get("file_name", ""),
+            )
         )
 
         self.mw.image_list.blockSignals(True)
@@ -297,10 +300,14 @@ class ImageController(QObject):
 
     @staticmethod
     def _is_missing_codec_error(exc):
-        """True if a tifffile read failed because a compression codec
-        (imagecodecs) is unavailable — e.g. LZW (#56)."""
-        msg = str(exc).lower()
-        return "imagecodecs" in msg or "compression" in msg
+        """True if a tifffile read failed because the imagecodecs package
+        is unavailable for the TIFF's compression — e.g. LZW (#56).
+
+        Matches only the reliable 'imagecodecs' token: tifffile names the
+        package in every such message. A broader 'compression' match would
+        silently swallow unrelated ValueErrors behind a misleading dialog.
+        """
+        return "imagecodecs" in str(exc).lower()
 
     def update_all_images(self, new_image_info):
         for info in new_image_info:

--- a/src/digitalsreeni_image_annotator/controllers/image_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/image_controller.py
@@ -236,7 +236,25 @@ class ImageController(QObject):
                 }
 
                 if file_name.lower().endswith((".tif", ".tiff", ".czi")):
-                    self.load_multi_slice_image(file_name)
+                    try:
+                        self.load_multi_slice_image(file_name)
+                    except ValueError as e:
+                        # LZW/compressed TIFFs need the optional imagecodecs
+                        # package; without it tifffile raises ValueError and
+                        # the app used to crash (#56). Skip the file with an
+                        # actionable message instead of a half-added entry.
+                        if self._is_missing_codec_error(e):
+                            QMessageBox.critical(
+                                self.mw,
+                                "Cannot open TIFF",
+                                f"'{base_name}' uses a compression that requires "
+                                "the 'imagecodecs' package, which is not "
+                                "installed.\n\nInstall it with:\n"
+                                "    pip install imagecodecs\n\n"
+                                "then reopen the image.",
+                            )
+                            continue
+                        raise
                     base_name_without_ext = os.path.splitext(base_name)[0]
                     if (
                         base_name_without_ext in self.mw.image_slices
@@ -276,6 +294,13 @@ class ImageController(QObject):
 
         if not self.mw.is_loading_project:
             self.mw.auto_save()
+
+    @staticmethod
+    def _is_missing_codec_error(exc):
+        """True if a tifffile read failed because a compression codec
+        (imagecodecs) is unavailable — e.g. LZW (#56)."""
+        msg = str(exc).lower()
+        return "imagecodecs" in msg or "compression" in msg
 
     def update_all_images(self, new_image_info):
         for info in new_image_info:

--- a/src/digitalsreeni_image_annotator/controllers/image_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/image_controller.py
@@ -86,10 +86,52 @@ class ImageController(QObject):
         self.mw = main_window
 
     def update_image_list(self):
+        # Rebuild (and sort) the list, preserving the current selection
+        # without switching images.
+        self.sort_image_list()
+
+    def sort_image_list(self, select_name=None, do_switch=False):
+        """Populate image_list in alphabetical order (upstream issue #60).
+
+        Sorts the model (`all_images`) and the view together so the
+        `all_images[i]` ↔ `image_list.item(i)` positional invariant holds
+        (relied on by COCO import reconciliation). `setSortingEnabled` is
+        deliberately NOT used: `currentRowChanged` is wired to
+        `switch_image`, so a live re-sort would fire spurious image
+        switches. We rebuild with signals blocked instead, then re-select
+        explicitly.
+
+        select_name: file to select after the rebuild (defaults to the
+        previously-current item). do_switch: call switch_image once for
+        the selected item (used when adding new images).
+        """
+        current = None
+        if self.mw.image_list.currentItem() is not None:
+            current = self.mw.image_list.currentItem().text()
+
+        self.mw.all_images.sort(
+            key=lambda info: (info["file_name"].casefold(), info["file_name"])
+        )
+
+        self.mw.image_list.blockSignals(True)
         self.mw.image_list.clear()
-        for image_info in self.mw.all_images:
-            self.mw.image_list.addItem(image_info["file_name"])
+        for info in self.mw.all_images:
+            self.mw.image_list.addItem(info["file_name"])
+        self.mw.image_list.blockSignals(False)
+
         self.apply_image_filter()
+
+        target = select_name if select_name is not None else current
+        if target is not None:
+            items = self.mw.image_list.findItems(
+                target, Qt.MatchFlag.MatchExactly
+            )
+            if items:
+                self.mw.image_list.blockSignals(True)
+                self.mw.image_list.setCurrentItem(items[0])
+                self.mw.image_list.blockSignals(False)
+                if do_switch:
+                    self.switch_image(items[0])
 
     def image_has_annotations(self, image_info):
         """True if the image (or, for multi-dim images, any of its slices)
@@ -181,7 +223,7 @@ class ImageController(QObject):
             self.add_images_to_list(file_names)
 
     def add_images_to_list(self, file_names):
-        first_added_item = None
+        first_added_name = None
         for file_name in file_names:
             base_name = os.path.basename(file_name)
             if base_name not in self.mw.image_paths:
@@ -218,18 +260,19 @@ class ImageController(QObject):
                     image_info["width"] = image.width()
 
                 self.mw.all_images.append(image_info)
-                item = QListWidgetItem(base_name)
-                self.mw.image_list.addItem(item)
-                if first_added_item is None:
-                    first_added_item = item
+                if first_added_name is None:
+                    first_added_name = base_name
 
                 self.mw.image_paths[base_name] = file_name
 
-        if first_added_item:
-            self.mw.image_list.setCurrentItem(first_added_item)
-            self.switch_image(first_added_item)
-
-        self.apply_image_filter()
+        # Rebuild the list in sorted order and select/switch to the first
+        # newly added image. Skipped during project load (the list is
+        # rebuilt once via update_ui afterwards, and load picks row 0) to
+        # avoid an O(n^2) re-sort per image.
+        if first_added_name is not None and not self.mw.is_loading_project:
+            self.sort_image_list(select_name=first_added_name, do_switch=True)
+        else:
+            self.apply_image_filter()
 
         if not self.mw.is_loading_project:
             self.mw.auto_save()

--- a/src/digitalsreeni_image_annotator/controllers/project_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/project_controller.py
@@ -116,7 +116,7 @@ class ProjectController(QObject):
             try:
                 self.mw.is_loading_project = True
 
-                with open(project_file, "r") as f:
+                with open(project_file, "r", encoding='utf-8') as f:
                     project_data = json.load(f)
 
                 self.mw.clear_all(show_messages=False)
@@ -490,7 +490,7 @@ class ProjectController(QObject):
         if dino_cfg["phrases"] or dino_cfg["thresholds"]:
             project_data["dino_config"] = dino_cfg
 
-        with open(self.mw.current_project_file, "w") as f:
+        with open(self.mw.current_project_file, "w", encoding='utf-8') as f:
             json.dump(image_utils.convert_to_serializable(project_data), f, indent=2)
 
         if show_message:

--- a/src/digitalsreeni_image_annotator/dialogs/coco_json_combiner.py
+++ b/src/digitalsreeni_image_annotator/dialogs/coco_json_combiner.py
@@ -63,7 +63,7 @@ class COCOJSONCombinerDialog(QDialog):
     
         try:
             for file_path in self.json_files:
-                with open(file_path, 'r') as f:
+                with open(file_path, 'r', encoding='utf-8') as f:
                     data = json.load(f)
                 
                 # Combine categories
@@ -98,7 +98,7 @@ class COCOJSONCombinerDialog(QDialog):
     
             output_file, _ = QFileDialog.getSaveFileName(self, "Save Combined JSON", "", "JSON Files (*.json)")
             if output_file:
-                with open(output_file, 'w') as f:
+                with open(output_file, 'w', encoding='utf-8') as f:
                     json.dump(combined_data, f, indent=2)
                 QMessageBox.information(self, "Success", f"Combined JSON saved to {output_file}")
     

--- a/src/digitalsreeni_image_annotator/dialogs/dataset_splitter.py
+++ b/src/digitalsreeni_image_annotator/dialogs/dataset_splitter.py
@@ -160,7 +160,7 @@ class DatasetSplitterTool(QDialog):
         QMessageBox.information(self, "Success", "Dataset split successfully!")
 
     def split_images_and_annotations(self):
-        with open(self.json_file, 'r') as f:
+        with open(self.json_file, 'r', encoding='utf-8') as f:
             coco_data = json.load(f)
 
         image_files = [img['file_name'] for img in coco_data['images']]
@@ -246,7 +246,7 @@ class DatasetSplitterTool(QDialog):
         subset_dir = os.path.join(self.output_directory, subset)
         os.makedirs(subset_dir, exist_ok=True)
         output_file = os.path.join(subset_dir, f"{subset}_annotations.json")
-        with open(output_file, 'w') as f:
+        with open(output_file, 'w', encoding='utf-8') as f:
             json.dump(data, f, indent=2)
 
     def split_yolo_format(self, coco_data, train_images, val_images, test_images):
@@ -289,7 +289,7 @@ class DatasetSplitterTool(QDialog):
                 
                 # Create YOLO format labels
                 label_file = os.path.join(labels_dir, os.path.splitext(image_file)[0] + ".txt")
-                with open(label_file, "w") as f:
+                with open(label_file, "w", encoding='utf-8') as f:
                     for ann in annotations:
                         # Convert COCO class id to YOLO class id
                         yolo_class = categories[ann["category_id"]]
@@ -310,7 +310,7 @@ class DatasetSplitterTool(QDialog):
         }
         yaml_data.update(yaml_paths)  # Add only paths for non-empty splits
 
-        with open(os.path.join(self.output_directory, 'data.yaml'), 'w') as f:
+        with open(os.path.join(self.output_directory, 'data.yaml'), 'w', encoding='utf-8') as f:
             yaml.dump(yaml_data, f, default_flow_style=False)
 
         QMessageBox.information(self, "Success", "Dataset and YOLO annotations split successfully!")

--- a/src/digitalsreeni_image_annotator/dialogs/dicom_converter.py
+++ b/src/digitalsreeni_image_annotator/dialogs/dicom_converter.py
@@ -3,8 +3,7 @@ import json
 import numpy as np
 from datetime import datetime
 from PyQt6.QtWidgets import (QDialog, QVBoxLayout, QHBoxLayout, QPushButton, QFileDialog, 
-                            QLabel, QProgressDialog, QRadioButton, QButtonGroup, 
-                            QMessageBox, QApplication, QGroupBox)
+                            QLabel, QProgressDialog, QRadioButton, QMessageBox, QApplication, QGroupBox)
 from PyQt6.QtCore import Qt
 import pydicom
 from pydicom.pixel_data_handlers.util import apply_voi_lut

--- a/src/digitalsreeni_image_annotator/dialogs/dicom_converter.py
+++ b/src/digitalsreeni_image_annotator/dialogs/dicom_converter.py
@@ -230,7 +230,7 @@ class DicomConverter(QDialog):
             metadata_file = os.path.join(self.output_directory, 
                                        os.path.splitext(os.path.basename(self.input_file))[0] + 
                                        "_metadata.json")
-            with open(metadata_file, 'w') as f:
+            with open(metadata_file, 'w', encoding='utf-8') as f:
                 json.dump(series_metadata, f, indent=2)
             
             # Get physical sizes from metadata

--- a/src/digitalsreeni_image_annotator/dialogs/dino_merge_dialog.py
+++ b/src/digitalsreeni_image_annotator/dialogs/dino_merge_dialog.py
@@ -180,7 +180,7 @@ class DinoMergeDialog(QDialog):
             # Load and validate
             records = []
             for path in coco_files:
-                with open(path) as f:
+                with open(path, encoding='utf-8') as f:
                     data = json.load(f)
                 if not data.get("images") or not data.get("annotations"):
                     self._log_msg(f"  [skip] {path.name}: empty.")
@@ -295,9 +295,9 @@ class DinoMergeDialog(QDialog):
             train_data = _build_coco(train_imgs)
             val_data = _build_coco(val_imgs)
 
-            with open(out_path / "train.json", "w") as f:
+            with open(out_path / "train.json", "w", encoding='utf-8') as f:
                 json.dump(train_data, f, indent=2)
-            with open(out_path / "val.json", "w") as f:
+            with open(out_path / "val.json", "w", encoding='utf-8') as f:
                 json.dump(val_data, f, indent=2)
 
             self._log_msg(f"Train images: {len(train_imgs)}, annotations: {len(train_data['annotations'])}")

--- a/src/digitalsreeni_image_annotator/dialogs/dino_merge_dialog.py
+++ b/src/digitalsreeni_image_annotator/dialogs/dino_merge_dialog.py
@@ -6,7 +6,6 @@ Ported from annotation_tool_v4.py _MergeCOCODialog.
 
 import json
 import math
-import os
 import random
 import traceback
 from collections import defaultdict

--- a/src/digitalsreeni_image_annotator/dialogs/image_augmenter.py
+++ b/src/digitalsreeni_image_annotator/dialogs/image_augmenter.py
@@ -169,7 +169,7 @@ class ImageAugmenterDialog(QDialog):
         self.coco_file, _ = QFileDialog.getOpenFileName(self, "Select COCO JSON File", "", "JSON Files (*.json)")
         if self.coco_file:
             self.coco_label.setText(f"COCO JSON File: {os.path.basename(self.coco_file)}")
-            with open(self.coco_file, 'r') as f:
+            with open(self.coco_file, 'r', encoding='utf-8') as f:
                 self.coco_data = json.load(f)
             self.coco_check.setChecked(True)  # Automatically check the box when a file is loaded
                 
@@ -270,7 +270,7 @@ class ImageAugmenterDialog(QDialog):
     
         if self.coco_check.isChecked():
             output_coco_path = os.path.join(self.output_dir, "augmented_annotations.json")
-            with open(output_coco_path, 'w') as f:
+            with open(output_coco_path, 'w', encoding='utf-8') as f:
                 json.dump(augmented_coco_data, f, indent=2)
     
         QMessageBox.information(self, "Augmentation Complete", "Image and annotation augmentation has been completed successfully.")

--- a/src/digitalsreeni_image_annotator/dialogs/project_search.py
+++ b/src/digitalsreeni_image_annotator/dialogs/project_search.py
@@ -1,7 +1,7 @@
 from PyQt6.QtWidgets import (QDialog, QVBoxLayout, QHBoxLayout, QLineEdit, QPushButton, 
-                             QDateEdit, QLabel, QListWidget, QDialogButtonBox, QFormLayout,
+                             QDateEdit, QListWidget, QDialogButtonBox, QFormLayout,
                              QFileDialog, QMessageBox)
-from PyQt6.QtCore import Qt, QDate
+from PyQt6.QtCore import QDate
 import os
 import json
 from datetime import datetime

--- a/src/digitalsreeni_image_annotator/dialogs/project_search.py
+++ b/src/digitalsreeni_image_annotator/dialogs/project_search.py
@@ -83,7 +83,7 @@ class ProjectSearchDialog(QDialog):
                 if filename.endswith('.iap'):
                     project_path = os.path.join(root, filename)
                     try:
-                        with open(project_path, 'r') as f:
+                        with open(project_path, 'r', encoding='utf-8') as f:
                             project_data = json.load(f)
                         
                         if self.project_matches(project_data, query, start_date, end_date):

--- a/src/digitalsreeni_image_annotator/dialogs/yolo_trainer.py
+++ b/src/digitalsreeni_image_annotator/dialogs/yolo_trainer.py
@@ -1,7 +1,7 @@
 import os
 from PyQt6.QtWidgets import QFileDialog, QMessageBox
 from PyQt6.QtWidgets import (QDialog, QVBoxLayout, QHBoxLayout, QPushButton,
-                             QLineEdit, QLabel, QFileDialog, QDialogButtonBox)
+                             QLineEdit, QLabel, QDialogButtonBox)
 import yaml
 import numpy as np
 from pathlib import Path
@@ -11,8 +11,8 @@ from ..io.export_formats import export_yolo_v5plus
 from collections import deque
 
 
-from PyQt6.QtWidgets import QDialog, QVBoxLayout, QTextEdit, QPushButton
-from PyQt6.QtCore import Qt, pyqtSignal, QObject
+from PyQt6.QtWidgets import QTextEdit
+from PyQt6.QtCore import pyqtSignal, QObject
 
 class TrainingInfoDialog(QDialog):
     stop_signal = pyqtSignal()
@@ -279,9 +279,9 @@ class YOLOTrainer(QObject):
             missing_dirs.append(f"Validation labels directory: {val_labels_dir}")
         
         if missing_dirs:
-            raise FileNotFoundError(f"The following directories were not found:\n" + "\n".join(missing_dirs))
+            raise FileNotFoundError("The following directories were not found:\n" + "\n".join(missing_dirs))
         
-        print(f"Dataset structure verified:")
+        print("Dataset structure verified:")
         print(f"Train images: {train_images_dir}")
         print(f"Train labels: {train_labels_dir}")
         print(f"Val images: {val_images_dir}")
@@ -332,7 +332,7 @@ class YOLOTrainer(QObject):
         info = f"Epoch {epoch}/{total_epochs}, Loss: {loss:.4f}"
         self.epoch_info.append(info)
         
-        display_text = f"Current Progress:\n" + "\n".join(self.epoch_info)
+        display_text = "Current Progress:\n" + "\n".join(self.epoch_info)
         if self.progress_callback:
             self.progress_callback(display_text)
 

--- a/src/digitalsreeni_image_annotator/dialogs/yolo_trainer.py
+++ b/src/digitalsreeni_image_annotator/dialogs/yolo_trainer.py
@@ -342,7 +342,7 @@ class YOLOTrainer(QObject):
             raise ValueError("No model to save. Please train a model first.")
         save_path, _ = QFileDialog.getSaveFileName(self.main_window, "Save YOLO Model", "", "YOLO Model (*.pt)")
         if save_path:
-            self.model.export(save_path)
+            self.model.save(save_path)
             return True
         return False
 

--- a/src/digitalsreeni_image_annotator/dialogs/yolo_trainer.py
+++ b/src/digitalsreeni_image_annotator/dialogs/yolo_trainer.py
@@ -140,7 +140,7 @@ class YOLOTrainer(QObject):
         )
         
         yaml_path = Path(yaml_path)
-        with yaml_path.open('r') as f:
+        with yaml_path.open('r', encoding='utf-8') as f:
             yaml_content = yaml.safe_load(f)
         
         # Update paths for new YOLO v5+ structure
@@ -148,7 +148,7 @@ class YOLOTrainer(QObject):
         yaml_content['val'] = 'images/val'      # Changed from train/images
         yaml_content['test'] = '../test/images'
         
-        with yaml_path.open('w') as f:
+        with yaml_path.open('w', encoding='utf-8') as f:
             yaml.dump(yaml_content, f, default_flow_style=False)
         
         self.yaml_path = str(yaml_path)
@@ -158,7 +158,7 @@ class YOLOTrainer(QObject):
         if yaml_path is None:
             yaml_path, _ = QFileDialog.getOpenFileName(self.main_window, "Select YOLO Dataset YAML", "", "YAML Files (*.yaml *.yml)")
         if yaml_path and os.path.exists(yaml_path):
-            with open(yaml_path, 'r') as f:
+            with open(yaml_path, 'r', encoding='utf-8') as f:
                 try:
                     yaml_data = yaml.safe_load(f)
                     print(f"Loaded YAML contents: {yaml_data}")
@@ -175,7 +175,7 @@ class YOLOTrainer(QObject):
                     self.yaml_path = yaml_path
     
                     # Write the updated YAML back to the file
-                    with open(yaml_path, 'w') as f:
+                    with open(yaml_path, 'w', encoding='utf-8') as f:
                         yaml.dump(yaml_data, f, default_flow_style=False)
     
                     return True
@@ -218,7 +218,7 @@ class YOLOTrainer(QObject):
             print(f"Training with YAML: {yaml_path}")
             print(f"YAML directory: {yaml_dir}")
             
-            with yaml_path.open('r') as f:
+            with yaml_path.open('r', encoding='utf-8') as f:
                 yaml_content = yaml.safe_load(f)
             print(f"YAML content: {yaml_content}")
             
@@ -237,7 +237,7 @@ class YOLOTrainer(QObject):
             
             # Write updated YAML with adjusted paths
             temp_yaml_path = yaml_dir / 'temp_train.yaml'
-            with temp_yaml_path.open('w') as f:
+            with temp_yaml_path.open('w', encoding='utf-8') as f:
                 yaml.dump(yaml_content, f, default_flow_style=False)
             
             print(f"Training with updated YAML: {temp_yaml_path}")
@@ -258,7 +258,7 @@ class YOLOTrainer(QObject):
         yaml_path = Path(self.yaml_path)
         yaml_dir = yaml_path.parent
         
-        with yaml_path.open('r') as f:
+        with yaml_path.open('r', encoding='utf-8') as f:
             yaml_content = yaml.safe_load(f)
         
         # Use paths from YAML content
@@ -290,7 +290,7 @@ class YOLOTrainer(QObject):
     def check_ultralytics_settings(self):
         settings_path = Path.home() / ".config" / "Ultralytics" / "settings.yaml"
         if settings_path.exists():
-            with settings_path.open('r') as f:
+            with settings_path.open('r', encoding='utf-8') as f:
                 settings = yaml.safe_load(f)
             print(f"Ultralytics settings: {settings}")
         else:
@@ -351,7 +351,7 @@ class YOLOTrainer(QObject):
 
         try:
             self.model = YOLO(model_path)
-            with open(yaml_path, 'r') as f:
+            with open(yaml_path, 'r', encoding='utf-8') as f:
                 self.prediction_yaml = yaml.safe_load(f)
             
             if 'names' not in self.prediction_yaml:

--- a/src/digitalsreeni_image_annotator/io/export_formats.py
+++ b/src/digitalsreeni_image_annotator/io/export_formats.py
@@ -280,7 +280,7 @@ def export_yolo_v5plus(all_annotations, class_mapping, image_paths, slices, imag
         print(f"[YOLO v5+]   image={image_name!r} annotation-classes={list(annotations.keys()) if annotations else '(none)'}")
         # Skip if there are no annotations for this image/slice
         if not annotations:
-            print(f"[YOLO v5+]     skipping: no annotations")
+            print("[YOLO v5+]     skipping: no annotations")
             continue
 
         # For simplicity, we'll put all data in the train directory

--- a/src/digitalsreeni_image_annotator/io/export_formats.py
+++ b/src/digitalsreeni_image_annotator/io/export_formats.py
@@ -19,7 +19,7 @@ def convert_to_coco(all_annotations, class_mapping, image_paths, slices, image_s
     with tempfile.TemporaryDirectory() as temp_dir:
         json_file_path, images_dir = export_coco_json(all_annotations, class_mapping, image_paths, slices, image_slices, temp_dir)
         
-        with open(json_file_path, 'r') as f:
+        with open(json_file_path, 'r', encoding='utf-8') as f:
             coco_data = json.load(f)
         
     return coco_data, images_dir
@@ -118,7 +118,7 @@ def export_coco_json(all_annotations, class_mapping, image_paths, slices, image_
 
     # Save COCO JSON file
     json_file_path = os.path.join(output_dir, json_filename)
-    with open(json_file_path, 'w') as f:
+    with open(json_file_path, 'w', encoding='utf-8') as f:
         json.dump(coco_format, f, indent=2)
 
     return json_file_path, images_dir
@@ -205,7 +205,7 @@ def export_yolo_v4(all_annotations, class_mapping, image_paths, slices, image_sl
 
         # Write YOLO format annotation
         label_file = os.path.splitext(file_name_img)[0] + '.txt'
-        with open(os.path.join(labels_dir, label_file), 'w') as f:
+        with open(os.path.join(labels_dir, label_file), 'w', encoding='utf-8') as f:
             for class_name, class_annotations in annotations.items():
                 if class_name not in class_to_index:
                     print(f"[YOLO v4] warning: class {class_name!r} not in class_mapping, skipped")
@@ -236,7 +236,7 @@ def export_yolo_v4(all_annotations, class_mapping, image_paths, slices, image_sl
 
     # Save YAML file in the output directory
     yaml_path = os.path.join(output_dir, 'data.yaml')
-    with open(yaml_path, 'w') as f:
+    with open(yaml_path, 'w', encoding='utf-8') as f:
         yaml.dump(yaml_data, f, default_flow_style=False)
 
     return train_dir, yaml_path
@@ -334,7 +334,7 @@ def export_yolo_v5plus(all_annotations, class_mapping, image_paths, slices, imag
         label_file = os.path.splitext(file_name_img)[0] + '.txt'
         label_path = os.path.join(labels_dir, label_file)
         ann_lines = 0
-        with open(label_path, 'w') as f:
+        with open(label_path, 'w', encoding='utf-8') as f:
             for class_name, class_annotations in annotations.items():
                 if class_name not in class_to_index:
                     print(f"[YOLO v5+]     warning: class {class_name!r} not in class_mapping, skipped")
@@ -372,7 +372,7 @@ def export_yolo_v5plus(all_annotations, class_mapping, image_paths, slices, imag
 
     # Save YAML file in the output directory
     yaml_path = os.path.join(output_dir, 'data.yaml')
-    with open(yaml_path, 'w') as f:
+    with open(yaml_path, 'w', encoding='utf-8') as f:
         yaml.dump(yaml_data, f, default_flow_style=False)
 
     return output_dir, yaml_path
@@ -477,7 +477,7 @@ def export_labeled_images(all_annotations, class_mapping, image_paths, slices, i
 
     # Create summary text file
     summary_path = os.path.join(labeled_images_dir, 'class_summary.txt')
-    with open(summary_path, 'w') as f:
+    with open(summary_path, 'w', encoding='utf-8') as f:
         f.write("Classes (folder names):\n")
         for class_name, files in class_summary.items():
             if files:  # Only include classes that have annotations
@@ -575,7 +575,7 @@ def export_semantic_labels(all_annotations, class_mapping, image_paths, slices, 
 
     # Create class mapping text file
     mapping_path = os.path.join(segmented_images_dir, 'class_pixel_mapping.txt')
-    with open(mapping_path, 'w') as f:
+    with open(mapping_path, 'w', encoding='utf-8') as f:
         f.write("Pixel Value : Class Name\n")
         for class_name, pixel_value in class_to_pixel.items():
             f.write(f"{pixel_value} : {class_name}\n")
@@ -680,7 +680,7 @@ def export_pascal_voc_bbox(all_annotations, class_mapping, image_paths, slices, 
         # Save the XML file
         xml_str = minidom.parseString(ET.tostring(root)).toprettyxml(indent="    ")
         xml_filename = os.path.splitext(file_name_img)[0] + '.xml'
-        with open(os.path.join(annotations_dir, xml_filename), 'w') as f:
+        with open(os.path.join(annotations_dir, xml_filename), 'w', encoding='utf-8') as f:
             f.write(xml_str)
     
     return output_dir         
@@ -798,7 +798,7 @@ def export_pascal_voc_both(all_annotations, class_mapping, image_paths, slices, 
         # Save the XML file
         xml_str = minidom.parseString(ET.tostring(root)).toprettyxml(indent="    ")
         xml_filename = os.path.splitext(file_name_img)[0] + '.xml'
-        with open(os.path.join(annotations_dir, xml_filename), 'w') as f:
+        with open(os.path.join(annotations_dir, xml_filename), 'w', encoding='utf-8') as f:
             f.write(xml_str)
 
     return output_dir

--- a/src/digitalsreeni_image_annotator/io/import_formats.py
+++ b/src/digitalsreeni_image_annotator/io/import_formats.py
@@ -4,13 +4,8 @@ import os
 import yaml
 from PIL import Image
 
-from PyQt6.QtCore import QRectF
-from PyQt6.QtGui import QColor
-from PyQt6.QtWidgets import QMessageBox, QFileDialog
-
-import os
-import json
 from PyQt6.QtWidgets import QMessageBox
+
 
 def import_coco_json(file_path, class_mapping):
     try:

--- a/src/digitalsreeni_image_annotator/io/import_formats.py
+++ b/src/digitalsreeni_image_annotator/io/import_formats.py
@@ -14,7 +14,7 @@ from PyQt6.QtWidgets import QMessageBox
 
 def import_coco_json(file_path, class_mapping):
     try:
-        with open(file_path, 'r') as f:
+        with open(file_path, 'r', encoding='utf-8') as f:
             coco_data = json.load(f)
 
         # Validate required fields
@@ -127,7 +127,7 @@ def import_yolo_v4(yaml_file_path, class_mapping):
     
     directory_path = os.path.dirname(yaml_file_path)
     
-    with open(yaml_file_path, 'r') as f:
+    with open(yaml_file_path, 'r', encoding='utf-8') as f:
         yaml_data = yaml.safe_load(f)
     
     class_names = yaml_data.get('names', [])
@@ -184,7 +184,7 @@ def import_yolo_v4(yaml_file_path, class_mapping):
             imported_annotations[img_file] = {}
             
             label_path = os.path.join(labels_dir, label_file)
-            with open(label_path, 'r') as f:
+            with open(label_path, 'r', encoding='utf-8') as f:
                 lines = f.readlines()
             
             for line in lines:
@@ -267,7 +267,7 @@ def import_yolo_v5plus(yaml_file_path, class_mapping):
     
     root_dir = os.path.dirname(yaml_file_path)
     
-    with open(yaml_file_path, 'r') as f:
+    with open(yaml_file_path, 'r', encoding='utf-8') as f:
         yaml_data = yaml.safe_load(f)
     
     class_names = yaml_data.get('names', [])
@@ -320,7 +320,7 @@ def import_yolo_v5plus(yaml_file_path, class_mapping):
                 imported_annotations[img_file] = {}
                 
                 label_path = os.path.join(labels_dir, label_file)
-                with open(label_path, 'r') as f:
+                with open(label_path, 'r', encoding='utf-8') as f:
                     lines = f.readlines()
                 
                 for line in lines:

--- a/src/digitalsreeni_image_annotator/widgets/image_label.py
+++ b/src/digitalsreeni_image_annotator/widgets/image_label.py
@@ -848,6 +848,14 @@ class ImageLabel(QLabel):
         self.update()
 
     def start_polygon_edit(self, pos):
+        # Among all polygons containing the click, edit the smallest by
+        # area so an annotation fully nested inside another is reachable
+        # (upstream issue #33) instead of always grabbing the first/outer
+        # match.
+        from ..utils import calculate_area
+
+        best = None
+        best_area = None
         for class_name, annotations in self.annotations.items():
             for annotation in annotations:
                 if "segmentation" in annotation:
@@ -859,11 +867,16 @@ class ImageLabel(QLabel):
                         )
                     ]
                     if self.point_in_polygon(pos, points):
-                        self.editing_polygon = annotation
-                        self.current_tool = None
-                        self.disableToolsRequested.emit()
-                        self.resetToolButtonsRequested.emit()
-                        return annotation
+                        area = calculate_area(annotation)
+                        if best is None or area < best_area:
+                            best = annotation
+                            best_area = area
+        if best is not None:
+            self.editing_polygon = best
+            self.current_tool = None
+            self.disableToolsRequested.emit()
+            self.resetToolButtonsRequested.emit()
+            return best
         return None
 
     def handle_editing_click(self, pos, event):

--- a/src/digitalsreeni_image_annotator/widgets/image_label.py
+++ b/src/digitalsreeni_image_annotator/widgets/image_label.py
@@ -29,6 +29,7 @@ from PyQt6.QtGui import (
 from PyQt6.QtWidgets import QLabel, QMessageBox
 
 from .tools import EraserTool, PaintBrushTool, PolygonTool, RectangleTool
+from ..utils import calculate_area
 
 warnings.filterwarnings("ignore", category=UserWarning)
 
@@ -852,8 +853,6 @@ class ImageLabel(QLabel):
         # area so an annotation fully nested inside another is reachable
         # (upstream issue #33) instead of always grabbing the first/outer
         # match.
-        from ..utils import calculate_area
-
         best = None
         best_area = None
         for class_name, annotations in self.annotations.items():

--- a/tests/unit/test_image_list_sort.py
+++ b/tests/unit/test_image_list_sort.py
@@ -1,0 +1,92 @@
+"""
+Unit tests for alphabetical image-list sorting (upstream issue #60).
+
+sort_image_list must order the list case-insensitively, keep the
+all_images model aligned with the list rows (positional invariant used
+by COCO import), and never fire a spurious switch_image.
+"""
+
+import pytest
+from PyQt6.QtWidgets import QWidget, QListWidget, QComboBox
+
+from src.digitalsreeni_image_annotator.controllers.image_controller import (
+    ImageController,
+)
+
+
+class FakeMainWindow(QWidget):
+    pass
+
+
+@pytest.fixture
+def mw(qtbot):
+    window = FakeMainWindow()
+    qtbot.addWidget(window)
+    window.image_list = QListWidget(window)
+    window.image_filter_combo = QComboBox(window)
+    window.image_filter_combo.addItems(
+        ["All images", "Without annotations", "With annotations"]
+    )
+    window.all_images = []
+    window.all_annotations = {}
+    window.image_slices = {}
+    window.image_controller = ImageController(window)
+    return window
+
+
+def _populate(mw, names):
+    # Populate out of order, mimicking the model+view pairing that
+    # add_images_to_list produces before a sort.
+    for n in names:
+        mw.all_images.append({"file_name": n, "is_multi_slice": False})
+        mw.image_list.addItem(n)
+
+
+def _list_texts(mw):
+    return [mw.image_list.item(i).text() for i in range(mw.image_list.count())]
+
+
+def test_sorts_alphabetically(mw):
+    _populate(mw, ["banana.png", "apple.png", "cherry.png"])
+    mw.image_controller.sort_image_list()
+    assert _list_texts(mw) == ["apple.png", "banana.png", "cherry.png"]
+
+
+def test_sort_is_case_insensitive(mw):
+    _populate(mw, ["Zebra.png", "apple.png", "Banana.png"])
+    mw.image_controller.sort_image_list()
+    assert _list_texts(mw) == ["apple.png", "Banana.png", "Zebra.png"]
+
+
+def test_model_and_view_stay_aligned(mw):
+    _populate(mw, ["d.png", "a.png", "c.png", "b.png"])
+    mw.image_controller.sort_image_list()
+    assert _list_texts(mw) == [info["file_name"] for info in mw.all_images]
+
+
+def test_sort_fires_no_switch_image(mw):
+    _populate(mw, ["b.png", "a.png"])
+    calls = []
+    mw.switch_image = lambda item: calls.append(item)
+    mw.image_controller.switch_image = lambda item: calls.append(item)
+    mw.image_list.setCurrentRow(0)
+    calls.clear()
+    mw.image_controller.sort_image_list()  # no select_name, do_switch=False
+    assert calls == []
+
+
+def test_selection_preserved_across_sort(mw):
+    _populate(mw, ["b.png", "a.png", "c.png"])
+    mw.image_list.setCurrentRow(0)  # b.png
+    mw.image_controller.sort_image_list()
+    assert mw.image_list.currentItem().text() == "b.png"
+
+
+def test_select_name_and_switch(mw):
+    _populate(mw, ["b.png", "a.png"])
+    calls = []
+    mw.switch_image = lambda item: calls.append(item.text())
+    mw.image_controller.switch_image = lambda item: calls.append(item.text())
+    mw.image_controller.sort_image_list(select_name="a.png", do_switch=True)
+    assert mw.image_list.currentItem().text() == "a.png"
+    assert calls == ["a.png"]

--- a/tests/unit/test_image_list_sort.py
+++ b/tests/unit/test_image_list_sort.py
@@ -30,6 +30,9 @@ def mw(qtbot):
     window.all_images = []
     window.all_annotations = {}
     window.image_slices = {}
+    window.image_paths = {}
+    window.is_loading_project = False
+    window.auto_save = lambda: None
     window.image_controller = ImageController(window)
     return window
 
@@ -90,3 +93,21 @@ def test_select_name_and_switch(mw):
     mw.image_controller.sort_image_list(select_name="a.png", do_switch=True)
     assert mw.image_list.currentItem().text() == "a.png"
     assert calls == ["a.png"]
+
+
+def test_project_load_path_ends_sorted(mw):
+    # Contract: during project load add_images_to_list does NOT sort per
+    # image (avoids O(n^2)); the list is rebuilt once afterwards via the
+    # update_ui -> update_image_list call. This guards a refactor of that
+    # call from silently leaving the post-load list unsorted.
+    mw.is_loading_project = True
+    mw.image_controller.add_images_to_list(["c.png", "a.png", "b.png"])
+    # Not populated/sorted yet while loading.
+    assert mw.image_list.count() == 0
+
+    mw.is_loading_project = False
+    mw.image_controller.update_image_list()  # what update_ui triggers
+
+    texts = [mw.image_list.item(i).text() for i in range(mw.image_list.count())]
+    assert texts == ["a.png", "b.png", "c.png"]
+    assert texts == [info["file_name"] for info in mw.all_images]

--- a/tests/unit/test_polygon_edit.py
+++ b/tests/unit/test_polygon_edit.py
@@ -1,0 +1,71 @@
+"""
+Unit tests for nested-polygon edit selection (upstream issue #33).
+
+start_polygon_edit must enter edit mode on the *smallest* polygon that
+contains the click, so an annotation fully nested inside another is
+reachable instead of always grabbing the outer one.
+"""
+
+import pytest
+
+from src.digitalsreeni_image_annotator.widgets.image_label import ImageLabel
+
+
+@pytest.fixture
+def label(qtbot):
+    lbl = ImageLabel(None)
+    qtbot.addWidget(lbl)
+    return lbl
+
+
+def _square(x0, y0, side, name):
+    return {
+        "segmentation": [x0, y0, x0 + side, y0, x0 + side, y0 + side, x0, y0 + side],
+        "category_name": name,
+    }
+
+
+@pytest.fixture
+def nested(label):
+    outer = _square(0, 0, 100, "outer")      # area 10000
+    inner = _square(40, 40, 20, "inner")     # area 400, fully inside outer
+    # Insert outer first so the old "return first match" behavior would
+    # have returned outer — the test fails unless smallest-area wins.
+    label.annotations = {"cell": [outer, inner]}
+    return label, outer, inner
+
+
+def test_click_in_nested_region_selects_inner(nested):
+    label, outer, inner = nested
+    result = label.start_polygon_edit((50, 50))  # inside both
+    assert result is inner
+    assert label.editing_polygon is inner
+
+
+def test_click_only_in_outer_selects_outer(nested):
+    label, outer, inner = nested
+    result = label.start_polygon_edit((10, 10))  # inside outer only
+    assert result is outer
+    assert label.editing_polygon is outer
+
+
+def test_click_outside_all_returns_none(nested):
+    label, outer, inner = nested
+    label.editing_polygon = None
+    result = label.start_polygon_edit((500, 500))
+    assert result is None
+
+
+def test_insertion_order_does_not_matter(label):
+    # Inner listed first: result must still be the smallest, not the first.
+    outer = _square(0, 0, 100, "outer")
+    inner = _square(40, 40, 20, "inner")
+    label.annotations = {"cell": [inner, outer]}
+    assert label.start_polygon_edit((50, 50)) is inner
+
+
+def test_bbox_only_annotation_is_ignored(label):
+    # start_polygon_edit only handles "segmentation"; bbox editing is #40.
+    bbox_ann = {"bbox": [0, 0, 100, 100], "category_name": "box"}
+    label.annotations = {"cell": [bbox_ann]}
+    assert label.start_polygon_edit((50, 50)) is None

--- a/tests/unit/test_tiff_codec.py
+++ b/tests/unit/test_tiff_codec.py
@@ -67,6 +67,11 @@ def test_is_missing_codec_error_matches():
     assert ImageController._is_missing_codec_error(
         ValueError("requires the 'imagecodecs' package")
     )
+    # A bare "compression" mention must NOT match — that would swallow
+    # unrelated errors behind a misleading "install imagecodecs" dialog.
+    assert not ImageController._is_missing_codec_error(
+        ValueError("unsupported compression scheme")
+    )
 
 
 def test_unrelated_value_error_is_reraised(mw, monkeypatch):

--- a/tests/unit/test_tiff_codec.py
+++ b/tests/unit/test_tiff_codec.py
@@ -1,0 +1,81 @@
+"""
+Unit tests for graceful handling of compressed TIFFs missing imagecodecs
+(upstream issue #56).
+
+An LZW TIFF read raises ValueError when imagecodecs is absent; the app
+must skip the file with a dialog instead of crashing, and must not leave
+a half-added entry.
+"""
+
+import pytest
+from PyQt6.QtWidgets import QWidget, QListWidget, QComboBox
+
+import src.digitalsreeni_image_annotator.controllers.image_controller as ic_module
+from src.digitalsreeni_image_annotator.controllers.image_controller import (
+    ImageController,
+)
+
+LZW_ERROR = "<COMPRESSION.LZW: 5> requires the 'imagecodecs' package"
+
+
+class FakeMainWindow(QWidget):
+    pass
+
+
+@pytest.fixture
+def mw(qtbot):
+    window = FakeMainWindow()
+    qtbot.addWidget(window)
+    window.image_list = QListWidget(window)
+    window.image_filter_combo = QComboBox(window)
+    window.image_filter_combo.addItems(
+        ["All images", "Without annotations", "With annotations"]
+    )
+    window.all_images = []
+    window.all_annotations = {}
+    window.image_slices = {}
+    window.image_paths = {}
+    window.is_loading_project = False
+    window.auto_save = lambda: None
+    window.image_controller = ImageController(window)
+    return window
+
+
+def test_lzw_tiff_without_codec_is_skipped_with_dialog(mw, monkeypatch):
+    dialogs = []
+    monkeypatch.setattr(
+        ic_module.QMessageBox, "critical",
+        lambda *a, **k: dialogs.append(a),
+    )
+
+    def raise_lzw(_path):
+        raise ValueError(LZW_ERROR)
+
+    mw.image_controller.load_multi_slice_image = raise_lzw
+
+    # Must not raise.
+    mw.image_controller.add_images_to_list(["C:/data/scan.tif"])
+
+    assert len(dialogs) == 1          # one critical dialog shown
+    assert mw.all_images == []        # no half-added entry
+    assert mw.image_list.count() == 0
+    assert "scan.tif" not in mw.image_paths
+
+
+def test_is_missing_codec_error_matches():
+    assert ImageController._is_missing_codec_error(ValueError(LZW_ERROR))
+    assert ImageController._is_missing_codec_error(
+        ValueError("requires the 'imagecodecs' package")
+    )
+
+
+def test_unrelated_value_error_is_reraised(mw, monkeypatch):
+    monkeypatch.setattr(ic_module.QMessageBox, "critical", lambda *a, **k: None)
+
+    def raise_other(_path):
+        raise ValueError("corrupt dimension metadata")
+
+    mw.image_controller.load_multi_slice_image = raise_other
+
+    with pytest.raises(ValueError, match="corrupt dimension metadata"):
+        mw.image_controller.add_images_to_list(["C:/data/scan.tif"])

--- a/tests/unit/test_yaml_encoding.py
+++ b/tests/unit/test_yaml_encoding.py
@@ -1,0 +1,33 @@
+"""
+Regression guard for UTF-8 file encoding (upstream issue #44).
+
+Reading a COCO JSON that contains non-ASCII category names must succeed
+regardless of the platform's default code page. Before the fix, open()
+without encoding used cp1252 on Windows and crashed on these bytes. The
+test writes genuine non-ASCII bytes (ensure_ascii=False) and asserts the
+unicode survives the round-trip through import_coco_json's open().
+"""
+
+import json
+
+from src.digitalsreeni_image_annotator.io.import_formats import import_coco_json
+
+UNICODE_CLASS = "Zellkörper-Ü-中"  # German + a CJK char
+
+
+def test_import_coco_json_preserves_unicode_class(tmp_path):
+    coco = {
+        "images": [{"id": 1, "file_name": "img.png", "width": 10, "height": 10}],
+        "categories": [{"id": 1, "name": UNICODE_CLASS}],
+        "annotations": [
+            {"id": 1, "image_id": 1, "category_id": 1, "bbox": [0, 0, 5, 5]}
+        ],
+    }
+    json_path = tmp_path / "annotations.json"
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump(coco, f, ensure_ascii=False)
+
+    imported_annotations, image_info = import_coco_json(str(json_path), {})
+
+    assert UNICODE_CLASS in imported_annotations["img.png"]
+    assert image_info[1]["file_name"] == "img.png"


### PR DESCRIPTION
Fixes five upstream quick-win issues, one logical commit each, with a test per issue. Fork-internal PR.

## Issues fixed
- **#30 — YOLO save_model crash**: `model.export()` converts to a deployment format and crashes on a `.pt` path; switched to `model.save()` (reporter-verified).
- **#44 — Windows charmap crash**: added `encoding='utf-8'` to every text-mode `open()` across YAML/JSON/TXT — including the `.iap` project save/load, COCO import/export, YOLO yaml/labels, augmenter, combiner, dino merge, dicom metadata, project search. Non-ASCII class names and paths no longer crash on cp1252. PIL `Image.open` (binary) untouched.
- **#33 — can't edit nested annotation**: `start_polygon_edit` now edits the *smallest* containing polygon (reusing shoelace `calculate_area`), so a polygon inside another is reachable. bbox-only editing remains out of scope (#40).
- **#60 — sort image list alphabetically**: new `ImageController.sort_image_list` sorts the model (`all_images`) and the list widget together with signals blocked — deliberately **not** `setSortingEnabled`, since `currentRowChanged` is wired to `switch_image` and live re-sorts would fire spurious switches. Preserves the `all_images[i]` ↔ `image_list.item(i)` invariant COCO import relies on. Skipped per-image during project load to avoid O(n²).
- **#56 — LZW TIFF crash**: added `imagecodecs` to `install_requires` (fixes new installs) and catch the codec `ValueError` in `add_images_to_list` — actionable "pip install imagecodecs" dialog and skip the file instead of crashing or leaving a half-added entry. Non-codec ValueErrors still propagate.

## Testing
- **157 tests pass** (16 new across `test_polygon_edit.py`, `test_image_list_sort.py`, `test_tiff_codec.py`, `test_yaml_encoding.py`), including the model↔view alignment invariant, the no-spurious-switch property, the project-load-ends-sorted contract, and the UTF-8 round-trip.
- `ruff check --select F,E9` clean on all touched files (a separate commit also clears pre-existing lint in those files).
- Offscreen app launch verified; live sort confirmed.
- Senior-reviewer agent run twice to a clean pass (P1 codec heuristic + P2s addressed).

## Docs / backlog
- arc42 updates: image-list sort rule and TIFF-codec handling in crosscutting concepts; `ImageController` building-block row.
- CLAUDE.md backlog: the five resolved quick-win rows removed per its self-deletion hook (medium/large/blocked items remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)