### PR TITLE
feat: Fine-tune SAM 2 / 2.1 on user annotations (bnsreenu#73)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,14 +65,17 @@ src/digitalsreeni_image_annotator/
 ├── __init__.py                   # Public API re-exports
 │
 ├── core/                         # constants, annotation_utils, image_utils
-├── controllers/                  # 7 controllers (project, image, sam, dino,
-│                                 #   yolo, annotation, class) + io_controller
+├── controllers/                  # 8 controllers (project, image, sam,
+│                                 #   sam_train, dino, yolo, annotation,
+│                                 #   class) + io_controller
 ├── widgets/
 │   ├── image_label.py            # ImageLabel canvas widget (dispatcher)
 │   ├── canvas_context.py         # CanvasContext read accessor (ADR-018)
 │   └── tools/                    # Per-tool handlers (ADR-019): rectangle,
 │                                 #   polygon, paint, eraser
 ├── inference/                    # sam_utils.py, dino_utils.py
+├── training/                     # SAM fine-tuning (ADR-021): sam_trainer.py
+│                                 #   (SAMFineTuner), sam_dataset.py
 ├── io/                           # export_formats.py, import_formats.py
 ├── ui/                           # menu_bar, sidebar, shortcuts, theme, stylesheets
 └── dialogs/                      # Standalone tool dialogs (statistics,
@@ -94,8 +97,10 @@ src/digitalsreeni_image_annotator/
 | `SAMController` | controllers/sam_controller.py | SAM model picker, debounce, in-flight guard (ADR-013) |
 | `DINOController` | controllers/dino_controller.py | DINO single/batch detection, batch review, temp-class workflow |
 | `YOLOController` | controllers/yolo_controller.py | YOLO training menu + prediction wiring |
-| `SAMUtils` | inference/sam_utils.py | Load SAM models, run inference |
+| `SAMUtils` | inference/sam_utils.py | Load SAM models (built-in + fine-tuned), run inference |
 | `DINOUtils` | inference/dino_utils.py | Grounding-DINO model load + inference |
+| `SAMFineTuner` | training/sam_trainer.py | Fine-tune SAM 2 decoder/encoder via custom loop over Ultralytics SAM2Model (ADR-021) |
+| `SAMTrainController` | controllers/sam_train_controller.py | SAM fine-tune menu, GPU gate, training thread, selector registration |
 
 See [Building Block View](docs/05_building_block_view.md) for detailed class documentation.
 

--- a/docs/05_building_block_view.md
+++ b/docs/05_building_block_view.md
@@ -156,6 +156,23 @@ The earlier subprocess approach is documented as
 [ADR-011](09_architecture_decisions.md#adr-011-run-torch-based-workers-in-isolated-subprocesses)
 (Superseded).
 
+### SAM Fine-Tuning Subsystem (`training/`)
+
+Lets users fine-tune SAM 2 / 2.1 on their own annotations, since
+Ultralytics ships no SAM trainer (ADR-021). Distinct from `inference/`
+because it is *training*, not inference.
+
+| Module | Responsibility |
+|--------|----------------|
+| `training/sam_trainer.py` | `SAMFineTuner` — custom decoder (optionally encoder) fine-tuning loop reusing `SAM2Predictor.get_im_features` / `prompt_inference` under autograd, focal+dice loss, AdamW, checkpoint save+reload-verify. Also geometry helpers (`polygon_to_mask`, `mask_to_xyxy`, `mask_to_point`), `make_custom_filename`, `list_custom_models`, and the `SampleGroup` lazy-rasterising dataset item. |
+| `training/sam_dataset.py` | `build_groups_from_project` (live `all_annotations`) and `build_groups_from_folder` (prepared dataset) → `list[SampleGroup]`, mirroring `export_yolo_v5plus` image resolution. |
+| `io/export_formats.py::export_sam_dataset` | Writes `images/` + `manifest.json` (authoritative bbox/segmentation specs) for an inspectable, re-trainable on-disk dataset. |
+
+Fine-tuned checkpoints save as `{"model": state_dict}` and reload
+through the unchanged `SAM(path)` inference path; `SAMUtils` gains a
+`custom_models` registry so they appear in the SAM selector alongside
+the eight built-ins.
+
 ### DINO Subsystem (Grounding DINO + SAM pipeline)
 
 LLM-assisted detection: the user gives free-form text phrases per class,
@@ -196,7 +213,7 @@ export time — see [Cross-cutting Concepts](08_crosscutting_concepts.md)).
 
 ## Level 3: Controllers
 
-Seven `QObject` controllers plus an `io_controller` helper module
+Eight `QObject` controllers plus an `io_controller` helper module
 carve `ImageAnnotator` into single-responsibility owners that the
 orchestrator delegates to. Each `QObject` controller holds `self.mw
 = main_window` and owns one slice of behaviour; the
@@ -215,6 +232,7 @@ the controller graph.
 | `SAMController` | SAM box/points tool lifecycle, debounce timer, `_sam_inference_in_flight` re-entrancy guard (ADR-013), model picker. |
 | `DINOController` | Single + batch detection, batch review navigation, temp-annotation accept/reject, custom-model browse, `DINOReviewEventFilter` ownership (ADR-015). |
 | `YOLOController` | Training menu, `TrainingThread`, prediction dialog, result processing. |
+| `SAMTrainController` | SAM fine-tuning menu, GPU gate, `SAMTrainingThread`, config dialog, registers fine-tuned checkpoints into the SAM selector (ADR-021). |
 | `io_controller` *(module-level functions, not a class)* | Thin UI wrappers around the pure `io/export_formats.py` and `io/import_formats.py` modules. |
 
 Communication: `ImageLabel` does not import controllers directly —

--- a/docs/06_runtime_view.md
+++ b/docs/06_runtime_view.md
@@ -370,3 +370,37 @@ User clicks "Export" > "YOLO v8/v11"
     │
     └─> Return
 ```
+
+## SAM Fine-Tuning (annotate → train → use)
+
+See [ADR-021](09_architecture_decisions.md#adr-021-sam-fine-tuning-via-a-custom-loop-over-the-ultralytics-sam2-module).
+
+```
+User: SAM Fine-Tune (beta) > Train on Current Project…
+    │
+    ├─> build_groups_from_project(all_annotations, image_paths, slices, image_slices)
+    │       polygons/bboxes → SampleGroup(image_loader, specs)   (masks rasterised lazily)
+    │
+    ├─> _gpu_gate(): resolve_torch_device(); if "cpu" → warn + let user back out
+    │
+    ├─> SAMTrainConfigDialog: base model, epochs, lr, batch, prompt (bbox/point),
+    │                          "also fine-tune image encoder?"
+    │
+    ├─> sam_controller.deactivate_sam_tools()   (model is driven from the worker thread)
+    │
+    └─> SAMTrainingThread → SAMFineTuner.train(...)
+            │  build predictor (one warmup predict), pin device, apply freeze policy
+            │  for each epoch / image / instance:
+            │     set_image → get_im_features  (no_grad when encoder frozen)
+            │     prompt_inference(bbox|point) under enable_grad → mask logits
+            │     focal+dice loss → backward → AdamW step (every batch_size instances)
+            │     progress_signal → TrainingInfoDialog (Stop supported)
+            │  save {"model": state_dict} as <name>_<base_token>.pt → reload-verify via SAM()
+            │
+            └─> training_finished: register in SAMUtils.custom_models,
+                add "★ <name>" to the SAM selector and select it
+                → SAM-box / SAM-points now use the fine-tuned model
+
+Offline variant: "Prepare SAM Dataset…" → export_sam_dataset (images/ + manifest.json),
+then "Train from Dataset Folder…" → build_groups_from_folder → same training path.
+```

--- a/docs/06_runtime_view.md
+++ b/docs/06_runtime_view.md
@@ -386,7 +386,8 @@ User: SAM Fine-Tune (beta) > Train on Current Project…
     ├─> SAMTrainConfigDialog: base model, epochs, lr, batch, prompt (bbox/point),
     │                          "also fine-tune image encoder?"
     │
-    ├─> sam_controller.deactivate_sam_tools()   (model is driven from the worker thread)
+    ├─> deactivate_sam_tools() + lock SAM inference UI (tools, selector, menu)
+    │       trainer loads its OWN SAM instance; locking avoids a 2nd model on the same CUDA context
     │
     └─> SAMTrainingThread → SAMFineTuner.train(...)
             │  build predictor (one warmup predict), pin device, apply freeze policy

--- a/docs/09_architecture_decisions.md
+++ b/docs/09_architecture_decisions.md
@@ -792,10 +792,14 @@ won't reload (cf. facebookresearch/sam2#337 key-mismatch failures).
   already-exercised predictor methods, guarded by
   `test_sam_finetuning.py::TestUltralyticsAPI` (fails on an upgrade
   that renames them).
-- ⚠️ Training drives the resident SAM model on its own `QThread` and
-  must **not** use `sam_utils._run_sync` (its re-entry guard is
-  GUI-thread-local). `SAMTrainController` deactivates SAM tools for the
-  duration so inference can't fire concurrently.
+- ⚠️ The trainer loads its **own** `SAM` instance on its `QThread`
+  (it does not touch `SAMUtils._model`), and must **not** use
+  `sam_utils._run_sync` (its re-entry guard is GUI-thread-local). The
+  real hazard is two SAM models (resident inference + training) on one
+  CUDA context, so `SAMTrainController` locks the SAM inference UI
+  (tools + model selector + the fine-tune menu) for the duration —
+  re-enabled in `training_finished` on both the success and error
+  paths.
 - ⚠️ Decoder fine-tuning is realistically GPU-only; a CPU-only box is
   hard-warned before a run (`resolve_torch_device`), and the device is
   pinned so an incompatible GPU is honoured as CPU instead of crashing.

--- a/docs/09_architecture_decisions.md
+++ b/docs/09_architecture_decisions.md
@@ -805,6 +805,17 @@ won't reload (cf. facebookresearch/sam2#337 key-mismatch failures).
   pinned so an incompatible GPU is honoured as CPU instead of crashing.
 - ⚠️ Encoder features are recomputed per epoch (bounded memory) rather
   than cached across epochs; revisit if large datasets need the speedup.
+- ⚠️ **Loss must use the inference coordinate frame.** SAM2 letterboxes
+  the image (`LetterBox(1024, center=False)`, pad bottom/right) and
+  inference maps masks back with `ops.scale_masks(..., padding=False)`,
+  which crops that padding before upsampling. The training loss therefore
+  runs the decoder logits through the *same* `ops.scale_masks` before
+  comparing to the GT mask — a naive `F.interpolate` over the full
+  low-res mask bakes the padding into the target and the decoder learns
+  masks shifted by the pad (a downward shift on non-square images, caught
+  only during GUI testing because the e2e tests used square images). The
+  landscape regression test (`test_landscape_no_mask_shift`) and the
+  `ops.scale_masks` API-drift guard protect this.
 
 ---
 

--- a/docs/09_architecture_decisions.md
+++ b/docs/09_architecture_decisions.md
@@ -739,6 +739,71 @@ persistence mechanism in the app.
 
 ---
 
+## ADR-021: SAM Fine-Tuning via a Custom Loop over the Ultralytics SAM2 Module
+
+**Status**: Accepted
+
+**Context**: Users annotating domain-specific imagery (microscopy,
+medical, materials) get generic SAM masks that need heavy correction.
+We want to let them fine-tune SAM 2 / 2.1 on their own annotations and
+reuse the result in the existing SAM-box / SAM-points workflow
+(upstream issue bnsreenu#73).
+
+The obvious approach — mirror the YOLO trainer's `model.train(...)` —
+**does not work**: Ultralytics registers only a *predictor* for SAM's
+`segment` task (`SAM.task_map`), so `SAM(...).train()` raises
+`NotImplementedError` (verified on ultralytics 8.4.51).
+
+**Decision**: Fine-tune with a custom PyTorch loop that **reuses
+Ultralytics' own forward path**. `SAM(...).model` is a plain
+`SAM2Model` `nn.Module`; its `SAM2Predictor` exposes the forward in
+reusable pieces — `get_im_features` (image encoder) and
+`prompt_inference` / `_inference_features` (prompt encoder + mask
+decoder). These are *not* wrapped in `inference_mode` unless reached
+via the public `__call__`, so calling them directly under
+`torch.enable_grad()` yields differentiable mask logits. The engine
+(`training/sam_trainer.py`) adds focal+dice loss (≈20:1) + AdamW +
+backward. Default freeze policy: train only `sam_mask_decoder`
+(image + prompt encoders frozen); an optional flag also unfreezes the
+image encoder.
+
+Checkpoints are saved as `{"model": state_dict}` — the exact shape
+Ultralytics' `_load_checkpoint` reads (it rebuilds the architecture
+from the filename suffix and `load_state_dict`s the nested `model`
+key). Consequently a fine-tuned file **must keep its base token in the
+name** (e.g. `myrun_sam2_t.pt`), enforced by `make_custom_filename`;
+`build_sam` selects the architecture by `ckpt.endswith(token)`. Every
+save is round-trip-verified by reloading through `SAM(out_path)` and
+running one forward — failing loudly rather than producing a file that
+won't reload (cf. facebookresearch/sam2#337 key-mismatch failures).
+
+**Alternatives considered**:
+- *facebookresearch/sam2 training code* — rejected: heavy extra
+  dependency overlapping Ultralytics' bundled SAM2, and its checkpoints
+  need state-dict conversion to reload into our `SAM()` inference path.
+- *Export dataset + train externally* — rejected as the default (less
+  "integrated"), though `Prepare SAM Dataset` + folder training give a
+  similar offline path for users who want it.
+
+**Consequences**:
+- ✅ No new runtime dependency; fine-tuned models drop straight into
+  the existing SAM selector and inference path.
+- ✅ Exposure to Ultralytics internals is confined to a few
+  already-exercised predictor methods, guarded by
+  `test_sam_finetuning.py::TestUltralyticsAPI` (fails on an upgrade
+  that renames them).
+- ⚠️ Training drives the resident SAM model on its own `QThread` and
+  must **not** use `sam_utils._run_sync` (its re-entry guard is
+  GUI-thread-local). `SAMTrainController` deactivates SAM tools for the
+  duration so inference can't fire concurrently.
+- ⚠️ Decoder fine-tuning is realistically GPU-only; a CPU-only box is
+  hard-warned before a run (`resolve_torch_device`), and the device is
+  pinned so an incompatible GPU is honoured as CPU instead of crashing.
+- ⚠️ Encoder features are recomputed per epoch (bounded memory) rather
+  than cached across epochs; revisit if large datasets need the speedup.
+
+---
+
 ## Decisions Under Consideration
 
 ### Consider pytest-qt for Utility Testing

--- a/docs/12_glossary.md
+++ b/docs/12_glossary.md
@@ -20,6 +20,15 @@ Carl Zeiss Image file format for multi-dimensional microscopy images. Contains m
 ### DINO / Grounding DINO
 "DINO" in this codebase refers specifically to **Grounding DINO** (IDEA-Research, 2023) — an open-set object detector that takes a natural-language phrase ("drone", "wing of an aircraft") and returns bounding boxes for matching regions of an image. Not to be confused with the self-supervised vision-only DINOv1/v2 backbones (similar name, different model). Models live under `models/grounding-dino-base/` and `models/grounding-dino-tiny/`.
 
+### Fine-Tuning (SAM)
+Continuing training of a pre-trained SAM 2 / 2.1 model on the user's own annotations so the assisted tools work better on their imagery. Because Ultralytics ships no SAM trainer, the app uses a custom loop over the Ultralytics `SAM2Model` (see [ADR-021](09_architecture_decisions.md#adr-021-sam-fine-tuning-via-a-custom-loop-over-the-ultralytics-sam2-module)). **Decoder-only** (default) trains just the mask decoder, freezing the image and prompt encoders — fast, low-VRAM, robust on modest data; optionally the image encoder is also unfrozen for heavily domain-shifted data.
+
+### Focal + Dice Loss
+The mask-supervision loss used during SAM fine-tuning: a focal term (down-weights easy pixels, emphasises hard ones) plus a dice term (region overlap), combined ≈20:1. Standard across the SAM fine-tuning literature.
+
+### Mask Decoder
+The lightweight SAM head that turns image embeddings + prompt embeddings into mask logits. The default fine-tuning target (`sam_mask_decoder`, ~4.2M params for the tiny model) since it is small and adapts quickly.
+
 ### Multi-dimensional Image
 An image with more than 2 dimensions, typically from microscopy. Dimensions include T (time), Z (depth), C (channel), S (scene), H (height), W (width).
 

--- a/src/digitalsreeni_image_annotator/annotator_window.py
+++ b/src/digitalsreeni_image_annotator/annotator_window.py
@@ -24,6 +24,7 @@ from .controllers.dino_controller import DINOController
 from .controllers.image_controller import ImageController
 from .controllers.project_controller import ProjectController
 from .controllers.sam_controller import SAMController
+from .controllers.sam_train_controller import SAMTrainController
 from .controllers.yolo_controller import YOLOController
 from .core import image_utils
 from .ui import theme
@@ -117,6 +118,7 @@ class ImageAnnotator(QMainWindow):
         self._sam_inference_in_flight = False
 
         self.sam_controller = SAMController(self)
+        self.sam_train_controller = SAMTrainController(self)
         self.dino_controller = DINOController(self)
         self.yolo_controller = YOLOController(self)
         self.annotation_controller = AnnotationController(self)
@@ -162,6 +164,11 @@ class ImageAnnotator(QMainWindow):
         # YOLO Trainer
         self.yolo_trainer = None
         self.setup_yolo_menu()
+
+        # SAM fine-tuning menu + register any previously fine-tuned models so
+        # they appear in the SAM model selector (built during setup_ui above).
+        self.sam_train_controller.setup_sam_train_menu()
+        self.sam_train_controller.refresh_model_selector()
 
         install_shortcuts(self)
         install_event_filters(self)

--- a/src/digitalsreeni_image_annotator/controllers/project_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/project_controller.py
@@ -146,12 +146,10 @@ class ProjectController(QObject):
                 self.mw.initialize_yolo_trainer()
                 self.update_window_title()
 
+                # No success dialog — the loaded canvas + updated window title
+                # already make a successful open obvious; a modal just adds a
+                # click. Errors below still surface as dialogs.
                 print(f"Project opened successfully: {project_file}")
-                QMessageBox.information(
-                    self.mw,
-                    "Project Opened",
-                    f"Project opened successfully: {os.path.basename(project_file)}",
-                )
 
             except Exception as e:
                 self.mw.is_loading_project = False

--- a/src/digitalsreeni_image_annotator/controllers/sam_train_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/sam_train_controller.py
@@ -171,22 +171,29 @@ class SAMTrainController(QObject):
         self.mw.sam_controller.deactivate_sam_tools()
         self._set_sam_ui_locked(True)
 
-        self.mw.sam_finetuner = SAMFineTuner()
-        if not hasattr(self.mw, "sam_training_dialog"):
-            self.mw.sam_training_dialog = TrainingInfoDialog(self.mw)
-        self.mw.sam_training_dialog.setWindowTitle("SAM Fine-Tuning Progress")
-        self.mw.sam_training_dialog.stop_button.setEnabled(True)
-        self.mw.sam_training_dialog.stop_button.setText("Stop Training")
-        self.mw.sam_training_dialog.show()
+        # Everything from here to start() must restore the UI if it raises —
+        # otherwise training_finished (the only other unlock site) never fires
+        # and the SAM tools stay disabled until app restart.
+        try:
+            self.mw.sam_finetuner = SAMFineTuner()
+            if not hasattr(self.mw, "sam_training_dialog"):
+                self.mw.sam_training_dialog = TrainingInfoDialog(self.mw)
+            self.mw.sam_training_dialog.setWindowTitle("SAM Fine-Tuning Progress")
+            self.mw.sam_training_dialog.stop_button.setEnabled(True)
+            self.mw.sam_training_dialog.stop_button.setText("Stop Training")
+            self.mw.sam_training_dialog.show()
 
-        self.mw.sam_finetuner.progress_signal.connect(self.mw.sam_training_dialog.update_info)
-        self.mw.sam_training_dialog.stop_signal.connect(self.mw.sam_finetuner.stop_training_signal)
+            self.mw.sam_finetuner.progress_signal.connect(self.mw.sam_training_dialog.update_info)
+            self.mw.sam_training_dialog.stop_signal.connect(self.mw.sam_finetuner.stop_training_signal)
 
-        self.mw.sam_training_thread = SAMTrainingThread(
-            self.mw.sam_finetuner, base_model, groups, cfg
-        )
-        self.mw.sam_training_thread.finished.connect(self.training_finished)
-        self.mw.sam_training_thread.start()
+            self.mw.sam_training_thread = SAMTrainingThread(
+                self.mw.sam_finetuner, base_model, groups, cfg
+            )
+            self.mw.sam_training_thread.finished.connect(self.training_finished)
+            self.mw.sam_training_thread.start()
+        except Exception as e:
+            self._set_sam_ui_locked(False)
+            QMessageBox.critical(self.mw, "Could Not Start Training", str(e))
 
     def _gpu_gate(self) -> bool:
         """Warn (and let the user back out) when no usable GPU is present."""

--- a/src/digitalsreeni_image_annotator/controllers/sam_train_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/sam_train_controller.py
@@ -179,6 +179,10 @@ class SAMTrainController(QObject):
             if not hasattr(self.mw, "sam_training_dialog"):
                 self.mw.sam_training_dialog = TrainingInfoDialog(self.mw)
             self.mw.sam_training_dialog.setWindowTitle("SAM Fine-Tuning Progress")
+            # The dialog is reused across runs (same TrainingInfoDialog class as
+            # YOLO, but a separate instance) — clear the previous run's log so a
+            # new run doesn't append under stale output.
+            self.mw.sam_training_dialog.info_text.clear()
             self.mw.sam_training_dialog.stop_button.setEnabled(True)
             self.mw.sam_training_dialog.stop_button.setText("Stop Training")
             self.mw.sam_training_dialog.show()
@@ -226,7 +230,10 @@ class SAMTrainController(QObject):
     def training_finished(self, result):
         self._set_sam_ui_locked(False)
         dlg = self.mw.sam_training_dialog
-        dlg.stop_button.setEnabled(True)
+        # Training is over — DISABLE Stop so a post-completion click can't strand
+        # the button on "Stopping…" forever (it only un-sticks when a run
+        # finishes, and none is running). _launch re-enables it for the next run.
+        dlg.stop_button.setEnabled(False)
         dlg.stop_button.setText("Stop Training")
         try:
             self.mw.sam_finetuner.progress_signal.disconnect(dlg.update_info)

--- a/src/digitalsreeni_image_annotator/controllers/sam_train_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/sam_train_controller.py
@@ -1,0 +1,239 @@
+"""SAM 2 fine-tuning coordination controller.
+
+Mirrors ``YOLOController``'s shape (menu → validate → config dialog →
+``QThread`` worker → finished handler) but drives the Ultralytics-native
+:class:`~..training.sam_trainer.SAMFineTuner` instead of ``model.train`` —
+Ultralytics has no SAM trainer (see the SAM fine-tuning ADR).
+
+Key differences from YOLO training:
+- **GPU gate**: decoder fine-tuning is realistically GPU-only, so a CPU-only
+  box is hard-warned before a run starts.
+- **Re-entrancy**: training and inference both drive the resident SAM model, so
+  SAM inference tools are deactivated for the duration. The trainer runs on its
+  own ``QThread`` and never goes through ``sam_utils._run_sync``.
+- On success the fine-tuned checkpoint is registered into the SAM model
+  selector so it's immediately usable for annotation.
+"""
+
+import os
+
+from PyQt6.QtCore import QObject, QThread, pyqtSignal
+from PyQt6.QtGui import QAction
+from PyQt6.QtWidgets import QFileDialog, QMessageBox
+
+from ..dialogs.sam_trainer_dialog import SAMTrainConfigDialog
+from ..dialogs.yolo_trainer import TrainingInfoDialog
+from ..training.sam_trainer import (
+    SAMFineTuner,
+    list_custom_models,
+    make_custom_filename,
+)
+
+
+class SAMTrainingThread(QThread):
+    """Runs a fine-tuning job off the GUI thread. Emits the result dict on
+    success or the exception's string on failure (same contract as YOLO's
+    ``TrainingThread``)."""
+
+    finished = pyqtSignal(object)
+
+    def __init__(self, trainer: SAMFineTuner, base_model, groups, config):
+        super().__init__()
+        self.trainer = trainer
+        self.base_model = base_model
+        self.groups = groups
+        self.config = config
+
+    def run(self):
+        try:
+            result = self.trainer.train(self.base_model, self.groups, **self.config)
+            self.finished.emit(result)
+        except Exception as e:  # surfaced to the GUI thread by training_finished
+            import traceback
+            traceback.print_exc()
+            self.finished.emit(str(e))
+
+
+class SAMTrainController(QObject):
+    def __init__(self, main_window):
+        super().__init__(main_window)
+        self.mw = main_window
+
+    # -- menu ----------------------------------------------------------------
+
+    def setup_sam_train_menu(self):
+        menu = self.mw.menuBar().addMenu("SAM &Fine-Tune (beta)")
+
+        train_project = QAction("Train on Current Project…", self.mw)
+        train_project.triggered.connect(self.train_on_project)
+        menu.addAction(train_project)
+
+        prepare = QAction("Prepare SAM Dataset…", self.mw)
+        prepare.triggered.connect(self.prepare_dataset)
+        menu.addAction(prepare)
+
+        train_folder = QAction("Train from Dataset Folder…", self.mw)
+        train_folder.triggered.connect(self.train_from_folder)
+        menu.addAction(train_folder)
+
+        menu.addSeparator()
+        refresh = QAction("Refresh Fine-Tuned Model List", self.mw)
+        refresh.triggered.connect(self.refresh_model_selector)
+        menu.addAction(refresh)
+
+    # -- entry points --------------------------------------------------------
+
+    def train_on_project(self):
+        from ..training.sam_dataset import build_groups_from_project
+
+        groups = build_groups_from_project(
+            self.mw.all_annotations,
+            self.mw.image_paths,
+            self.mw.slices,
+            self.mw.image_slices,
+        )
+        if not groups:
+            QMessageBox.warning(
+                self.mw, "No Training Data",
+                "No usable annotations found. Annotate some objects (polygons "
+                "or boxes) first.",
+            )
+            return
+        self._launch(groups)
+
+    def prepare_dataset(self):
+        from ..io.export_formats import export_sam_dataset
+
+        out_dir = QFileDialog.getExistingDirectory(self.mw, "Choose dataset output folder")
+        if not out_dir:
+            return
+        try:
+            _, manifest = export_sam_dataset(
+                self.mw.all_annotations,
+                self.mw.class_mapping,
+                self.mw.image_paths,
+                self.mw.slices,
+                self.mw.image_slices,
+                out_dir,
+            )
+        except Exception as e:
+            QMessageBox.critical(self.mw, "Export Failed", str(e))
+            return
+        QMessageBox.information(
+            self.mw, "Dataset Prepared",
+            f"SAM dataset written to:\n{manifest}\n\nUse 'Train from Dataset "
+            f"Folder…' to fine-tune on it.",
+        )
+
+    def train_from_folder(self):
+        from ..training.sam_dataset import build_groups_from_folder
+
+        folder = QFileDialog.getExistingDirectory(self.mw, "Choose prepared SAM dataset folder")
+        if not folder:
+            return
+        try:
+            groups = build_groups_from_folder(folder)
+        except Exception as e:
+            QMessageBox.critical(self.mw, "Load Failed", str(e))
+            return
+        if not groups:
+            QMessageBox.warning(self.mw, "Empty Dataset", "No usable entries in that folder.")
+            return
+        self._launch(groups)
+
+    # -- run -----------------------------------------------------------------
+
+    def _launch(self, groups):
+        if hasattr(self.mw, "sam_training_thread") and self.mw.sam_training_thread is not None \
+                and self.mw.sam_training_thread.isRunning():
+            QMessageBox.information(self.mw, "Training Busy", "A fine-tuning run is already in progress.")
+            return
+        if not self._gpu_gate():
+            return
+
+        dialog = SAMTrainConfigDialog(self.mw)
+        if dialog.exec() != SAMTrainConfigDialog.DialogCode.Accepted:
+            return
+        cfg = dialog.get_config()
+        base_model = cfg.pop("base_model")
+        out_name = cfg.pop("out_name")
+        cfg["out_path"] = make_custom_filename(base_model, out_name)
+
+        # Training and inference both drive the resident SAM model — don't let a
+        # debounced inference fire mid-training.
+        self.mw.sam_controller.deactivate_sam_tools()
+
+        self.mw.sam_finetuner = SAMFineTuner()
+        if not hasattr(self.mw, "sam_training_dialog"):
+            self.mw.sam_training_dialog = TrainingInfoDialog(self.mw)
+        self.mw.sam_training_dialog.setWindowTitle("SAM Fine-Tuning Progress")
+        self.mw.sam_training_dialog.stop_button.setEnabled(True)
+        self.mw.sam_training_dialog.stop_button.setText("Stop Training")
+        self.mw.sam_training_dialog.show()
+
+        self.mw.sam_finetuner.progress_signal.connect(self.mw.sam_training_dialog.update_info)
+        self.mw.sam_training_dialog.stop_signal.connect(self.mw.sam_finetuner.stop_training_signal)
+
+        self.mw.sam_training_thread = SAMTrainingThread(
+            self.mw.sam_finetuner, base_model, groups, cfg
+        )
+        self.mw.sam_training_thread.finished.connect(self.training_finished)
+        self.mw.sam_training_thread.start()
+
+    def _gpu_gate(self) -> bool:
+        """Warn (and let the user back out) when no usable GPU is present."""
+        from ..core.torch_utils import resolve_torch_device
+
+        device, _ = resolve_torch_device()
+        if device == "cuda":
+            return True
+        choice = QMessageBox.warning(
+            self.mw, "No GPU — training will be very slow",
+            "No usable CUDA GPU was detected. Fine-tuning SAM on CPU is "
+            "impractically slow (minutes per image). Continue anyway with a "
+            "small run?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        return choice == QMessageBox.StandardButton.Yes
+
+    def training_finished(self, result):
+        dlg = self.mw.sam_training_dialog
+        dlg.stop_button.setEnabled(True)
+        dlg.stop_button.setText("Stop Training")
+        try:
+            self.mw.sam_finetuner.progress_signal.disconnect(dlg.update_info)
+            dlg.stop_signal.disconnect(self.mw.sam_finetuner.stop_training_signal)
+        except TypeError:
+            pass  # already disconnected
+
+        if isinstance(result, str):
+            QMessageBox.critical(self.mw, "Fine-Tuning Error", f"An error occurred:\n{result}")
+            return
+
+        self.refresh_model_selector()
+        out_path = result.get("out_path")
+        display = f"★ {os.path.splitext(os.path.basename(out_path))[0]}" if out_path else None
+        if display and hasattr(self.mw, "sam_model_selector"):
+            idx = self.mw.sam_model_selector.findText(display)
+            if idx >= 0:
+                self.mw.sam_model_selector.setCurrentIndex(idx)
+        QMessageBox.information(
+            self.mw, "Fine-Tuning Complete",
+            f"Saved and verified:\n{out_path}\n\nSelected it in the SAM model "
+            f"dropdown — use SAM-box / SAM-points to try it.",
+        )
+
+    # -- selector ------------------------------------------------------------
+
+    def refresh_model_selector(self):
+        """Register fine-tuned checkpoints and (re)add them to the SAM dropdown."""
+        customs = list_custom_models()
+        self.mw.sam_utils.register_custom_models(customs)
+        selector = getattr(self.mw, "sam_model_selector", None)
+        if selector is None:
+            return
+        existing = {selector.itemText(i) for i in range(selector.count())}
+        for display in customs:
+            if display not in existing:
+                selector.addItem(display)

--- a/src/digitalsreeni_image_annotator/controllers/sam_train_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/sam_train_controller.py
@@ -8,9 +8,11 @@ Ultralytics has no SAM trainer (see the SAM fine-tuning ADR).
 Key differences from YOLO training:
 - **GPU gate**: decoder fine-tuning is realistically GPU-only, so a CPU-only
   box is hard-warned before a run starts.
-- **Re-entrancy**: training and inference both drive the resident SAM model, so
-  SAM inference tools are deactivated for the duration. The trainer runs on its
-  own ``QThread`` and never goes through ``sam_utils._run_sync``.
+- **Re-entrancy**: the trainer loads its own SAM instance on a worker thread
+  (separate from the resident inference model), so this is not a one-model
+  race. But two SAM models on one CUDA context is, so the SAM inference UI
+  (tools + model selector + this menu) is locked for the duration and the
+  trainer never goes through ``sam_utils._run_sync``.
 - On success the fine-tuned checkpoint is registered into the SAM model
   selector so it's immediately usable for annotation.
 """
@@ -63,6 +65,7 @@ class SAMTrainController(QObject):
 
     def setup_sam_train_menu(self):
         menu = self.mw.menuBar().addMenu("SAM &Fine-Tune (beta)")
+        self._menu = menu
 
         train_project = QAction("Train on Current Project…", self.mw)
         train_project.triggered.connect(self.train_on_project)
@@ -159,9 +162,14 @@ class SAMTrainController(QObject):
         out_name = cfg.pop("out_name")
         cfg["out_path"] = make_custom_filename(base_model, out_name)
 
-        # Training and inference both drive the resident SAM model — don't let a
-        # debounced inference fire mid-training.
+        # The trainer loads its OWN SAM instance on a worker thread. The
+        # resident inference model is separate, but it stays reachable from the
+        # GUI — running inference (its own CUDA work) alongside training on the
+        # same device/context invites OOM and contention. Deactivate the tools
+        # and lock the SAM inference UI for the duration so no concurrent
+        # inference or model-swap can be triggered.
         self.mw.sam_controller.deactivate_sam_tools()
+        self._set_sam_ui_locked(True)
 
         self.mw.sam_finetuner = SAMFineTuner()
         if not hasattr(self.mw, "sam_training_dialog"):
@@ -197,7 +205,19 @@ class SAMTrainController(QObject):
         )
         return choice == QMessageBox.StandardButton.Yes
 
+    def _set_sam_ui_locked(self, locked: bool):
+        """Disable/enable SAM inference controls + the fine-tune menu so no
+        concurrent inference, model swap, or second training run can start
+        while a run is in flight."""
+        for attr in ("sam_box_button", "sam_points_button", "sam_model_selector"):
+            widget = getattr(self.mw, attr, None)
+            if widget is not None:
+                widget.setEnabled(not locked)
+        if getattr(self, "_menu", None) is not None:
+            self._menu.setEnabled(not locked)
+
     def training_finished(self, result):
+        self._set_sam_ui_locked(False)
         dlg = self.mw.sam_training_dialog
         dlg.stop_button.setEnabled(True)
         dlg.stop_button.setText("Stop Training")

--- a/src/digitalsreeni_image_annotator/dialogs/sam_trainer_dialog.py
+++ b/src/digitalsreeni_image_annotator/dialogs/sam_trainer_dialog.py
@@ -75,8 +75,10 @@ class SAMTrainConfigDialog(QDialog):
             "imagery but needs more GPU memory and labels."
         )
         note.setWordWrap(True)
-        # palette(text) so it follows the active light/dark stylesheet.
-        note.setStyleSheet("color:palette(text);")
+        # No inline color — inside a QDialog `palette(text)` resolves against the
+        # stale OS palette and renders near-white in light mode. Let the global
+        # QLabel stylesheet rule provide a theme-correct colour (No Hardcoded
+        # Colors Rule, docs/08_crosscutting_concepts.md).
         layout.addWidget(note)
 
         buttons = QDialogButtonBox(

--- a/src/digitalsreeni_image_annotator/dialogs/sam_trainer_dialog.py
+++ b/src/digitalsreeni_image_annotator/dialogs/sam_trainer_dialog.py
@@ -54,8 +54,8 @@ class SAMTrainConfigDialog(QDialog):
         self.batch_size.setRange(1, 64)
         self.batch_size.setValue(2)
         self.batch_size.setToolTip(
-            "Gradient-accumulation count — SAM prompts are per-object, so the "
-            "optimizer steps every N instances."
+            "Gradient-accumulation count — the optimizer steps every N images "
+            "(all of an image's objects are backpropagated together)."
         )
         form.addRow("Batch size:", self.batch_size)
 

--- a/src/digitalsreeni_image_annotator/dialogs/sam_trainer_dialog.py
+++ b/src/digitalsreeni_image_annotator/dialogs/sam_trainer_dialog.py
@@ -1,0 +1,98 @@
+"""Config dialog for SAM 2 fine-tuning.
+
+Collects the hyperparameters for ``training.sam_trainer.SAMFineTuner.train``.
+Progress is shown via the shared ``TrainingInfoDialog`` (reused from the YOLO
+trainer) — this module only owns the *config* dialog.
+"""
+
+from PyQt6.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QDoubleSpinBox,
+    QFormLayout,
+    QLabel,
+    QLineEdit,
+    QSpinBox,
+    QVBoxLayout,
+)
+
+from ..inference.sam_utils import MODEL_NAMES
+
+
+class SAMTrainConfigDialog(QDialog):
+    """Modal config for a fine-tuning run. Read results via :meth:`get_config`."""
+
+    def __init__(self, parent=None, *, default_name="my_finetune"):
+        super().__init__(parent)
+        self.setWindowTitle("Fine-Tune SAM Model")
+        layout = QVBoxLayout(self)
+        form = QFormLayout()
+
+        self.base_model = QComboBox()
+        self.base_model.addItems(MODEL_NAMES)
+        # tiny/small are the realistic choices for desktop fine-tuning.
+        form.addRow("Base model:", self.base_model)
+
+        self.out_name = QLineEdit(default_name)
+        form.addRow("Save as:", self.out_name)
+
+        self.epochs = QSpinBox()
+        self.epochs.setRange(1, 1000)
+        self.epochs.setValue(10)
+        form.addRow("Epochs:", self.epochs)
+
+        self.lr = QDoubleSpinBox()
+        self.lr.setDecimals(6)
+        self.lr.setRange(1e-6, 1e-1)
+        self.lr.setSingleStep(1e-5)
+        self.lr.setValue(1e-4)
+        form.addRow("Learning rate:", self.lr)
+
+        self.batch_size = QSpinBox()
+        self.batch_size.setRange(1, 64)
+        self.batch_size.setValue(2)
+        self.batch_size.setToolTip(
+            "Gradient-accumulation count — SAM prompts are per-object, so the "
+            "optimizer steps every N instances."
+        )
+        form.addRow("Batch size:", self.batch_size)
+
+        self.prompt_type = QComboBox()
+        self.prompt_type.addItems(["bbox", "point"])
+        self.prompt_type.setToolTip("Prompt derived from each ground-truth mask during training.")
+        form.addRow("Train prompt:", self.prompt_type)
+
+        self.train_encoder = QCheckBox("Also fine-tune image encoder (slower, needs more VRAM/data)")
+        form.addRow("", self.train_encoder)
+
+        layout.addLayout(form)
+
+        note = QLabel(
+            "Decoder-only (default) is fast and robust on modest data. "
+            "Fine-tuning the image encoder can help on heavily domain-shifted "
+            "imagery but needs more GPU memory and labels."
+        )
+        note.setWordWrap(True)
+        # palette(text) so it follows the active light/dark stylesheet.
+        note.setStyleSheet("color:palette(text);")
+        layout.addWidget(note)
+
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def get_config(self) -> dict:
+        return {
+            "base_model": self.base_model.currentText(),
+            "out_name": self.out_name.text().strip() or "my_finetune",
+            "epochs": self.epochs.value(),
+            "lr": self.lr.value(),
+            "batch_size": self.batch_size.value(),
+            "prompt_type": self.prompt_type.currentText(),
+            "freeze_image_encoder": not self.train_encoder.isChecked(),
+        }

--- a/src/digitalsreeni_image_annotator/inference/sam_utils.py
+++ b/src/digitalsreeni_image_annotator/inference/sam_utils.py
@@ -303,6 +303,21 @@ class SAMUtils(QObject):
         self._model = None  # ultralytics.SAM instance once loaded
         self._loaded_model_file: str | None = None
         self._device: str | None = None  # resolved at model load
+        # Fine-tuned checkpoints: {display_name: checkpoint_path}. Populated
+        # from training.sam_trainer.list_custom_models() so they load through
+        # the same SAM(path) path as the built-ins (see SAM fine-tuning ADR).
+        self.custom_models: dict[str, str] = {}
+
+    def register_custom_models(self, mapping: dict) -> None:
+        """Merge fine-tuned model entries so they become selectable."""
+        self.custom_models.update(mapping or {})
+
+    def _resolve_model_file(self, model_name: str) -> str:
+        if model_name in MODEL_NAMES:
+            return os.path.join(SAM_MODELS_DIR, MODEL_FILES[model_name])
+        if model_name in self.custom_models:
+            return self.custom_models[model_name]
+        raise ValueError(f"Unknown SAM model: {model_name}")
 
     # ── model lifecycle ────────────────────────────────────────────────
 
@@ -314,27 +329,27 @@ class SAMUtils(QObject):
             print("SAM model unset")
             return
 
-        if model_name not in MODEL_NAMES:
-            raise ValueError(f"Unknown SAM model: {model_name}")
+        # Resolve to a checkpoint path first (built-in name or fine-tuned
+        # model) so an unknown name fails before we touch a worker thread.
+        model_file = self._resolve_model_file(model_name)
 
         # Load on a worker thread to avoid stalling the UI on the
         # ~1-3 s torch model-load. Behaves synchronously to callers and
         # re-raises any load-time exception (network, corrupt weights,
         # CUDA OOM) — only flip `current_sam_model` AFTER success so
         # callers don't see a stale name on failure.
-        _run_sync(self._load_model_blocking, model_name)
+        _run_sync(self._load_model_blocking, model_file)
         self.current_sam_model = model_name
         self.model_changed.emit(model_name)
         print(f"SAM model loaded: {model_name}")
 
-    def _load_model_blocking(self, model_name: str) -> None:
+    def _load_model_blocking(self, model_file: str) -> None:
         # Lazy import keeps app startup fast for users who never use SAM.
         from ultralytics import SAM
         from ..core.torch_utils import resolve_torch_device
 
         self._device, _ = resolve_torch_device()
         self._log_device()
-        model_file = os.path.join(SAM_MODELS_DIR, MODEL_FILES[model_name])
         os.makedirs(os.path.dirname(model_file), exist_ok=True)
         self._model = SAM(model_file)
         self._loaded_model_file = model_file

--- a/src/digitalsreeni_image_annotator/io/export_formats.py
+++ b/src/digitalsreeni_image_annotator/io/export_formats.py
@@ -447,7 +447,7 @@ def export_sam_dataset(all_annotations, class_mapping, image_paths, slices, imag
     manifest_path = os.path.join(output_dir, 'manifest.json')
     with open(manifest_path, 'w', encoding='utf-8') as f:
         json.dump(manifest, f, indent=2)
-    print(f"[SAM dataset] wrote {len(manifest['images'])} image entries → {manifest_path}")
+    print(f"[SAM dataset] wrote {len(manifest['images'])} image entries -> {manifest_path}")
     return output_dir, manifest_path
 
 

--- a/src/digitalsreeni_image_annotator/io/export_formats.py
+++ b/src/digitalsreeni_image_annotator/io/export_formats.py
@@ -409,7 +409,9 @@ def export_sam_dataset(all_annotations, class_mapping, image_paths, slices, imag
                         break
             if qimage is None:
                 continue
-            file_name_img = f"{image_name}.png"
+            # basename guards against a separator in an image/slice key
+            # escaping images/ during write.
+            file_name_img = f"{os.path.basename(image_name)}.png"
             save_path = os.path.join(images_dir, file_name_img)
             if not os.path.exists(save_path):
                 qimage.save(save_path)
@@ -424,7 +426,7 @@ def export_sam_dataset(all_annotations, class_mapping, image_paths, slices, imag
                 continue
             if image_path.lower().endswith(('.tif', '.tiff', '.czi')):
                 continue
-            file_name_img = image_name
+            file_name_img = os.path.basename(image_name)
             dst_path = os.path.join(images_dir, file_name_img)
             if not os.path.exists(dst_path):
                 shutil.copy2(image_path, dst_path)

--- a/src/digitalsreeni_image_annotator/io/export_formats.py
+++ b/src/digitalsreeni_image_annotator/io/export_formats.py
@@ -405,7 +405,7 @@ def export_sam_dataset(all_annotations, class_mapping, image_paths, slices, imag
             if qimage is None:
                 for stack_slices in image_slices.values():
                     qimage = next((s[1] for s in stack_slices if s[0] == image_name), None)
-                    if qimage:
+                    if qimage is not None:
                         break
             if qimage is None:
                 continue

--- a/src/digitalsreeni_image_annotator/io/export_formats.py
+++ b/src/digitalsreeni_image_annotator/io/export_formats.py
@@ -379,6 +379,76 @@ def export_yolo_v5plus(all_annotations, class_mapping, image_paths, slices, imag
 
 
 
+def export_sam_dataset(all_annotations, class_mapping, image_paths, slices, image_slices, output_dir):
+    """Export a SAM fine-tuning dataset: ``images/`` + ``manifest.json``.
+
+    The manifest is the authoritative training source — per-instance ``bbox``/
+    ``segmentation`` specs are rasterised to masks deterministically at train
+    time (see ``training.sam_dataset``), so no separate mask PNGs are written.
+    Image resolution mirrors ``export_yolo_v5plus`` (slices via ``slices`` /
+    ``image_slices``; regular images via ``image_paths``; TIFF/CZI skipped).
+
+    Returns ``(output_dir, manifest_path)``.
+    """
+    images_dir = os.path.join(output_dir, 'images')
+    os.makedirs(images_dir, exist_ok=True)
+    slice_map = {slice_name: qimage for slice_name, qimage in slices}
+
+    manifest = {"classes": list(class_mapping.keys()), "images": []}
+    for image_name, annotations in all_annotations.items():
+        if not annotations:
+            continue
+
+        # Resolve + save the image (same branching as export_yolo_v5plus).
+        if image_name in slice_map or ('_' in image_name and '.' not in image_name):
+            qimage = slice_map.get(image_name)
+            if qimage is None:
+                for stack_slices in image_slices.values():
+                    qimage = next((s[1] for s in stack_slices if s[0] == image_name), None)
+                    if qimage:
+                        break
+            if qimage is None:
+                continue
+            file_name_img = f"{image_name}.png"
+            save_path = os.path.join(images_dir, file_name_img)
+            if not os.path.exists(save_path):
+                qimage.save(save_path)
+        else:
+            image_path = image_paths.get(image_name)
+            if image_path is None:
+                image_path = next(
+                    (path for name, path in image_paths.items() if image_name in name),
+                    None,
+                )
+            if not image_path:
+                continue
+            if image_path.lower().endswith(('.tif', '.tiff', '.czi')):
+                continue
+            file_name_img = image_name
+            dst_path = os.path.join(images_dir, file_name_img)
+            if not os.path.exists(dst_path):
+                shutil.copy2(image_path, dst_path)
+
+        instances = []
+        for class_name, class_annotations in annotations.items():
+            for ann in class_annotations:
+                if ann.get('segmentation'):
+                    instances.append({"class": class_name, "segmentation": ann['segmentation']})
+                elif ann.get('bbox'):
+                    instances.append({"class": class_name, "bbox": ann['bbox']})
+        if instances:
+            manifest["images"].append({
+                "image": os.path.join('images', file_name_img),
+                "instances": instances,
+            })
+
+    manifest_path = os.path.join(output_dir, 'manifest.json')
+    with open(manifest_path, 'w', encoding='utf-8') as f:
+        json.dump(manifest, f, indent=2)
+    print(f"[SAM dataset] wrote {len(manifest['images'])} image entries → {manifest_path}")
+    return output_dir, manifest_path
+
+
 def export_labeled_images(all_annotations, class_mapping, image_paths, slices, image_slices, output_dir):
     # Create output directories
     images_dir = os.path.join(output_dir, 'images')

--- a/src/digitalsreeni_image_annotator/training/__init__.py
+++ b/src/digitalsreeni_image_annotator/training/__init__.py
@@ -1,0 +1,1 @@
+"""SAM 2 / 2.1 fine-tuning: training engine and dataset builders."""

--- a/src/digitalsreeni_image_annotator/training/sam_dataset.py
+++ b/src/digitalsreeni_image_annotator/training/sam_dataset.py
@@ -56,7 +56,14 @@ def build_groups_from_project(all_annotations, image_paths, slices, image_slices
             if qimage is None:
                 print(f"[SAM dataset] skip slice {image_name!r}: no image data")
                 continue
-            groups.append(SampleGroup(lambda q=qimage: _qimage_to_numpy(q), specs))
+            # Convert the in-memory slice QImage to numpy HERE, on the GUI
+            # thread. The array is later consumed by the training worker
+            # thread; reading constBits() of a live, GUI-shared QImage from
+            # another thread is exactly what _qimage_to_numpy warns against,
+            # so we hand the worker a thread-owned copy instead of a lambda
+            # that defers the buffer read onto the worker.
+            arr = _qimage_to_numpy(qimage)
+            groups.append(SampleGroup(lambda a=arr: a, specs))
             continue
 
         image_path = image_paths.get(image_name)

--- a/src/digitalsreeni_image_annotator/training/sam_dataset.py
+++ b/src/digitalsreeni_image_annotator/training/sam_dataset.py
@@ -1,0 +1,100 @@
+"""Build SAM fine-tuning :class:`SampleGroup`s from either the live project
+annotations or a prepared on-disk dataset folder.
+
+The project path mirrors the image-resolution logic in
+``io.export_formats.export_yolo_v5plus`` (slice lookup via ``slices`` /
+``image_slices``; regular images via ``image_paths`` with exact-then-substring
+match; TIFF/CZI source files skipped in favour of their extracted slices), so a
+dataset that exports cleanly to YOLO also trains cleanly here.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+from PyQt6.QtGui import QImage
+
+from .sam_trainer import SampleGroup
+from ..inference.sam_utils import _qimage_to_numpy
+
+
+def _specs_for(annotations) -> list:
+    """Flatten ``{class: [ann, ...]}`` into raw instance specs the
+    :class:`SampleGroup` rasterises lazily."""
+    specs = []
+    for _class_name, class_annotations in (annotations or {}).items():
+        for ann in class_annotations:
+            if ann.get("segmentation"):
+                specs.append({"segmentation": ann["segmentation"]})
+            elif ann.get("bbox"):
+                specs.append({"bbox": ann["bbox"]})
+    return specs
+
+
+def build_groups_from_project(all_annotations, image_paths, slices, image_slices):
+    """Live project annotations → ``list[SampleGroup]``.
+
+    Images load lazily (one at a time during training) to bound memory; in-RAM
+    slice QImages are reused directly.
+    """
+    slice_map = {name: qimage for name, qimage in slices}
+    groups = []
+
+    for image_name, image_annotations in all_annotations.items():
+        specs = _specs_for(image_annotations)
+        if not specs:
+            continue
+
+        if image_name in slice_map or ("_" in image_name and "." not in image_name):
+            qimage = slice_map.get(image_name)
+            if qimage is None:
+                for stack_slices in image_slices.values():
+                    qimage = next((s[1] for s in stack_slices if s[0] == image_name), None)
+                    if qimage is not None:
+                        break
+            if qimage is None:
+                print(f"[SAM dataset] skip slice {image_name!r}: no image data")
+                continue
+            groups.append(SampleGroup(lambda q=qimage: _qimage_to_numpy(q), specs))
+            continue
+
+        image_path = image_paths.get(image_name)
+        if image_path is None:
+            image_path = next(
+                (p for name, p in image_paths.items() if image_name in name), None
+            )
+        if not image_path:
+            print(f"[SAM dataset] skip {image_name!r}: no image_paths entry")
+            continue
+        if image_path.lower().endswith((".tif", ".tiff", ".czi")):
+            print(f"[SAM dataset] skip TIFF/CZI source {image_name!r} (use slices)")
+            continue
+        groups.append(SampleGroup(lambda p=image_path: _qimage_to_numpy(QImage(p)), specs))
+
+    return groups
+
+
+# ── prepared folder ──────────────────────────────────────────────────────────
+
+def build_groups_from_folder(folder: str):
+    """Read a folder produced by ``export_sam_dataset`` → ``list[SampleGroup]``.
+
+    Expects ``<folder>/manifest.json`` with entries
+    ``{"image": "images/x.png", "instances": [{"bbox": [...]}|{"segmentation": [...]}]}``.
+    """
+    manifest_path = os.path.join(folder, "manifest.json")
+    if not os.path.exists(manifest_path):
+        raise FileNotFoundError(f"No manifest.json in {folder}")
+    with open(manifest_path, "r", encoding="utf-8") as f:
+        manifest = json.load(f)
+
+    groups = []
+    for entry in manifest.get("images", []):
+        img_rel = entry["image"]
+        img_path = os.path.join(folder, img_rel)
+        specs = entry.get("instances", [])
+        if not specs or not os.path.exists(img_path):
+            continue
+        groups.append(SampleGroup(lambda p=img_path: _qimage_to_numpy(QImage(p)), specs))
+    return groups

--- a/src/digitalsreeni_image_annotator/training/sam_trainer.py
+++ b/src/digitalsreeni_image_annotator/training/sam_trainer.py
@@ -228,6 +228,19 @@ class SAMFineTuner(QObject):
         return model, model.predictor, model_file
 
     @staticmethod
+    def _device_label(device) -> str:
+        """``cuda:0 (NVIDIA GeForce RTX 4070)`` — make it obvious the GPU is in
+        use (a bare ``cuda:0`` reads to users like the GPU wasn't detected)."""
+        try:
+            import torch
+            if str(device).startswith("cuda"):
+                idx = device.index if getattr(device, "index", None) is not None else 0
+                return f"{device} ({torch.cuda.get_device_name(idx)})"
+        except Exception:
+            pass
+        return str(device)
+
+    @staticmethod
     def _apply_freeze(net, freeze_image_encoder: bool):
         net.eval()
         for p in net.parameters():
@@ -258,11 +271,13 @@ class SAMFineTuner(QObject):
     ) -> dict:
         """Fine-tune and save. Returns a small result dict; raises on failure.
 
-        ``groups`` is an iterable of :class:`SampleGroup`. ``batch_size`` is
-        treated as a gradient-accumulation count (SAM prompts are per-object,
-        so we step the optimizer every ``batch_size`` instances).
+        ``groups`` is an iterable of :class:`SampleGroup`. ``batch_size`` is a
+        gradient-accumulation count over **images** — all of an image's objects
+        are backpropagated together (one backward per image), so the optimizer
+        steps every ``batch_size`` images.
         """
         import torch
+        from ultralytics.utils import ops
 
         groups = list(groups)
         if not groups:
@@ -275,7 +290,7 @@ class SAMFineTuner(QObject):
         device = next(net.parameters()).device
         trainable, n_trainable = self._apply_freeze(net, freeze_image_encoder)
         self.progress_signal.emit(
-            f"Base: {os.path.basename(base_file)} | device: {device} | "
+            f"Base: {os.path.basename(base_file)} | device: {self._device_label(device)} | "
             f"images: {len(groups)} | trainable params: {n_trainable:,} | "
             f"encoder {'TRAINED' if not freeze_image_encoder else 'frozen'}"
         )
@@ -317,9 +332,16 @@ class SAMFineTuner(QObject):
                         pm, _ = pred.prompt_inference(
                             im_t, multimask_output=False, **prompt
                         )
-                    logits = torch.nn.functional.interpolate(
-                        pm[:1].unsqueeze(0).float(), size=(h, w),
-                        mode="bilinear", align_corners=False,
+                    # Map the low-res logits back to the original image with the
+                    # SAME transform inference uses (SAM2Predictor.postprocess →
+                    # ops.scale_masks(padding=False)). SAM2 letterboxes the image
+                    # (resize-min-ratio + pad bottom/right) and scale_masks crops
+                    # that padding before upsampling. A naive interpolate over the
+                    # full low-res mask instead bakes the padding region into the
+                    # target, so the decoder learns masks shifted by the pad — the
+                    # downward shift seen on non-square images (issue #73 testing).
+                    logits = ops.scale_masks(
+                        pm[:1].unsqueeze(0).float(), (h, w), padding=False
                     )
                     target = torch.from_numpy(inst["mask"].astype(np.float32))[None, None].to(device)
                     inst_losses.append(_focal_dice_loss(logits, target))

--- a/src/digitalsreeni_image_annotator/training/sam_trainer.py
+++ b/src/digitalsreeni_image_annotator/training/sam_trainer.py
@@ -29,9 +29,15 @@ Threading
 ``train()`` is **blocking and CPU/GPU-bound**; the controller runs it on a
 dedicated ``QThread`` (never the GUI thread). Unlike SAM inference it does
 *not* go through ``sam_utils._run_sync`` — that helper's re-entry guard is
-GUI-thread-local. The controller is responsible for deactivating SAM tools and
-disabling inference buttons for the duration so the resident model isn't driven
-from two threads at once.
+GUI-thread-local.
+
+The trainer loads its **own** ``SAM`` instance (see ``_build_predictor``); it
+never touches ``SAMUtils._model``, so this is not "two threads driving one
+model". The hazard it *does* create is two SAM models (the resident inference
+one and this training one) competing for the same GPU/CUDA context. The
+controller therefore locks the SAM inference UI (tools + model selector + the
+fine-tune menu) for the duration so no concurrent inference or model swap can
+be triggered while a run is in flight.
 """
 
 from __future__ import annotations
@@ -294,12 +300,19 @@ class SAMFineTuner(QObject):
                 h, w = image.shape[:2]
                 im_t = self._set_image(pred, image, freeze_image_encoder)
 
+                # Accumulate all of THIS image's instance losses and backward
+                # ONCE per image. When the image encoder is trainable, every
+                # instance's decoder graph hangs off the one shared encoder
+                # feature graph; a per-instance backward() would free that
+                # shared graph and make the next instance raise "backward
+                # through the graph a second time". One backward per image
+                # keeps the shared graph alive for exactly one pass.
+                inst_losses = []
                 for inst in instances:
-                    mask = inst["mask"]
-                    bbox = mask_to_xyxy(mask)
+                    bbox = mask_to_xyxy(inst["mask"])
                     if bbox is None:
                         continue
-                    prompt = self._prompt_kwargs(prompt_type, mask, bbox)
+                    prompt = self._prompt_kwargs(prompt_type, inst["mask"], bbox)
                     with torch.enable_grad():
                         pm, _ = pred.prompt_inference(
                             im_t, multimask_output=False, **prompt
@@ -308,18 +321,24 @@ class SAMFineTuner(QObject):
                         pm[:1].unsqueeze(0).float(), size=(h, w),
                         mode="bilinear", align_corners=False,
                     )
-                    target = torch.from_numpy(mask.astype(np.float32))[None, None].to(device)
-                    loss = _focal_dice_loss(logits, target) / max(1, batch_size)
-                    loss.backward()
-                    epoch_loss += loss.detach().item() * max(1, batch_size)
-                    seen += 1
-                    accum += 1
-                    if accum >= batch_size:
-                        optimizer.step()
-                        optimizer.zero_grad()
-                        accum = 0
+                    target = torch.from_numpy(inst["mask"].astype(np.float32))[None, None].to(device)
+                    inst_losses.append(_focal_dice_loss(logits, target))
 
                 del image  # bound memory: encoder features recomputed per epoch
+                if not inst_losses:
+                    continue
+
+                # batch_size = number of IMAGES to accumulate before an
+                # optimizer step (gradient accumulation over images).
+                image_loss = torch.stack(inst_losses).mean() / max(1, batch_size)
+                image_loss.backward()
+                epoch_loss += image_loss.detach().item() * max(1, batch_size)
+                seen += 1
+                accum += 1
+                if accum >= batch_size:
+                    optimizer.step()
+                    optimizer.zero_grad()
+                    accum = 0
 
             if accum > 0:  # flush partial accumulation
                 optimizer.step()

--- a/src/digitalsreeni_image_annotator/training/sam_trainer.py
+++ b/src/digitalsreeni_image_annotator/training/sam_trainer.py
@@ -1,0 +1,402 @@
+"""SAM 2 / 2.1 fine-tuning engine — Ultralytics-native custom training loop.
+
+Why this exists
+---------------
+Ultralytics has **no SAM trainer**: ``SAM.task_map`` registers only a
+*predictor* for the ``segment`` task, so ``SAM(...).train()`` raises
+``NotImplementedError`` (verified on ultralytics 8.4.51). We therefore
+cannot mirror the YOLO ``model.train(data=yaml, ...)`` path.
+
+What we do instead
+------------------
+``SAM(...).model`` is a plain ``nn.Module`` (``SAM2Model``) exposing
+``image_encoder`` / ``sam_prompt_encoder`` / ``sam_mask_decoder``, and the
+Ultralytics ``SAM2Predictor`` already implements the forward path in reusable
+pieces — ``get_im_features`` (image encoder) and ``prompt_inference`` /
+``_inference_features`` (prompt encoder + mask decoder). We call those methods
+**under autograd** (they are not wrapped in ``inference_mode`` unless reached
+via the public ``__call__``), add a focal+dice loss and an AdamW step, and
+save a checkpoint that reloads through the existing ``SAM(path)`` inference
+path. No extra dependency, and the result drops straight into the app's SAM
+model selector.
+
+This keeps our exposure confined to a thin adapter over already-exercised
+predictor methods. The spike that validated the mechanic lives in the PR for
+issue bnsreenu#73.
+
+Threading
+---------
+``train()`` is **blocking and CPU/GPU-bound**; the controller runs it on a
+dedicated ``QThread`` (never the GUI thread). Unlike SAM inference it does
+*not* go through ``sam_utils._run_sync`` — that helper's re-entry guard is
+GUI-thread-local. The controller is responsible for deactivating SAM tools and
+disabling inference buttons for the duration so the resident model isn't driven
+from two threads at once.
+"""
+
+from __future__ import annotations
+
+import os
+import random
+
+import cv2
+import numpy as np
+from PyQt6.QtCore import QObject, pyqtSignal
+
+from ..inference.sam_utils import MODEL_FILES, MODEL_NAMES, SAM_MODELS_DIR
+
+# Fine-tuned checkpoints live alongside the base weights, namespaced so they
+# never collide with Ultralytics' auto-downloaded base files.
+SAM_CUSTOM_DIR = os.path.join(SAM_MODELS_DIR, "custom")
+
+
+def make_custom_filename(base_model: str, name: str) -> str:
+    """Build a fine-tuned checkpoint path under ``SAM_CUSTOM_DIR``.
+
+    Ultralytics' ``build_sam`` selects the architecture by ``ckpt.endswith(token)``
+    where ``token`` is the base file name (e.g. ``sam2_t.pt``). A fine-tuned file
+    therefore **must** keep that suffix or ``SAM(path)`` raises "not a supported
+    SAM model". We sanitise the user label and append ``_<base_token>``.
+    """
+    token = MODEL_FILES.get(base_model, os.path.basename(base_model))
+    safe = "".join(c if c.isalnum() or c in "-_" else "_" for c in name).strip("_")
+    safe = safe or "finetuned"
+    return os.path.join(SAM_CUSTOM_DIR, f"{safe}_{token}")
+
+
+def list_custom_models() -> dict:
+    """``{display_name: path}`` for fine-tuned checkpoints, for the SAM selector."""
+    out = {}
+    if os.path.isdir(SAM_CUSTOM_DIR):
+        for fn in sorted(os.listdir(SAM_CUSTOM_DIR)):
+            if fn.endswith(".pt"):
+                out[f"★ {os.path.splitext(fn)[0]}"] = os.path.join(SAM_CUSTOM_DIR, fn)
+    return out
+
+
+# ── geometry: annotation → (mask, prompt) ───────────────────────────────────
+
+def polygon_to_mask(segmentation, height: int, width: int) -> np.ndarray:
+    """Flat ``[x1,y1,x2,y2,...]`` polygon → bool mask (inverse of
+    ``sam_utils._mask_to_polygon``)."""
+    pts = np.array(segmentation, dtype=np.float32).reshape(-1, 2)
+    mask = np.zeros((height, width), dtype=np.uint8)
+    cv2.fillPoly(mask, [np.round(pts).astype(np.int32)], 1)
+    return mask.astype(bool)
+
+
+def bbox_to_mask(bbox, height: int, width: int) -> np.ndarray:
+    """``[x, y, w, h]`` → bool mask."""
+    x, y, w, h = bbox
+    mask = np.zeros((height, width), dtype=np.uint8)
+    cv2.rectangle(mask, (int(x), int(y)), (int(x + w), int(y + h)), 1, thickness=-1)
+    return mask.astype(bool)
+
+
+def mask_to_xyxy(mask: np.ndarray):
+    """Tight ``[x1, y1, x2, y2]`` bounding box of a bool mask, or None if empty."""
+    ys, xs = np.where(mask)
+    if xs.size == 0:
+        return None
+    return [float(xs.min()), float(ys.min()), float(xs.max()), float(ys.max())]
+
+
+def mask_to_point(mask: np.ndarray):
+    """A single foreground point well inside the mask.
+
+    Uses the distance transform's argmax so the point sits near the medial
+    axis rather than on an edge — a more stable positive prompt than a random
+    interior pixel.
+    """
+    m = mask.astype(np.uint8)
+    if m.sum() == 0:
+        return None
+    dist = cv2.distanceTransform(m, cv2.DIST_L2, 3)
+    y, x = np.unravel_index(int(np.argmax(dist)), dist.shape)
+    return [float(x), float(y)]
+
+
+# ── loss ────────────────────────────────────────────────────────────────────
+
+def _focal_dice_loss(logits, target, focal_weight: float = 20.0):
+    """SAM's mask supervision: focal + dice, ≈20:1 (focal:dice).
+
+    ``logits`` and ``target`` are ``(1, 1, H, W)`` on the same device; target
+    is float {0,1}. Matches the recipe used across the SAM fine-tuning
+    literature (focal for hard pixels, dice for region overlap).
+    """
+    import torch
+    import torch.nn.functional as F
+
+    prob = torch.sigmoid(logits)
+    # Focal (binary), gamma=2.
+    bce = F.binary_cross_entropy_with_logits(logits, target, reduction="none")
+    p_t = prob * target + (1 - prob) * (1 - target)
+    focal = (bce * (1 - p_t).pow(2)).mean()
+    # Dice.
+    inter = (prob * target).sum()
+    dice = 1 - (2 * inter + 1) / (prob.sum() + target.sum() + 1)
+    return focal_weight * focal + dice
+
+
+# ── dataset ──────────────────────────────────────────────────────────────────
+
+class SampleGroup:
+    """One image plus the specs for its instances, loaded lazily.
+
+    ``image_loader`` returns an RGB ``uint8`` array (matching what
+    ``sam_utils._qimage_to_numpy`` feeds inference — channel-order consistency
+    between train and predict matters more than absolute order). ``specs`` are
+    raw annotations (``{"segmentation": [...]}`` or ``{"bbox": [x,y,w,h]}``)
+    rasterised to bool masks **at load time** using the actual image size, so
+    masks are never held in RAM between epochs and always match the image.
+    """
+
+    def __init__(self, image_loader, specs):
+        self._image_loader = image_loader
+        self.specs = specs
+        self.n_instances = len(specs)
+
+    def load(self):
+        """Return ``(image_rgb, [{"mask": bool HxW}, ...])``."""
+        image = self._image_loader()
+        h, w = image.shape[:2]
+        instances = []
+        for spec in self.specs:
+            if spec.get("segmentation"):
+                mask = polygon_to_mask(spec["segmentation"], h, w)
+            elif spec.get("bbox"):
+                mask = bbox_to_mask(spec["bbox"], h, w)
+            else:
+                continue
+            if mask.any():
+                instances.append({"mask": mask})
+        return image, instances
+
+
+# ── engine ───────────────────────────────────────────────────────────────────
+
+class SAMFineTuner(QObject):
+    """Fine-tunes a SAM 2 mask decoder (optionally image encoder) on
+    user instances. Mirrors ``YOLOTrainer``'s signal/stop surface so the
+    controller and progress dialog wiring is identical."""
+
+    progress_signal = pyqtSignal(str)
+
+    def __init__(self):
+        super().__init__()
+        self.stop_training = False
+
+    def stop_training_signal(self):
+        self.stop_training = True
+        self.progress_signal.emit("Stopping after current step…")
+
+    # -- model setup ---------------------------------------------------------
+
+    def _build_predictor(self, base_model):
+        """Return a ready ``SAM2Predictor`` for ``base_model`` (a registry name
+        like ``"SAM 2 tiny"`` or a path to a ``.pt``).
+
+        Forces predictor creation with one throwaway predict so ``set_image`` /
+        ``prompt_inference`` are usable. Pins the device via
+        ``resolve_torch_device`` so an incompatible GPU (which Ultralytics would
+        otherwise pick blindly and crash on) is honoured as CPU — the same
+        device decision SAM/DINO/YOLO inference already share."""
+        from ultralytics import SAM
+
+        from ..core.torch_utils import resolve_torch_device
+
+        if base_model in MODEL_NAMES:
+            model_file = os.path.join(SAM_MODELS_DIR, MODEL_FILES[base_model])
+        else:
+            model_file = base_model
+        if not os.path.exists(model_file):
+            raise FileNotFoundError(f"Base SAM weights not found: {model_file}")
+
+        device, _ = resolve_torch_device()
+        model = SAM(model_file)
+        warm = (np.random.rand(64, 64, 3) * 255).astype(np.uint8)
+        # device= forces the warmup (and predictor model placement) onto the
+        # resolved device rather than Ultralytics' default cuda-if-present.
+        model(warm, bboxes=[[8, 8, 56, 56]], device=device, verbose=False)
+        return model, model.predictor, model_file
+
+    @staticmethod
+    def _apply_freeze(net, freeze_image_encoder: bool):
+        net.eval()
+        for p in net.parameters():
+            p.requires_grad_(False)
+        for p in net.sam_mask_decoder.parameters():
+            p.requires_grad_(True)
+        if not freeze_image_encoder:
+            for p in net.image_encoder.parameters():
+                p.requires_grad_(True)
+            net.image_encoder.train()
+        trainable = [p for p in net.parameters() if p.requires_grad]
+        n = sum(p.numel() for p in trainable)
+        return trainable, n
+
+    # -- training ------------------------------------------------------------
+
+    def train(
+        self,
+        base_model,
+        groups,
+        *,
+        epochs: int = 10,
+        lr: float = 1e-4,
+        batch_size: int = 1,
+        freeze_image_encoder: bool = True,
+        prompt_type: str = "bbox",
+        out_path: str,
+    ) -> dict:
+        """Fine-tune and save. Returns a small result dict; raises on failure.
+
+        ``groups`` is an iterable of :class:`SampleGroup`. ``batch_size`` is
+        treated as a gradient-accumulation count (SAM prompts are per-object,
+        so we step the optimizer every ``batch_size`` instances).
+        """
+        import torch
+
+        groups = list(groups)
+        if not groups:
+            raise ValueError("No annotated instances to train on.")
+        if prompt_type not in ("bbox", "point"):
+            raise ValueError(f"Unknown prompt_type: {prompt_type}")
+
+        model, pred, base_file = self._build_predictor(base_model)
+        net = pred.model
+        device = next(net.parameters()).device
+        trainable, n_trainable = self._apply_freeze(net, freeze_image_encoder)
+        self.progress_signal.emit(
+            f"Base: {os.path.basename(base_file)} | device: {device} | "
+            f"images: {len(groups)} | trainable params: {n_trainable:,} | "
+            f"encoder {'TRAINED' if not freeze_image_encoder else 'frozen'}"
+        )
+
+        optimizer = torch.optim.AdamW(trainable, lr=lr, weight_decay=0.1)
+        self.stop_training = False
+        total_instances = sum(g.n_instances for g in groups)
+        if total_instances == 0:
+            raise ValueError("No annotated instances to train on.")
+
+        for epoch in range(1, epochs + 1):
+            if self.stop_training:
+                break
+            random.shuffle(groups)
+            epoch_loss, seen, accum = 0.0, 0, 0
+            optimizer.zero_grad()
+
+            for group in groups:
+                if self.stop_training:
+                    break
+                image, instances = group.load()
+                h, w = image.shape[:2]
+                im_t = self._set_image(pred, image, freeze_image_encoder)
+
+                for inst in instances:
+                    mask = inst["mask"]
+                    bbox = mask_to_xyxy(mask)
+                    if bbox is None:
+                        continue
+                    prompt = self._prompt_kwargs(prompt_type, mask, bbox)
+                    with torch.enable_grad():
+                        pm, _ = pred.prompt_inference(
+                            im_t, multimask_output=False, **prompt
+                        )
+                    logits = torch.nn.functional.interpolate(
+                        pm[:1].unsqueeze(0).float(), size=(h, w),
+                        mode="bilinear", align_corners=False,
+                    )
+                    target = torch.from_numpy(mask.astype(np.float32))[None, None].to(device)
+                    loss = _focal_dice_loss(logits, target) / max(1, batch_size)
+                    loss.backward()
+                    epoch_loss += loss.detach().item() * max(1, batch_size)
+                    seen += 1
+                    accum += 1
+                    if accum >= batch_size:
+                        optimizer.step()
+                        optimizer.zero_grad()
+                        accum = 0
+
+                del image  # bound memory: encoder features recomputed per epoch
+
+            if accum > 0:  # flush partial accumulation
+                optimizer.step()
+                optimizer.zero_grad()
+            avg = epoch_loss / max(1, seen)
+            self.progress_signal.emit(f"Epoch {epoch}/{epochs}  loss={avg:.4f}")
+
+        result = self._save_and_verify(net, base_file, out_path)
+        result.update(stopped=self.stop_training, instances=total_instances)
+        self.progress_signal.emit(
+            f"Saved fine-tuned model: {out_path}" if not self.stop_training
+            else f"Stopped early — saved current state to {out_path}"
+        )
+        return result
+
+    def _set_image(self, pred, image: np.ndarray, freeze_image_encoder: bool):
+        """Preprocess ``image`` and compute encoder features into the predictor.
+
+        Sets ``pred.batch`` explicitly so ``_prepare_prompts`` maps bbox/point
+        prompts from this image's original pixel size into model coordinates —
+        a stale ``batch`` from a different-sized image would mis-scale prompts.
+        """
+        import torch
+
+        pred.setup_source(image)
+        im_t = None
+        for batch in pred.dataset:
+            im_t = pred.preprocess(batch[1])
+            break
+        # (paths, im0s, ...) — prompt_inference reads self.batch[1][0].shape for orig H,W.
+        pred.batch = (None, [image], None)
+        if freeze_image_encoder:
+            with torch.no_grad():
+                pred.features = pred.get_im_features(im_t)
+        else:
+            pred.features = pred.get_im_features(im_t)
+        return im_t
+
+    @staticmethod
+    def _prompt_kwargs(prompt_type: str, mask: np.ndarray, bbox):
+        if prompt_type == "bbox":
+            return {"bboxes": [bbox]}
+        pt = mask_to_point(mask)
+        return {"points": [pt], "labels": [1]}
+
+    # -- checkpoint ----------------------------------------------------------
+
+    def _save_and_verify(self, net, base_file: str, out_path: str) -> dict:
+        """Save fine-tuned weights as ``{"model": state_dict}`` and prove they
+        reload through ``SAM(out_path)``.
+
+        Ultralytics' ``_load_checkpoint`` reads only the nested ``"model"`` key
+        (a tensor dict) and rebuilds the architecture from the filename suffix,
+        so a pure state_dict is all we need — no need to ``torch.load`` (and
+        unpickle) the base file. Because ``net`` is the same ``SAM2Model`` class
+        Ultralytics instantiates, the keys match exactly, sidestepping the
+        "Unexpected key(s)" reload failures (facebookresearch/sam2#337).
+        """
+        import torch
+        from ultralytics import SAM
+
+        token = os.path.basename(base_file)
+        if not os.path.basename(out_path).endswith(token):
+            raise ValueError(
+                f"Fine-tuned checkpoint name must end with '{token}' so "
+                f"Ultralytics can pick the right architecture; got "
+                f"'{os.path.basename(out_path)}'. Use make_custom_filename()."
+            )
+
+        os.makedirs(os.path.dirname(out_path) or ".", exist_ok=True)
+        net_cpu_state = {k: v.detach().cpu() for k, v in net.state_dict().items()}
+        torch.save({"model": net_cpu_state}, out_path)
+
+        # Round-trip verification: load + one forward. Failing here is loud by design.
+        verify = SAM(out_path)
+        verify(
+            (np.random.rand(64, 64, 3) * 255).astype(np.uint8),
+            bboxes=[[8, 8, 56, 56]], verbose=False,
+        )
+        return {"out_path": out_path, "verified": True}

--- a/src/digitalsreeni_image_annotator/ui/sidebar.py
+++ b/src/digitalsreeni_image_annotator/ui/sidebar.py
@@ -146,11 +146,11 @@ def build_sidebar(window):
     dino_browse_layout.setContentsMargins(0, 0, 0, 0)
     window.lbl_dino_custom = QLabel("No path set")
     window.lbl_dino_custom.setWordWrap(True)
-    # Use palette(text) so the colour follows the active stylesheet
-    # (light or dark) — hardcoded #555 used to render unreadable on
-    # dark mode. See "No Hardcoded Colors Rule" in CLAUDE.md.
-    # No font-size here — the caption follows the global ui_font_pt rule.
-    window.lbl_dino_custom.setStyleSheet("color:palette(text);")
+    # No inline colour: `palette(text)` resolves to a near-white role in light
+    # mode (rendering this caption unreadable). The global QLabel stylesheet
+    # rule gives a theme-correct colour in both modes — leave the property out
+    # so the global sheet wins. See "No Hardcoded Colors Rule" in CLAUDE.md.
+    # No font-size here either — the caption follows the global ui_font_pt rule.
     btn_dino_browse = QPushButton("Browse")
     # No fixed width — a 60px cap clipped the caption at large UI font
     # sizes (low-vision zoom); sizeHint tracks the active font.

--- a/tests/integration/test_sam_finetuning.py
+++ b/tests/integration/test_sam_finetuning.py
@@ -251,3 +251,42 @@ def test_end_to_end_train_save_reload(temp_dir):
     from ultralytics import SAM
     SAM(out)((np.random.rand(120, 120, 3) * 255).astype(np.uint8),
              bboxes=[[40, 40, 80, 80]], verbose=False)
+
+
+@pytest.mark.skipif(
+    os.environ.get("SAM_TRAIN_E2E") != "1",
+    reason="set SAM_TRAIN_E2E=1 to run the encoder-path multi-instance test",
+)
+def test_encoder_path_multi_instance_per_image(temp_dir):
+    """Regression: encoder fine-tuning (freeze_image_encoder=False) on images
+    with >1 instance used to crash with 'backward through the graph a second
+    time' because all instances shared the one encoder feature graph. The
+    engine now backprops once per image."""
+    pytest.importorskip("ultralytics")
+    from src.digitalsreeni_image_annotator.training.sam_trainer import (
+        SAM_MODELS_DIR,
+        SAMFineTuner,
+    )
+
+    if not os.path.exists(os.path.join(SAM_MODELS_DIR, "sam2_t.pt")):
+        pytest.skip("sam2_t.pt not cached")
+
+    def two_instance_image(seed):
+        rng = np.random.RandomState(seed)
+        img = (rng.rand(140, 140, 3) * 255).astype(np.uint8)
+        specs = []
+        for cy, cx in [(40, 40), (95, 95)]:
+            yy, xx = np.ogrid[:140, :140]
+            m = (yy - cy) ** 2 + (xx - cx) ** 2 < 18 ** 2
+            img[m] = [30, 220, 30]
+            x1, y1, x2, y2 = mask_to_xyxy(m)
+            specs.append({"bbox": [x1, y1, x2 - x1, y2 - y1]})
+        return SampleGroup(lambda im=img: im.copy(), specs)
+
+    out = os.path.join(temp_dir, "enc_sam2_t.pt")
+    res = SAMFineTuner().train(
+        "SAM 2 tiny", [two_instance_image(i) for i in range(2)],
+        epochs=1, lr=1e-5, batch_size=1, freeze_image_encoder=False,
+        prompt_type="bbox", out_path=out,
+    )
+    assert res["verified"] and res["instances"] == 4

--- a/tests/integration/test_sam_finetuning.py
+++ b/tests/integration/test_sam_finetuning.py
@@ -210,6 +210,29 @@ class TestUltralyticsAPI:
                      "_prepare_prompts", "set_image"):
             assert hasattr(SAM2Predictor, name), f"SAM2Predictor.{name} missing"
 
+    def test_ops_scale_masks_padding_false_geometry(self):
+        """The training loss maps logits back with the same letterbox-aware
+        transform inference uses (ops.scale_masks, padding=False). Guard the
+        *behavior*, not just the name: with padding=False the crop is
+        top-left-anchored, so foreground in the bottom padding band of a
+        non-square target is dropped while top content survives. A semantic
+        change in Ultralytics (not just a rename) trips this fast test rather
+        than only the GPU-gated e2e."""
+        torch = pytest.importorskip("torch")
+        pytest.importorskip("ultralytics")
+        from ultralytics.utils import ops
+
+        assert hasattr(ops, "scale_masks")
+        # Target 600x1000 (landscape) -> ~bottom 40% of a 256-tall mask is padding.
+        top = torch.zeros(1, 1, 256, 256)
+        top[..., 0:40, :] = 1.0
+        bottom = torch.zeros(1, 1, 256, 256)
+        bottom[..., 215:256, :] = 1.0
+        out_top = ops.scale_masks(top, (600, 1000), padding=False)
+        out_bottom = ops.scale_masks(bottom, (600, 1000), padding=False)
+        assert out_top.sum() > 0, "top content must survive the crop"
+        assert out_bottom.sum() == 0, "bottom padding band must be cropped (padding=False)"
+
 
 # ── opt-in end-to-end (needs weights; realistically GPU) ─────────────────────
 
@@ -290,3 +313,66 @@ def test_encoder_path_multi_instance_per_image(temp_dir):
         prompt_type="bbox", out_path=out,
     )
     assert res["verified"] and res["instances"] == 4
+
+
+@pytest.mark.skipif(
+    os.environ.get("SAM_TRAIN_E2E") != "1",
+    reason="set SAM_TRAIN_E2E=1 to run the landscape mask-shift regression",
+)
+def test_landscape_no_mask_shift(temp_dir):
+    """Regression for the downward mask shift (issue #73 GUI testing).
+
+    SAM2 letterboxes (pad bottom/right) and inference crops the padding via
+    ops.scale_masks(padding=False). The training loss must use the SAME
+    transform; a naive interpolate baked the padding into the target and the
+    decoder learned masks shifted down. This must use a NON-square image (square
+    images have zero padding and so never exposed the bug).
+    """
+    pytest.importorskip("ultralytics")
+    import cv2
+    from ultralytics import SAM
+
+    from src.digitalsreeni_image_annotator.training.sam_trainer import (
+        SAM_MODELS_DIR,
+        SAMFineTuner,
+    )
+
+    if not os.path.exists(os.path.join(SAM_MODELS_DIR, "sam2_t.pt")):
+        pytest.skip("sam2_t.pt not cached")
+
+    H, W = 600, 1000  # landscape -> SAM2 pads the bottom
+
+    def disk(seed, cy, cx):
+        rng = np.random.RandomState(seed)
+        img = (rng.rand(H, W, 3) * 50).astype(np.uint8)
+        yy, xx = np.ogrid[:H, :W]
+        m = (yy - cy) ** 2 + (xx - cx) ** 2 < 60 ** 2
+        img[m] = [230, 40, 40]
+        return img, m
+
+    groups = []
+    for i in range(4):
+        img, m = disk(i, 460 + (i % 2) * 40, 300 + i * 120)
+        cnts, _ = cv2.findContours(m.astype(np.uint8), cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        groups.append(SampleGroup(lambda im=img: im.copy(), [{"segmentation": cnts[0].flatten().tolist()}]))
+
+    out = os.path.join(temp_dir, "landscape_sam2_t.pt")
+    SAMFineTuner().train(
+        "SAM 2 tiny", groups, epochs=8, lr=1e-4, batch_size=2,
+        freeze_image_encoder=True, prompt_type="bbox", out_path=out,
+    )
+
+    # Evaluate on a fresh image, object near the bottom (worst case for the shift).
+    img, m = disk(99, 480, 520)
+    x1, y1, x2, y2 = mask_to_xyxy(m)
+    gt_cy = float(np.where(m)[0].mean())
+
+    r = SAM(out)(img, bboxes=[[x1, y1, x2, y2]], verbose=False)
+    pm = r[0].masks.data.cpu().numpy()[0].astype(bool)
+    ys, xs = np.where(pm)
+    assert xs.size > 0, "fine-tuned model produced an empty mask"
+    pred_cy = ys.mean()
+    iou = (pm & m).sum() / (pm | m).sum()
+
+    assert abs(pred_cy - gt_cy) < 25, f"vertical shift {pred_cy - gt_cy:.1f}px (regression)"
+    assert iou > 0.7, f"IoU {iou:.3f} too low"

--- a/tests/integration/test_sam_finetuning.py
+++ b/tests/integration/test_sam_finetuning.py
@@ -1,0 +1,253 @@
+"""Tests for SAM 2 fine-tuning (issue bnsreenu#73).
+
+Most tests are CI-friendly: pure geometry/loss/dataset helpers that need no
+model weights or GPU. The full train→save→reload round trip is gated behind
+``SAM_TRAIN_E2E=1`` and the presence of cached weights, since it needs the
+~75 MB ``sam2_t.pt`` and is realistically GPU-only.
+"""
+
+import json
+import os
+import shutil
+import tempfile
+
+import numpy as np
+import pytest
+from PyQt6.QtGui import QImage
+
+from src.digitalsreeni_image_annotator.training.sam_trainer import (
+    SampleGroup,
+    bbox_to_mask,
+    list_custom_models,
+    make_custom_filename,
+    mask_to_point,
+    mask_to_xyxy,
+    polygon_to_mask,
+)
+
+
+@pytest.fixture
+def temp_dir():
+    d = tempfile.mkdtemp()
+    yield d
+    shutil.rmtree(d, ignore_errors=True)
+
+
+# ── geometry helpers ─────────────────────────────────────────────────────────
+
+class TestGeometry:
+    def test_polygon_to_mask_fills_interior(self):
+        mask = polygon_to_mask([10, 10, 40, 10, 40, 40, 10, 40], 50, 50)
+        assert mask.dtype == bool and mask.shape == (50, 50)
+        assert mask[25, 25] and not mask[5, 5]
+
+    def test_bbox_to_mask(self):
+        mask = bbox_to_mask([10, 10, 20, 20], 50, 50)  # x,y,w,h
+        assert mask[15, 15] and not mask[45, 45]
+
+    def test_mask_to_xyxy_tight(self):
+        mask = np.zeros((50, 50), bool)
+        mask[10:31, 5:26] = True
+        x1, y1, x2, y2 = mask_to_xyxy(mask)
+        assert (x1, y1, x2, y2) == (5, 10, 25, 30)
+
+    def test_mask_to_xyxy_empty_is_none(self):
+        assert mask_to_xyxy(np.zeros((10, 10), bool)) is None
+
+    def test_mask_to_point_inside(self):
+        mask = np.zeros((60, 60), bool)
+        mask[20:41, 20:41] = True
+        x, y = mask_to_point(mask)
+        assert mask[int(y), int(x)]  # point lands inside the object
+
+    def test_polygon_roundtrips_through_xyxy(self):
+        mask = polygon_to_mask([10, 10, 40, 10, 40, 40, 10, 40], 50, 50)
+        x1, y1, x2, y2 = mask_to_xyxy(mask)
+        assert x1 >= 9 and y1 >= 9 and x2 <= 41 and y2 <= 41
+
+
+# ── checkpoint naming (architecture-selection invariant) ─────────────────────
+
+class TestCustomNaming:
+    @pytest.mark.parametrize("base,token", [
+        ("SAM 2 tiny", "sam2_t.pt"),
+        ("SAM 2.1 base", "sam2.1_b.pt"),
+        ("SAM 2.1 large", "sam2.1_l.pt"),
+    ])
+    def test_filename_keeps_base_token(self, base, token):
+        # Ultralytics build_sam selects the architecture by ckpt.endswith(token);
+        # a fine-tuned name MUST keep that suffix or SAM(path) can't load it.
+        path = make_custom_filename(base, "my cool run!!")
+        assert os.path.basename(path).endswith(token)
+
+    def test_filename_sanitises_label(self):
+        path = make_custom_filename("SAM 2 tiny", "a/b c:*?")
+        name = os.path.basename(path)
+        assert "/" not in name and ":" not in name and "*" not in name
+
+    def test_filename_handles_empty_label(self):
+        path = make_custom_filename("SAM 2 tiny", "")
+        assert os.path.basename(path) == "finetuned_sam2_t.pt"
+
+    def test_list_custom_models_returns_dict(self):
+        assert isinstance(list_custom_models(), dict)
+
+
+# ── SampleGroup lazy rasterisation ───────────────────────────────────────────
+
+class TestSampleGroup:
+    def test_load_rasterises_specs(self):
+        img = np.zeros((50, 50, 3), np.uint8)
+        specs = [
+            {"segmentation": [10, 10, 40, 10, 40, 40, 10, 40]},
+            {"bbox": [5, 5, 10, 10]},
+        ]
+        group = SampleGroup(lambda: img.copy(), specs)
+        assert group.n_instances == 2
+        out_img, instances = group.load()
+        assert out_img.shape == (50, 50, 3)
+        assert len(instances) == 2
+        assert all(inst["mask"].dtype == bool for inst in instances)
+
+    def test_load_drops_empty_masks(self):
+        img = np.zeros((50, 50, 3), np.uint8)
+        # Box entirely outside the image → no in-bounds pixels → dropped.
+        group = SampleGroup(lambda: img.copy(), [{"bbox": [200, 200, 10, 10]}])
+        _, instances = group.load()
+        assert instances == []
+
+
+# ── loss ─────────────────────────────────────────────────────────────────────
+
+class TestLoss:
+    def test_focal_dice_lower_when_correct(self):
+        torch = pytest.importorskip("torch")
+        from src.digitalsreeni_image_annotator.training.sam_trainer import _focal_dice_loss
+
+        target = torch.zeros(1, 1, 16, 16)
+        target[..., 4:12, 4:12] = 1.0
+        good = (target * 12) - 6  # confident-correct logits
+        bad = (1 - target) * 12 - 6  # confident-wrong logits
+        l_good = _focal_dice_loss(good, target)
+        l_bad = _focal_dice_loss(bad, target)
+        assert torch.isfinite(l_good) and torch.isfinite(l_bad)
+        assert float(l_good) < float(l_bad)
+
+
+# ── dataset producers ────────────────────────────────────────────────────────
+
+class TestDatasetProducers:
+    def test_export_and_reload_folder_roundtrip(self, temp_dir):
+        from src.digitalsreeni_image_annotator.io.export_formats import export_sam_dataset
+        from src.digitalsreeni_image_annotator.training.sam_dataset import (
+            build_groups_from_folder,
+        )
+
+        img = QImage(60, 60, QImage.Format.Format_RGB32)
+        img.fill(0xFF202020)
+        img_path = os.path.join(temp_dir, "img1.png")
+        img.save(img_path)
+
+        all_annotations = {
+            "img1.png": {"cell": [{"segmentation": [10, 10, 40, 10, 40, 40, 10, 40]}]}
+        }
+        out_dir = os.path.join(temp_dir, "dataset")
+        _, manifest_path = export_sam_dataset(
+            all_annotations, {"cell": 1}, {"img1.png": img_path},
+            slices=[], image_slices={}, output_dir=out_dir,
+        )
+        assert os.path.exists(manifest_path)
+        with open(manifest_path) as f:
+            manifest = json.load(f)
+        assert len(manifest["images"]) == 1
+
+        groups = build_groups_from_folder(out_dir)
+        assert len(groups) == 1
+        _, instances = groups[0].load()
+        assert len(instances) == 1
+
+    def test_build_from_project_regular_image(self, temp_dir):
+        from src.digitalsreeni_image_annotator.training.sam_dataset import (
+            build_groups_from_project,
+        )
+
+        img = QImage(60, 60, QImage.Format.Format_RGB32)
+        img.fill(0xFF808080)
+        img_path = os.path.join(temp_dir, "img1.png")
+        img.save(img_path)
+
+        groups = build_groups_from_project(
+            {"img1.png": {"cell": [{"bbox": [10, 10, 20, 20]}]}},
+            {"img1.png": img_path}, slices=[], image_slices={},
+        )
+        assert len(groups) == 1
+        image, instances = groups[0].load()
+        assert image.shape[:2] == (60, 60) and len(instances) == 1
+
+    def test_build_from_project_skips_unresolvable(self):
+        from src.digitalsreeni_image_annotator.training.sam_dataset import (
+            build_groups_from_project,
+        )
+
+        groups = build_groups_from_project(
+            {"ghost.png": {"cell": [{"bbox": [1, 1, 5, 5]}]}},
+            {}, slices=[], image_slices={},
+        )
+        assert groups == []
+
+
+# ── ultralytics API-drift guard ──────────────────────────────────────────────
+
+class TestUltralyticsAPI:
+    def test_sam2predictor_exposes_forward_methods(self):
+        """The native training loop reuses these SAM2Predictor methods; if an
+        Ultralytics upgrade removes/renames them, fail loudly here rather than
+        mid-training."""
+        pytest.importorskip("ultralytics")
+        from ultralytics.models.sam.predict import SAM2Predictor
+
+        for name in ("get_im_features", "prompt_inference", "_inference_features",
+                     "_prepare_prompts", "set_image"):
+            assert hasattr(SAM2Predictor, name), f"SAM2Predictor.{name} missing"
+
+
+# ── opt-in end-to-end (needs weights; realistically GPU) ─────────────────────
+
+@pytest.mark.skipif(
+    os.environ.get("SAM_TRAIN_E2E") != "1",
+    reason="set SAM_TRAIN_E2E=1 to run the full train→save→reload test (needs weights)",
+)
+def test_end_to_end_train_save_reload(temp_dir):
+    pytest.importorskip("ultralytics")
+    from src.digitalsreeni_image_annotator.training.sam_trainer import (
+        SAM_MODELS_DIR,
+        SAMFineTuner,
+    )
+
+    if not os.path.exists(os.path.join(SAM_MODELS_DIR, "sam2_t.pt")):
+        pytest.skip("sam2_t.pt not cached")
+
+    def make(seed):
+        rng = np.random.RandomState(seed)
+        img = (rng.rand(120, 120, 3) * 255).astype(np.uint8)
+        cy, cx = rng.randint(40, 80, 2)
+        yy, xx = np.ogrid[:120, :120]
+        mask = (yy - cy) ** 2 + (xx - cx) ** 2 < 25 ** 2
+        img[mask] = [220, 30, 30]
+        x1, y1, x2, y2 = mask_to_xyxy(mask)
+        return SampleGroup(
+            lambda im=img: im.copy(),
+            [{"bbox": [x1, y1, x2 - x1, y2 - y1]}],
+        )
+
+    out = os.path.join(temp_dir, "e2e_sam2_t.pt")
+    res = SAMFineTuner().train(
+        "SAM 2 tiny", [make(i) for i in range(2)],
+        epochs=1, lr=1e-4, batch_size=1, freeze_image_encoder=True,
+        prompt_type="bbox", out_path=out,
+    )
+    assert res["verified"] and os.path.exists(out)
+
+    from ultralytics import SAM
+    SAM(out)((np.random.rand(120, 120, 3) * 255).astype(np.uint8),
+             bboxes=[[40, 40, 80, 80]], verbose=False)

--- a/tests/integration/test_sam_train_controller.py
+++ b/tests/integration/test_sam_train_controller.py
@@ -1,0 +1,74 @@
+"""SAMTrainController UI-locking tests (issue bnsreenu#73).
+
+The lock/unlock of the SAM inference UI during a fine-tuning run is exactly the
+kind of state machine that regresses silently. These build one real
+ImageAnnotator (offscreen) and exercise the controller directly — no model
+weights, no worker thread.
+"""
+
+import pytest
+
+
+@pytest.fixture
+def window(qt_application):
+    from digitalsreeni_image_annotator.annotator_window import ImageAnnotator
+
+    w = ImageAnnotator()
+    yield w
+    w.deleteLater()
+
+
+def test_set_sam_ui_locked_toggles_widgets(window):
+    # The helper's contract is the toggle itself; the buttons' construction-time
+    # enabled state depends on whether an image is loaded, so assert relative
+    # to an explicit unlocked baseline rather than the initial state.
+    c = window.sam_train_controller
+    widgets = [window.sam_box_button, window.sam_points_button, window.sam_model_selector]
+
+    c._set_sam_ui_locked(True)
+    assert not any(w.isEnabled() for w in widgets)
+    assert not c._menu.isEnabled()
+
+    c._set_sam_ui_locked(False)
+    assert all(w.isEnabled() for w in widgets)
+    assert c._menu.isEnabled()
+
+
+def test_launch_unlocks_ui_when_setup_raises(window, monkeypatch):
+    """If anything between locking and thread.start() raises, the SAM UI must
+    be restored — otherwise the tools stay dead until app restart."""
+    from PyQt6.QtWidgets import QMessageBox
+
+    import digitalsreeni_image_annotator.controllers.sam_train_controller as mod
+    from digitalsreeni_image_annotator.dialogs.sam_trainer_dialog import (
+        SAMTrainConfigDialog,
+    )
+
+    c = window.sam_train_controller
+    monkeypatch.setattr(c, "_gpu_gate", lambda: True)
+    monkeypatch.setattr(
+        SAMTrainConfigDialog, "exec",
+        lambda self: SAMTrainConfigDialog.DialogCode.Accepted,
+    )
+    monkeypatch.setattr(
+        SAMTrainConfigDialog, "get_config",
+        lambda self: {
+            "base_model": "SAM 2 tiny", "out_name": "t", "epochs": 1,
+            "lr": 1e-4, "batch_size": 1, "prompt_type": "bbox",
+            "freeze_image_encoder": True,
+        },
+    )
+
+    class Boom:
+        def __init__(self, *a, **k):
+            raise RuntimeError("setup failed on purpose")
+
+    monkeypatch.setattr(mod, "SAMFineTuner", Boom)
+    monkeypatch.setattr(QMessageBox, "critical", staticmethod(lambda *a, **k: None))
+
+    c._launch([object()])  # group content irrelevant — fails before use
+
+    assert window.sam_box_button.isEnabled()
+    assert window.sam_points_button.isEnabled()
+    assert window.sam_model_selector.isEnabled()
+    assert c._menu.isEnabled()


### PR DESCRIPTION
## What & why

Lets users **fine-tune SAM 2 / 2.1 on their own annotations** so the assisted
SAM-box / SAM-points tools produce better masks on domain-specific imagery,
then use the fine-tuned model in the existing inference workflow. Tracks
upstream feature request bnsreenu#73.

## The constraint that shaped the design

**Ultralytics has no SAM trainer** — `SAM(...).train()` raises
`NotImplementedError` (task_map registers only a predictor; verified on
ultralytics 8.4.51). So the YOLO `model.train(...)` pattern can't be mirrored.

**Approach (ADR-021):** a custom PyTorch loop that *reuses Ultralytics' own*
`SAM2Predictor` forward methods (`get_im_features`, `prompt_inference`) under
`torch.enable_grad()`, adding focal+dice loss + AdamW. Trains the mask decoder
by default; an optional flag also unfreezes the image encoder. Checkpoints save
as `{"model": state_dict}` keeping the base filename token (e.g.
`myrun_sam2_t.pt`) and are **reload-verified through `SAM(path)`** before
success — so a fine-tuned model drops straight into the unchanged inference
path and appears in the SAM model selector. No new dependency.

## What's included

- `training/sam_trainer.py` — `SAMFineTuner` engine + geometry/loss/naming helpers
- `training/sam_dataset.py` + `io/export_formats.export_sam_dataset` — train from
  the live project **or** a prepared on-disk dataset folder
- `dialogs/sam_trainer_dialog.py` — config dialog (reuses `TrainingInfoDialog`)
- `controllers/sam_train_controller.py` — menu, GPU gate, `SAMTrainingThread`,
  SAM-UI locking during runs, selector registration
- `inference/sam_utils.py` — custom-model registry (load fine-tuned `.pt` by path)
- Tests: geometry / loss / dataset / Ultralytics-API-drift guards + UI-lock +
  opt-in end-to-end (`SAM_TRAIN_E2E=1`)
- Docs: ADR-021, building-block, runtime, glossary, CLAUDE.md

## Validation

- Full suite: **178 passed, 2 skipped** (skips = opt-in GPU e2e).
- End-to-end on real `sam2_t.pt`: decoder-only and encoder paths, single- and
  multi-instance — loss decreases, checkpoint reloads + predicts.
- Two rounds of the senior-reviewer quality gate; all P0/P1 addressed.

## Notes / follow-ups

- Decoder fine-tuning is realistically GPU-only; CPU is hard-warned, not silently slow.
- The image-resolution branching is now mirrored in three places
  (`export_yolo_v5plus`, `export_sam_dataset`, `build_groups_from_project`) per
  the existing CLAUDE.md pattern — extracting one shared helper is a sensible
  non-blocking follow-up.
- Draft pending manual GUI walkthrough (golden path + dark mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
