### PR TITLE
Canvas mask selection, multi-delete & visible selection styling (bnsreenu#75)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,8 @@ See [Runtime View](docs/06_runtime_view.md#multi-dimensional-image-loading) for 
 | GPU model unload | `model.cpu()` → `gc.collect()` → `torch.cuda.empty_cache()` + `ipc_collect()` + `synchronize()` — full reclaim requires app restart due to per-process CUDA context | Setting refs to None alone leaves circular refs pinned and shows zero Task Manager drop. See [Releasing Model GPU Memory](docs/08_crosscutting_concepts.md#releasing-model-gpu-memory). |
 | Export image-path lookup | Exact-key match first, substring fallback only | `"bee.jpg" in "honeybee.jpg"` is True — substring-only matching writes the wrong file. See [Export Format Filename Matching](docs/08_crosscutting_concepts.md#export-format-filename-matching). |
 | F2 / global shortcuts | Use `QShortcut` with `Qt.ShortcutContext.ApplicationShortcut`, not `keyPressEvent` | `QTableWidget` consumes F2 for in-cell edit before it bubbles up. |
+| Canvas ↔ list selection sync | Canvas selection (idle-mode click/Shift/rubber-band) drives the annotation list via `apply_canvas_selection`; mirror the list with `blockSignals(True/False)` and match annotations by **value-equality**, never identity | PyQt round-trips `UserRole` dicts as copies and `image_label.annotations` is a deepcopy, so identity is never stable; un-blocked `setSelected` recurses through `update_highlighted_annotations`. Multi-select uses **Shift** (Ctrl stays pan). See [ADR-022](docs/09_architecture_decisions.md#adr-022-canvas-mask-selection-unified-with-the-annotation-list). |
+| Selection rendering | Don't recolour a selected mask. Keep its class colour; draw a class-colour-independent overlay (dashed `_SELECTION_COLOR` blue bounding box + bright handle squares at corners/edge-midpoints, OGP-style) in a final pass — `_draw_selection_overlay`. Handles are visual-only (resize = #40). Default class colours come from `core/constants.py::default_class_color` (red last, muted) | Red selection was invisible on a red-class mask; a thin dashed outline alone was too faint; the handles carry the visibility. See ADR-022 amendment. |
 
 ## Development Workflow
 
@@ -268,6 +270,10 @@ See [Risks and Technical Debt](docs/11_risks_and_technical_debt.md) for full lis
 |--------|--------|
 | Ctrl+Wheel | Zoom |
 | Ctrl+Drag | Pan |
+| Click / Shift+Click (no tool) | Select / toggle mask |
+| Drag / Shift+Drag (no tool) | Rubber-band select / add |
+| Double-click | Vertex-edit mode |
+| Delete | Delete selected mask(s) |
 | Enter | Finish/Accept |
 | Esc | Cancel |
 | Up/Down | Navigate slices |

--- a/docs/06_runtime_view.md
+++ b/docs/06_runtime_view.md
@@ -66,6 +66,37 @@ User presses Enter
     └─> update() to show final annotation
 ```
 
+## Mask Selection & Deletion on the Canvas (issue #75)
+
+Active only when no drawing/SAM tool is selected (`ImageLabel._is_select_mode()`).
+Double-click still enters vertex-edit; Ctrl+drag still pans.
+
+```
+User clicks / drags on image (no tool active)
+    │
+    ├─> ImageLabel mouse press/move/release
+    │   ├─> click            → annotation_at(pos)        (smallest mask, seg or bbox)
+    │   ├─> click empty      → []                        (clears selection)
+    │   ├─> drag             → annotations_in_rect(rect) (rubber band, bounds-intersect)
+    │   └─> Shift            → toggle (click) / add (drag)
+    │
+    ├─> emit canvasSelectionChanged(annotations, mode)   mode = replace|add|toggle
+    │
+    └─> AnnotationController.apply_canvas_selection()
+        ├─> compute new set from highlighted_annotations + annotations per mode
+        ├─> image_label.highlighted_annotations = new    (blue selection overlay)
+        ├─> mirror onto annotation_list (blockSignals while selecting)
+        └─> enable Merge (≥2) / Change Class (≥1)
+
+User presses Delete (canvas focused)
+    │
+    ├─> ImageLabel.keyPressEvent → deleteSelectionRequested
+    └─> AnnotationController.delete_selected_annotations()  (confirm → remove → re-sort → autosave)
+```
+
+The canvas and the list share one selection (matched by dict value-equality), so
+Delete/Merge/Change-Class behave the same from either surface. See ADR-022.
+
 ## SAM-Assisted Annotation (SAM-box / SAM-points)
 
 ```

--- a/docs/08_crosscutting_concepts.md
+++ b/docs/08_crosscutting_concepts.md
@@ -404,6 +404,11 @@ def generate_slice_name(filename, t, z, c, s):
 |----------|--------|
 | Ctrl+Wheel | Zoom In/Out |
 | Ctrl+Drag | Pan |
+| Click (no tool) | Select mask under cursor |
+| Shift+Click (no tool) | Toggle mask in selection |
+| Drag (no tool) | Rubber-band box-select; Shift+Drag adds |
+| Delete | Delete selected mask(s) |
+| Double-click | Enter vertex-edit mode |
 | Esc | Cancel Current Annotation |
 | Enter | Finish/Accept Annotation |
 | Up/Down | Navigate Slices (multi-dimensional) |
@@ -639,3 +644,55 @@ paint commits into O(N). See ADR-018.
 
 See ADR-018 in `09_architecture_decisions.md` for the rationale and
 the full pattern.
+
+## Canvas Selection ↔ List Selection
+
+When no drawing tool is active (`ImageLabel._is_select_mode()`), the canvas
+behaves like a pointer: a single click selects the smallest mask under the
+cursor, a drag draws a rubber band that box-selects, and **Shift** toggles /
+adds. This is wired so there is **one** selection shared by the canvas overlay
+(`highlighted_annotations`, blue selection outline + handles) and the bottom-left
+annotation list — so
+`Delete` / `Merge` / `Change Class` (which read `annotation_list.selectedItems()`)
+work identically whether you selected on the image or in the list. See ADR-022.
+
+Flow: `ImageLabel` emits `canvasSelectionChanged(annotations, mode)` (mode =
+`replace` | `add` | `toggle`) → `AnnotationController.apply_canvas_selection`
+computes the new set, assigns `image_label.highlighted_annotations`, and mirrors
+it onto the list.
+
+Two non-obvious rules make this correct:
+
+- **Match by value-equality, never identity.** `image_label.annotations` is a
+  `deepcopy` of `all_annotations`, and PyQt round-trips dicts stored in a list
+  item's `UserRole` as *copies* — so the "same" annotation has different object
+  identity on the canvas, in `all_annotations`, and in a list item. Every
+  selection comparison therefore uses dict `==` (`a == b`), the same convention
+  as `select_annotation_in_list`, `delete_selected_annotations`, and the
+  `annotation in highlighted_annotations` test in `draw_annotations`. A
+  consequence: two value-equal duplicate masks select together — accepted, and
+  pre-existing.
+- **Block list signals while mirroring.** `apply_canvas_selection` wraps the
+  programmatic list selection in `annotation_list.blockSignals(True/False)`.
+  Without it, `setSelected` fires `itemSelectionChanged` →
+  `update_highlighted_annotations`, which would overwrite the freshly-computed
+  set with the list items' own objects (and clobber a `toggle`).
+
+**Ctrl is reserved for pan.** Multi-select uses **Shift**, not Ctrl, because
+Ctrl+drag is the pan gesture (whose reference-frame handling is deliberately
+delicate — see [Pan + Zoom Reference Frames](#pan--zoom-reference-frames)).
+Leaving Ctrl untouched keeps that gesture intact.
+
+**Selection is drawn independent of class colour.** A selected mask is *not*
+recoloured (the first version turned it red, which vanished on a red-class mask,
+and red was the default first class colour). Instead `draw_annotations` keeps the
+class colour and, in a final pass on top of every mask, draws a dashed
+selection-blue **bounding-box marquee plus bright handle squares** at the 4
+corners + 4 edge midpoints (`_SELECTION_COLOR`, `_draw_selection_overlay`) —
+modelled on the sibling open-garden-planner app's CAD selection. The handles
+carry the visibility (a single thin dashed outline was too faint); they are
+visual markers only — resize-by-handle is a separate feature (upstream #40). This
+never collides with any class colour. Relatedly, the default class palette
+(`core/constants.py`) was reordered so red is last and the fill opacity lowered
+to keep the image legible — see the No Hardcoded Colors Rule for the broader
+"don't fight the theme/colours" theme.

--- a/docs/09_architecture_decisions.md
+++ b/docs/09_architecture_decisions.md
@@ -819,6 +819,70 @@ won't reload (cf. facebookresearch/sam2#337 key-mismatch failures).
 
 ---
 
+## ADR-022: Canvas Mask Selection Unified with the Annotation List
+
+**Status**: Accepted (issue bnsreenu#75)
+
+**Context**: Selecting an existing annotation was only possible through the
+bottom-left annotation list (already `ExtendedSelection`) or by *double*-clicking
+a mask on the canvas — which immediately enters vertex-edit mode. There was no
+single-click select, no box/multi-select on the image, and canvas `Delete` worked
+only while in vertex-edit mode. Issue #75 asked for single-click select (without
+entering edit), rubber-band box select, modifier multi-select, and multi-delete —
+all directly on the canvas.
+
+**Decision**: Add an **idle-mode selection layer** to `ImageLabel` and route it
+through the *existing* annotation-list selection so delete/merge/change-class are
+reused unchanged:
+
+- **Idle activation.** Selection is live only in `_is_select_mode()` — no drawing
+  tool, not editing, not SAM, no temp review. Picking any tool restores drawing.
+  No new tool button (matches the user's "a single click should select" ask).
+- **Gestures.** Plain click selects the smallest mask under the cursor (covers
+  segmentation *and* bbox); click on empty space clears; drag draws a rubber band
+  and selects every annotation whose bounds intersect it; **Shift** makes a click
+  toggle and a drag additive. Double-click is unchanged (still vertex edit).
+- **Ctrl stays pan.** Ctrl+drag pan (with its carefully tuned reference frame) is
+  left untouched; multi-select uses Shift instead of Ctrl.
+- **One selection, two surfaces.** The canvas emits
+  `canvasSelectionChanged(annotations, mode)`; `AnnotationController.apply_canvas_selection`
+  computes the new set (replace/add/toggle), sets `image_label.highlighted_annotations`,
+  and **mirrors it onto the list** with signals blocked. `Delete` on the canvas
+  reuses `delete_selected_annotations` (which reads the list selection).
+
+**Consequences**:
+- Delete / Merge / Change-Class need no new logic — they already operate on the
+  list selection, which the canvas now drives.
+- ⚠️ Matching between the canvas and list relies on **dict value-equality**, like
+  the rest of the selection code (`image_label.annotations` is a deepcopy of
+  `all_annotations`, and PyQt round-trips `UserRole` dicts as copies, so identity
+  is never stable). Value-equal duplicate masks would select together — a
+  pre-existing, accepted limitation. See the crosscutting "Canvas selection ↔
+  list selection" section.
+- ⚠️ The list mirror must block `itemSelectionChanged` while selecting, or it
+  recurses back through `update_highlighted_annotations` and overwrites the set.
+
+**Selection is rendered class-colour-independent (amendment).** The first cut
+drew the selected mask in solid **red** — invisible on a red-class mask, and the
+default palette assigned red as the *first* class colour. Selection is now an
+overlay drawn in a final pass on top of every mask, independent of class colour
+and modelled on the sibling open-garden-planner app's CAD selection: a dashed
+selection-blue **bounding-box marquee** (`_SELECTION_COLOR = QColor(0, 120, 215,
+220)`) plus bright opaque-blue **handle squares** at the 4 corners + 4 edge
+midpoints, white-cased and fixed on-screen size (`_draw_selection_overlay` in
+`widgets/image_label.py`). The handles are what make selection unmistakable
+regardless of mask colour (a single thin dashed outline was too faint; an earlier
+marching-ants + marquee was too busy). The handles are visual markers only —
+resizing via handles is a separate feature (upstream #40). The mask keeps its
+class colour; the rubber-band rect uses the same blue dashed style. Separately,
+the default class palette
+(`core/constants.py::DEFAULT_CLASS_COLORS` / `default_class_color`) was reordered
+so red is **last** (no fresh project starts on red) and muted, and the default
+fill opacity dropped to `0.2` (`DEFAULT_FILL_OPACITY`) so masks don't bury the
+image. Existing projects keep their persisted class colours.
+
+---
+
 ## Decisions Under Consideration
 
 ### Consider pytest-qt for Utility Testing

--- a/docs/12_glossary.md
+++ b/docs/12_glossary.md
@@ -56,6 +56,16 @@ Segment Anything Model - Meta's foundation model for image segmentation. Version
 ### SAM Point Mode
 Annotation mode where user clicks positive points (inside object) and negative points (outside object) to guide SAM segmentation.
 
+### Select Mode (Canvas)
+The idle canvas state (no drawing/SAM tool active, not editing, no temp review) in
+which clicks and drags select existing masks instead of drawing. Single-click
+selects, Shift toggles/adds, drag box-selects; double-click still enters vertex
+edit. See ADR-022.
+
+### Rubber-Band Selection
+A dashed selection rectangle dragged on the canvas in Select Mode; every annotation
+whose bounds intersect it is selected. Shift+drag adds to the current selection.
+
 ### Semantic Labels
 Single-channel image where each pixel value represents the class ID. Used for semantic segmentation training.
 

--- a/src/digitalsreeni_image_annotator/annotator_window.py
+++ b/src/digitalsreeni_image_annotator/annotator_window.py
@@ -191,6 +191,7 @@ class ImageAnnotator(QMainWindow):
         il.annotationsReplaced.connect(ac.replace_annotations)
         il.annotationListUpdateRequested.connect(ac.update_annotation_list)
         il.annotationSelected.connect(ac.select_annotation_in_list)
+        il.canvasSelectionChanged.connect(ac.apply_canvas_selection)
         il.deleteSelectionRequested.connect(ac.delete_selected_annotations)
         il.finishPolygonRequested.connect(ac.finish_polygon)
         il.finishRectangleRequested.connect(ac.finish_rectangle)

--- a/src/digitalsreeni_image_annotator/controllers/annotation_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/annotation_controller.py
@@ -36,6 +36,7 @@ from PyQt6.QtWidgets import (
 from shapely.geometry import MultiPolygon, Polygon
 from shapely.ops import unary_union
 
+from ..core.constants import default_class_color
 from ..utils import calculate_area, calculate_bbox
 
 
@@ -229,7 +230,7 @@ class AnnotationController(QObject):
 
             if class_name not in self.mw.image_label.class_colors:
                 color = QColor(
-                    Qt.GlobalColor(len(self.mw.image_label.class_colors) % 16 + 7)
+                    default_class_color(len(self.mw.image_label.class_colors))
                 )
                 self.mw.image_label.class_colors[class_name] = color
 
@@ -333,6 +334,9 @@ class AnnotationController(QObject):
 
     def clear_highlighted_annotation(self):
         self.mw.image_label.highlighted_annotations.clear()
+        # Selection is gone — Merge/Change Class must follow, or they linger
+        # enabled against an empty list selection after an image/slice switch.
+        self._sync_selection_buttons(0)
         self.mw.image_label.update()
 
     def update_highlighted_annotations(self):
@@ -341,9 +345,59 @@ class AnnotationController(QObject):
             item.data(Qt.ItemDataRole.UserRole) for item in selected_items
         ]
         self.mw.image_label.update()
+        self._sync_selection_buttons(len(selected_items))
 
-        self.mw.merge_button.setEnabled(len(selected_items) >= 2)
-        self.mw.change_class_button.setEnabled(len(selected_items) > 0)
+    def _sync_selection_buttons(self, count):
+        """Merge needs ≥2 annotations; Change Class needs ≥1. Shared by the
+        list-driven and canvas-driven (issue #75) selection paths."""
+        self.mw.merge_button.setEnabled(count >= 2)
+        self.mw.change_class_button.setEnabled(count > 0)
+
+    def apply_canvas_selection(self, annotations, mode):
+        """Apply a selection change that originated on the canvas (issue #75)
+        and mirror it onto the annotation list so Delete / Merge / Change
+        Class operate on the same set. Matching uses dict value-equality,
+        consistent with the rest of the selection code.
+
+        ``mode`` is one of ``"replace"``, ``"add"``, ``"toggle"``.
+        """
+        current = list(self.mw.image_label.highlighted_annotations)
+
+        def contains(seq, ann):
+            return any(a == ann for a in seq)
+
+        if mode == "replace":
+            new = list(annotations)
+        elif mode == "add":
+            new = current + [a for a in annotations if not contains(current, a)]
+        elif mode == "toggle":
+            new = list(current)
+            for a in annotations:
+                match = next((x for x in new if x == a), None)
+                if match is not None:
+                    new.remove(match)
+                else:
+                    new.append(a)
+        else:
+            return
+
+        self.mw.image_label.highlighted_annotations = new
+
+        # Mirror onto the list widget. Block signals so the programmatic
+        # selection doesn't retrigger itemSelectionChanged →
+        # update_highlighted_annotations, which would overwrite `new` with
+        # the list items' own (all_annotations) object identities.
+        lst = self.mw.annotation_list
+        lst.blockSignals(True)
+        lst.clearSelection()
+        for i in range(lst.count()):
+            item = lst.item(i)
+            if contains(new, item.data(Qt.ItemDataRole.UserRole)):
+                item.setSelected(True)
+        lst.blockSignals(False)
+
+        self._sync_selection_buttons(len(new))
+        self.mw.image_label.update()
 
     def highlight_annotation_in_list(self, annotation):
         for i in range(self.mw.annotation_list.count()):
@@ -422,6 +476,8 @@ class AnnotationController(QObject):
                 self.sort_annotations_by_class()
 
             self.mw.image_label.highlighted_annotations.clear()
+            # Selection is now empty — Merge/Change Class must follow.
+            self._sync_selection_buttons(0)
             self.mw.image_label.update()
 
             self.mw.update_slice_list_colors()

--- a/src/digitalsreeni_image_annotator/controllers/class_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/class_controller.py
@@ -27,6 +27,8 @@ from PyQt6.QtWidgets import (
     QMessageBox,
 )
 
+from ..core.constants import default_class_color
+
 
 class ClassController(QObject):
     def __init__(self, main_window):
@@ -143,7 +145,7 @@ class ClassController(QObject):
 
         if color is None:
             color = QColor(
-                Qt.GlobalColor(len(self.mw.image_label.class_colors) % 16 + 7)
+                default_class_color(len(self.mw.image_label.class_colors))
             )
         elif isinstance(color, str):
             color = QColor(color)

--- a/src/digitalsreeni_image_annotator/controllers/dino_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/dino_controller.py
@@ -38,6 +38,8 @@ from PyQt6.QtWidgets import (
     QTextEdit,
 )
 
+from ..core.constants import default_class_color
+
 
 class DINOReviewEventFilter(QObject):
     """Application-wide event filter that lets Enter / Escape accept or
@@ -687,7 +689,7 @@ class DINOController(QObject):
         for temp_class_name, annotations in temp_annotations.items():
             if temp_class_name not in self.mw.image_label.class_colors:
                 color = QColor(
-                    Qt.GlobalColor(len(self.mw.image_label.class_colors) % 16 + 7)
+                    default_class_color(len(self.mw.image_label.class_colors))
                 )
                 self.mw.image_label.class_colors[temp_class_name] = color
             self.mw.image_label.annotations[temp_class_name] = annotations

--- a/src/digitalsreeni_image_annotator/controllers/io_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/io_controller.py
@@ -11,9 +11,10 @@ inside `annotator_window.py` delegate trivially.
 
 import os
 
-from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QColor
 from PyQt6.QtWidgets import QFileDialog, QMessageBox
+
+from ..core.constants import default_class_color
 
 from ..io.export_formats import (
     export_coco_json,
@@ -157,7 +158,7 @@ def import_annotations(mw):
                 new_id = len(mw.class_mapping) + 1
                 mw.class_mapping[category_name] = new_id
                 mw.image_label.class_colors[category_name] = QColor(
-                    Qt.GlobalColor(new_id % 16 + 7)
+                    default_class_color(new_id - 1)
                 )
 
     print("Updating UI")

--- a/src/digitalsreeni_image_annotator/core/constants.py
+++ b/src/digitalsreeni_image_annotator/core/constants.py
@@ -21,5 +21,32 @@ MAX_ZOOM = 500
 DEFAULT_ZOOM = 100
 
 # Annotation settings
-DEFAULT_FILL_OPACITY = 0.3
+# Mask fill alpha — kept low so the underlying image stays legible through
+# overlapping masks (the border still carries the class colour).
+DEFAULT_FILL_OPACITY = 0.2
+
+# Default class colour palette (tab10-style, moderately muted so masks don't
+# overpower the image). Red is intentionally LAST so a fresh project's first
+# class isn't red — selection highlighting is class-colour-independent, but
+# starting on red was needlessly harsh. Hex strings keep this module Qt-free.
+DEFAULT_CLASS_COLORS = [
+    "#1F77B4",  # blue
+    "#FF7F0E",  # orange
+    "#2CA02C",  # green
+    "#9467BD",  # purple
+    "#17BECF",  # cyan
+    "#BCBD22",  # olive
+    "#E377C2",  # pink
+    "#8C564B",  # brown
+    "#7F7F7F",  # gray
+    "#D62728",  # red (last)
+]
+
+
+def default_class_color(index: int) -> str:
+    """Hex colour for the index-th class, cycling through DEFAULT_CLASS_COLORS.
+
+    Callers wrap the result in ``QColor(...)`` (kept out of this module so the
+    core stays Qt-free)."""
+    return DEFAULT_CLASS_COLORS[index % len(DEFAULT_CLASS_COLORS)]
 

--- a/src/digitalsreeni_image_annotator/dialogs/dino_phrase_editor.py
+++ b/src/digitalsreeni_image_annotator/dialogs/dino_phrase_editor.py
@@ -65,15 +65,17 @@ class ClassThresholdTable(QTableWidget):
         self.verticalHeader().setSectionResizeMode(
             QHeaderView.ResizeMode.ResizeToContents)
         self.setMaximumHeight(160)
-        # No hardcoded background colors — pick them up from the active
-        # stylesheet so the table integrates with both light and dark
-        # mode. The earlier "background: #e0e0e0" produced a bright bar
-        # across the top of the panel in dark mode.
-        # No font-size either: the compact size is set (and scaled with
-        # ui_font_pt) by the appended overrides in ui/theme.py.
+        # Structural only — no colours here. Header background/text come from
+        # the active stylesheet's QHeaderView::section rule (light:
+        # default_stylesheet, dark: soft_dark_stylesheet), so the header
+        # matches both themes. The earlier inline "background: palette(mid);
+        # color: palette(text)" resolved against the *OS* palette (dark on
+        # some boxes) and painted the header black in the app's light mode —
+        # see the No Hardcoded Colors Rule. No font-size either: the compact
+        # size is set (and scaled with ui_font_pt) by the overrides in
+        # ui/theme.py.
         self.setStyleSheet(
-            "QHeaderView::section { font-weight: bold; "
-            "  padding: 2px; background-color: palette(mid); color: palette(text); }"
+            "QHeaderView::section { font-weight: bold; padding: 2px; }"
         )
 
     def _make_spin(self, value=0.25):

--- a/src/digitalsreeni_image_annotator/ui/default_stylesheet.py
+++ b/src/digitalsreeni_image_annotator/ui/default_stylesheet.py
@@ -45,6 +45,14 @@ QListWidget::item:selected {
 }
 
 
+QHeaderView::section {
+    background-color: #E0E0E0;
+    color: #333333;
+    border: 1px solid #CCCCCC;
+    padding: 4px;
+}
+
+
 QLabel {
     color: #333333;
 }

--- a/src/digitalsreeni_image_annotator/widgets/canvas_context.py
+++ b/src/digitalsreeni_image_annotator/widgets/canvas_context.py
@@ -38,6 +38,12 @@ class CanvasContext:
     def current_image_key(self):
         return self._mw.current_slice or self._mw.image_file_name
 
+    def has_annotation_selection(self) -> bool:
+        # The annotation list is the source of truth for what a Delete acts
+        # on; the canvas Delete must read it (not the possibly-stale red
+        # highlight) so it can't fire on an empty list selection. See ADR-022.
+        return bool(self._mw.annotation_list.selectedItems())
+
     def all_annotations(self) -> dict:
         return self._mw.all_annotations
 

--- a/src/digitalsreeni_image_annotator/widgets/image_label.py
+++ b/src/digitalsreeni_image_annotator/widgets/image_label.py
@@ -29,6 +29,7 @@ from PyQt6.QtGui import (
 from PyQt6.QtWidgets import QLabel, QMessageBox
 
 from .tools import EraserTool, PaintBrushTool, PolygonTool, RectangleTool
+from ..core.constants import DEFAULT_FILL_OPACITY
 from ..utils import calculate_area
 
 warnings.filterwarnings("ignore", category=UserWarning)
@@ -45,6 +46,7 @@ class ImageLabel(QLabel):
     annotationsReplaced = pyqtSignal(str, dict)         # eraser path: (image_key, per-class dict)
     annotationListUpdateRequested = pyqtSignal()        # editing-mode exit refresh
     annotationSelected = pyqtSignal(object)             # double-click selection
+    canvasSelectionChanged = pyqtSignal(object, str)    # (list[annotation], mode); mode: replace|add|toggle
     deleteSelectionRequested = pyqtSignal()
     finishPolygonRequested = pyqtSignal()
     finishRectangleRequested = pyqtSignal()
@@ -69,6 +71,12 @@ class ImageLabel(QLabel):
     zoomOutRequested = pyqtSignal()
     imageInfoChanged = pyqtSignal()
 
+    # Selection highlight: a semi-transparent selection-blue, drawn as the
+    # dashed bounding-box marquee (handles use the opaque variant). Class-
+    # colour-independent, so it never vanishes the way the old red-on-red
+    # highlight did.
+    _SELECTION_COLOR = QColor(0, 120, 215, 220)
+
     def __init__(self, parent=None):
         super().__init__(parent)
         self.annotations = {}
@@ -86,6 +94,11 @@ class ImageLabel(QLabel):
         self.start_point = None
         self.end_point = None
         self.highlighted_annotations = []
+        # Idle-mode mask selection (issue #75): drag a rubber band to box-select.
+        # selection_rect is (x0, y0, x1, y1) in image coords while a drag is live.
+        self.selection_origin = None
+        self.selecting = False
+        self.selection_rect = None
         self.setMouseTracking(True)
         self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
         self.original_pixmap = None
@@ -98,7 +111,7 @@ class ImageLabel(QLabel):
         self.editing_polygon = None
         self.editing_point_index = None
         self.hover_point_index = None
-        self.fill_opacity = 0.3
+        self.fill_opacity = DEFAULT_FILL_OPACITY
         self.drawing_rectangle = False
         self.current_rectangle = None
         self.bit_depth = None
@@ -222,6 +235,11 @@ class ImageLabel(QLabel):
         self.temp_point = None
         self.start_point = None
         self.end_point = None
+        # Drop any in-progress rubber-band so a stale rect can't render on
+        # the next image/slice (switch_image/switch_slice call through here).
+        self.selection_origin = None
+        self.selecting = False
+        self.selection_rect = None
 
     def clear_current_annotation(self):
         """Clear the current annotation."""
@@ -250,6 +268,9 @@ class ImageLabel(QLabel):
             # Polygon edit mode is modal; runs orthogonal to tool selection
             if self.editing_polygon:
                 self.draw_editing_polygon(painter)
+            # Idle-mode rubber-band selection rectangle (issue #75)
+            if self.selection_rect is not None:
+                self.draw_selection_rect(painter)
             # SAM overlays (cross-cutting; not part of the tool handlers)
             if self.sam_box_active and self.sam_bbox:
                 self.draw_sam_bbox(painter)
@@ -414,6 +435,23 @@ class ImageLabel(QLabel):
         painter.drawRect(QRectF(min(x1, x2), min(y1, y2), abs(x2 - x1), abs(y2 - y1)))
         painter.restore()
 
+    def draw_selection_rect(self, painter):
+        """Draw the idle-mode rubber-band selection rectangle (issue #75).
+
+        A single dashed selection-blue rect with a faint fill — same restrained
+        style as the selection outline (not red, which clashes with class colours)."""
+        painter.save()
+        painter.translate(self.offset_x, self.offset_y)
+        painter.scale(self.zoom_factor, self.zoom_factor)
+        x0, y0, x1, y1 = self.selection_rect
+        rect = QRectF(min(x0, x1), min(y0, y1), abs(x1 - x0), abs(y1 - y0))
+        fill = QColor(self._SELECTION_COLOR)
+        fill.setAlphaF(0.10)
+        painter.setBrush(QBrush(fill))
+        painter.setPen(QPen(self._SELECTION_COLOR, self._pen_w(1), Qt.PenStyle.DashLine))
+        painter.drawRect(rect)
+        painter.restore()
+
     def clear_temp_sam_prediction(self):
         self.temp_sam_prediction = None
         self.update()
@@ -449,6 +487,9 @@ class ImageLabel(QLabel):
         self.start_point = None
         self.end_point = None
         self.highlighted_annotations.clear()
+        self.selection_origin = None
+        self.selecting = False
+        self.selection_rect = None
         self.original_pixmap = None
         self.scaled_pixmap = None
         self.editing_polygon = None
@@ -477,13 +518,12 @@ class ImageLabel(QLabel):
 
             color = self.class_colors.get(class_name, QColor(Qt.GlobalColor.white))
             for annotation in class_annotations:
-                if annotation in self.highlighted_annotations:
-                    border_color = Qt.GlobalColor.red
-                    fill_color = QColor(Qt.GlobalColor.red)
-                else:
-                    border_color = color
-                    fill_color = QColor(color)
-
+                # Selection no longer recolours the mask (it used to turn red,
+                # which was invisible on a red-class mask). The mask always
+                # keeps its class colour; selection is drawn as a
+                # class-colour-independent overlay in a final pass below.
+                border_color = color
+                fill_color = QColor(color)
                 fill_color.setAlphaF(self.fill_opacity)
 
                 text_color = Qt.GlobalColor.white if self.dark_mode else Qt.GlobalColor.black
@@ -553,7 +593,46 @@ class ImageLabel(QLabel):
                         centroid, f"SAM: {self.temp_sam_prediction['score']:.2f}"
                     )
 
+        # Selection overlay — drawn LAST so it sits on top of every mask's
+        # fill, and in a class-colour-independent style so it's recognisable
+        # regardless of the selected mask's colour (issue #75 follow-up).
+        for annotation in self.highlighted_annotations:
+            self._draw_selection_overlay(painter, annotation)
+
         painter.restore()
+
+    def _draw_selection_overlay(self, painter, annotation):
+        """Mark a selected annotation the way the sibling open-garden-planner
+        app does: a dashed selection-blue bounding box plus bright square
+        handles at the 4 corners and 4 edge midpoints. Class-colour-independent
+        and clearly visible regardless of the mask's own colour."""
+        if not self._is_class_pickable(annotation.get("category_name")):
+            return  # don't draw selection chrome over a hidden mask
+        bb = self._annotation_bbox(annotation)
+        if bb is None:
+            return
+        x0, y0, x1, y1 = bb
+        rect = QRectF(x0, y0, x1 - x0, y1 - y0)
+
+        # Dashed bounding-box marquee.
+        painter.setBrush(Qt.BrushStyle.NoBrush)
+        painter.setPen(QPen(self._SELECTION_COLOR, self._pen_w(1.5), Qt.PenStyle.DashLine))
+        painter.drawRect(rect)
+
+        # Handle squares — opaque blue with a white casing so they read on any
+        # background; fixed on-screen size (zoom-compensated). Visual selection
+        # markers; resizing via handles is a separate feature (upstream #40).
+        cx, cy = (x0 + x1) / 2.0, (y0 + y1) / 2.0
+        handles = [
+            (x0, y0), (cx, y0), (x1, y0),
+            (x0, cy), (x1, cy),
+            (x0, y1), (cx, y1), (x1, y1),
+        ]
+        half = 4 * self.ui_scale / self.zoom_factor
+        painter.setPen(QPen(Qt.GlobalColor.white, self._pen_w(1), Qt.PenStyle.SolidLine))
+        painter.setBrush(QBrush(QColor(0, 120, 215)))
+        for hx, hy in handles:
+            painter.drawRect(QRectF(hx - half, hy - half, 2 * half, 2 * half))
 
     def draw_editing_polygon(self, painter):
         """Draw the polygon being edited."""
@@ -683,6 +762,13 @@ class ImageLabel(QLabel):
                 self.drawing_sam_bbox = True
             elif self.editing_polygon:
                 self.handle_editing_click(pos, event)
+            elif self._is_select_mode():
+                # Idle-mode mask selection (issue #75): remember the press as
+                # the potential rubber-band origin; a click vs. drag is
+                # decided on move/release.
+                self.selection_origin = pos
+                self.selecting = False
+                self.selection_rect = None
             else:
                 handler = self.active_tool_handler
                 if handler is not None:
@@ -717,6 +803,10 @@ class ImageLabel(QLabel):
             self.sam_bbox[3] = pos[1]
         elif self.editing_polygon:
             self.handle_editing_move(pos)
+        elif self._is_select_mode() and self.selection_origin is not None and (
+            event.buttons() & Qt.MouseButton.LeftButton
+        ):
+            self._update_selection_drag(pos)
         else:
             handler = self.active_tool_handler
             if handler is not None:
@@ -744,6 +834,8 @@ class ImageLabel(QLabel):
                     self.samPredictionApplyRequested.emit()
                 elif self.editing_polygon:
                     self.editing_point_index = None
+                elif self._is_select_mode() and self.selection_origin is not None:
+                    self._finish_selection(pos, event)
                 else:
                     handler = self.active_tool_handler
                     if handler is not None:
@@ -816,6 +908,13 @@ class ImageLabel(QLabel):
                 self.editing_point_index = None
                 self.hover_point_index = None
                 self.enableToolsRequested.emit()
+            elif self._is_select_mode() and (
+                self.selecting or self.selection_origin is not None
+            ):
+                # Cancel an in-progress rubber band (selection unchanged).
+                self.selection_origin = None
+                self.selecting = False
+                self.selection_rect = None
             else:
                 handler = self.active_tool_handler
                 if handler is not None:
@@ -828,6 +927,18 @@ class ImageLabel(QLabel):
                 self.hover_point_index = None
                 self.enableToolsRequested.emit()
                 self.update()
+            elif (
+                self._is_select_mode()
+                and self._ctx is not None
+                and self._ctx.has_annotation_selection()
+            ):
+                # Idle-mode canvas selection: delete the selected masks.
+                # Gate on the annotation-list selection (the controller's
+                # source of truth) rather than the red highlight, which a
+                # list rebuild (e.g. a sort) can leave stale — otherwise a
+                # canvas Delete would pop a spurious "nothing selected"
+                # warning. See ADR-022.
+                self.deleteSelectionRequested.emit()
         elif event.key() == Qt.Key.Key_Minus:
             if self.current_tool == "paint_brush":
                 new_size = max(1, self._ctx.paint_brush_size() - 1)
@@ -847,6 +958,120 @@ class ImageLabel(QLabel):
                 self.toolSizeChanged.emit("eraser", new_size)
                 print(f"Eraser size: {new_size}")
         self.update()
+
+    # --- Idle-mode mask selection (issue #75) ---
+
+    def _is_select_mode(self):
+        """True when the canvas is idle (no drawing/SAM tool, not editing,
+        no temp review) — the only state where bare clicks/drags select
+        existing masks instead of drawing."""
+        return (
+            self.current_tool is None
+            and not self.editing_polygon
+            and not self.sam_box_active
+            and not self.sam_points_active
+            and not self.temp_annotations
+            and not self.temp_sam_prediction
+        )
+
+    @staticmethod
+    def _annotation_contains(annotation, pos):
+        """Hit-test a single annotation (segmentation polygon or bbox)."""
+        if "segmentation" in annotation:
+            seg = annotation["segmentation"]
+            points = [QPoint(int(x), int(y)) for x, y in zip(seg[0::2], seg[1::2])]
+            return len(points) >= 3 and ImageLabel.point_in_polygon(pos, points)
+        if "bbox" in annotation:
+            x, y, w, h = annotation["bbox"]
+            return x <= pos[0] <= x + w and y <= pos[1] <= y + h
+        return False
+
+    @staticmethod
+    def _annotation_bbox(annotation):
+        """Axis-aligned bounds (x0, y0, x1, y1) of an annotation, or None."""
+        if "segmentation" in annotation:
+            seg = annotation["segmentation"]
+            xs, ys = seg[0::2], seg[1::2]
+            if not xs or not ys:
+                return None
+            return (min(xs), min(ys), max(xs), max(ys))
+        if "bbox" in annotation:
+            x, y, w, h = annotation["bbox"]
+            return (x, y, x + w, y + h)
+        return None
+
+    def _is_class_pickable(self, class_name):
+        # No context (e.g. unit tests) → everything is pickable.
+        return self._ctx is None or self._ctx.is_class_visible(class_name)
+
+    def annotation_at(self, pos):
+        """Smallest-area annotation containing pos, or None. Covers both
+        segmentation and bbox annotations and skips hidden classes. Smallest
+        wins so a mask nested inside another stays reachable (cf.
+        start_polygon_edit / upstream #33)."""
+        best = None
+        best_area = None
+        for class_name, annotations in self.annotations.items():
+            if not self._is_class_pickable(class_name):
+                continue
+            for annotation in annotations:
+                if self._annotation_contains(annotation, pos):
+                    area = calculate_area(annotation)
+                    if best is None or area < best_area:
+                        best = annotation
+                        best_area = area
+        return best
+
+    def annotations_in_rect(self, rect):
+        """All annotations whose bounds intersect the rubber-band rect.
+        rect is (x0, y0, x1, y1) in image coords (any corner order)."""
+        x0, y0, x1, y1 = rect
+        rx0, rx1 = min(x0, x1), max(x0, x1)
+        ry0, ry1 = min(y0, y1), max(y0, y1)
+        result = []
+        for class_name, annotations in self.annotations.items():
+            if not self._is_class_pickable(class_name):
+                continue
+            for annotation in annotations:
+                bb = self._annotation_bbox(annotation)
+                if bb is None:
+                    continue
+                ax0, ay0, ax1, ay1 = bb
+                if ax0 <= rx1 and ax1 >= rx0 and ay0 <= ry1 and ay1 >= ry0:
+                    result.append(annotation)
+        return result
+
+    def _update_selection_drag(self, pos):
+        """Grow the rubber band once the drag clears the click threshold."""
+        if self.selection_origin is None:
+            return
+        if not self.selecting:
+            threshold = 3.0 / max(self.zoom_factor, 1e-6)
+            if self.distance(pos, self.selection_origin) < threshold:
+                return
+            self.selecting = True
+        ox, oy = self.selection_origin
+        self.selection_rect = (ox, oy, pos[0], pos[1])
+
+    def _finish_selection(self, pos, event):
+        """Resolve a press→release in select mode into a selection change.
+        Shift makes it additive (drag) / toggling (click)."""
+        additive = bool(event.modifiers() & Qt.KeyboardModifier.ShiftModifier)
+        if self.selecting and self.selection_rect is not None:
+            anns = self.annotations_in_rect(self.selection_rect)
+            self.canvasSelectionChanged.emit(anns, "add" if additive else "replace")
+        else:
+            ann = self.annotation_at(pos)
+            if additive:
+                if ann is not None:  # Shift+click on empty space keeps the selection
+                    self.canvasSelectionChanged.emit([ann], "toggle")
+            else:
+                self.canvasSelectionChanged.emit(
+                    [ann] if ann is not None else [], "replace"
+                )
+        self.selection_origin = None
+        self.selecting = False
+        self.selection_rect = None
 
     def start_polygon_edit(self, pos):
         # Among all polygons containing the click, edit the smallest by

--- a/tests/integration/test_canvas_selection_controller.py
+++ b/tests/integration/test_canvas_selection_controller.py
@@ -1,0 +1,167 @@
+"""Canvas-selection ↔ annotation-list integration tests (bnsreenu #75).
+
+apply_canvas_selection must update image_label.highlighted_annotations,
+mirror that onto the annotation list selection (so Delete / Merge /
+Change-Class operate on the same set), and toggle the merge / change-class
+buttons. The canvas Delete path then reuses delete_selected_annotations.
+
+One real offscreen ImageAnnotator; no model weights, no worker thread.
+"""
+
+import copy
+
+import pytest
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import QMessageBox
+
+
+@pytest.fixture
+def window(qt_application):
+    from digitalsreeni_image_annotator.annotator_window import ImageAnnotator
+
+    w = ImageAnnotator()
+    yield w
+    w.deleteLater()
+
+
+def _square(x0, y0, side, number):
+    return {
+        "segmentation": [x0, y0, x0 + side, y0, x0 + side, y0 + side, x0, y0 + side],
+        "category_name": "cell",
+        "number": number,
+    }
+
+
+def _seed(window, anns):
+    window.image_file_name = "img.png"
+    window.current_slice = None
+    window.all_annotations = {"img.png": {"cell": list(anns)}}
+    window.image_label.annotations = copy.deepcopy(window.all_annotations["img.png"])
+    window.update_annotation_list()
+
+
+def _selected_data(window):
+    return [
+        item.data(Qt.ItemDataRole.UserRole)
+        for item in window.annotation_list.selectedItems()
+    ]
+
+
+def test_replace_selects_one(window):
+    a1, a2, a3 = _square(0, 0, 10, 1), _square(50, 0, 10, 2), _square(100, 0, 10, 3)
+    _seed(window, [a1, a2, a3])
+
+    window.annotation_controller.apply_canvas_selection([a1], "replace")
+
+    assert window.image_label.highlighted_annotations == [a1]
+    assert _selected_data(window) == [a1]
+    assert not window.merge_button.isEnabled()       # needs ≥2
+    assert window.change_class_button.isEnabled()    # needs ≥1
+
+
+def test_add_then_toggle(window):
+    a1, a2, a3 = _square(0, 0, 10, 1), _square(50, 0, 10, 2), _square(100, 0, 10, 3)
+    _seed(window, [a1, a2, a3])
+    ac = window.annotation_controller
+
+    ac.apply_canvas_selection([a1], "replace")
+    ac.apply_canvas_selection([a2], "add")
+    assert window.image_label.highlighted_annotations == [a1, a2]
+    # The list mirrors by value-equality (PyQt round-trips UserRole dicts as
+    # copies), so compare by membership, not identity.
+    sel = _selected_data(window)
+    assert len(sel) == 2 and a1 in sel and a2 in sel
+    assert window.merge_button.isEnabled()
+
+    # Toggling a1 off leaves only a2.
+    ac.apply_canvas_selection([a1], "toggle")
+    assert window.image_label.highlighted_annotations == [a2]
+    assert _selected_data(window) == [a2]
+    assert not window.merge_button.isEnabled()
+
+
+def test_replace_empty_clears(window):
+    a1, a2 = _square(0, 0, 10, 1), _square(50, 0, 10, 2)
+    _seed(window, [a1, a2])
+    ac = window.annotation_controller
+
+    ac.apply_canvas_selection([a1, a2], "replace")
+    assert window.merge_button.isEnabled()
+
+    ac.apply_canvas_selection([], "replace")
+    assert window.image_label.highlighted_annotations == []
+    assert _selected_data(window) == []
+    assert not window.merge_button.isEnabled()
+    assert not window.change_class_button.isEnabled()
+
+
+def test_canvas_delete_removes_selected_set(window, monkeypatch):
+    a1, a2, a3 = _square(0, 0, 10, 1), _square(50, 0, 10, 2), _square(100, 0, 10, 3)
+    _seed(window, [a1, a2, a3])
+
+    monkeypatch.setattr(
+        QMessageBox, "question",
+        staticmethod(lambda *a, **k: QMessageBox.StandardButton.Yes),
+    )
+    monkeypatch.setattr(QMessageBox, "information", staticmethod(lambda *a, **k: None))
+    monkeypatch.setattr(window, "auto_save", lambda: None)
+
+    window.annotation_controller.apply_canvas_selection([a1, a2], "replace")
+    window.delete_selected_annotations()
+
+    remaining = window.image_label.annotations.get("cell", [])
+    assert a3 in remaining
+    assert a1 not in remaining and a2 not in remaining
+    assert window.all_annotations["img.png"]["cell"] == remaining
+    assert window.image_label.highlighted_annotations == []
+
+
+def test_canvas_delete_gated_on_list_selection(window, monkeypatch):
+    """Canvas Delete fires only when the annotation list actually has a
+    selection — not when only the red highlight is (stale) populated, e.g.
+    after a sort rebuilds the list. Otherwise it pops a spurious warning."""
+    from PyQt6.QtCore import QEvent
+    from PyQt6.QtGui import QKeyEvent
+
+    monkeypatch.setattr(
+        QMessageBox, "question",
+        staticmethod(lambda *a, **k: QMessageBox.StandardButton.Yes),
+    )
+    monkeypatch.setattr(QMessageBox, "information", staticmethod(lambda *a, **k: None))
+    monkeypatch.setattr(window, "auto_save", lambda: None)
+
+    a1, a2, a3 = _square(0, 0, 10, 1), _square(50, 0, 10, 2), _square(100, 0, 10, 3)
+    _seed(window, [a1, a2, a3])
+    il = window.image_label
+    il.current_tool = None
+
+    def press_delete():
+        il.keyPressEvent(
+            QKeyEvent(
+                QEvent.Type.KeyPress,
+                Qt.Key.Key_Delete,
+                Qt.KeyboardModifier.NoModifier,
+            )
+        )
+
+    emitted = []
+    il.deleteSelectionRequested.connect(lambda: emitted.append(True))
+
+    # In sync (canvas selection mirrored to the list) → Delete fires.
+    window.annotation_controller.apply_canvas_selection([a1], "replace")
+    assert il._ctx.has_annotation_selection()
+    press_delete()
+    assert emitted == [True]
+    assert a1 not in il.annotations.get("cell", [])
+
+    # Construct the divergence the gate guards against: a stale red highlight
+    # with no list selection. The canvas Delete keys off the list (the
+    # controller's source of truth), so it must NOT fire here — no spurious
+    # "nothing selected" warning.
+    emitted.clear()
+    il.highlighted_annotations = [a2]
+    window.annotation_list.clearSelection()
+    assert il.highlighted_annotations                # highlight is stale
+    assert not il._ctx.has_annotation_selection()    # but the list isn't selected
+    press_delete()
+    assert emitted == []

--- a/tests/unit/test_canvas_selection.py
+++ b/tests/unit/test_canvas_selection.py
@@ -1,0 +1,244 @@
+"""
+Unit tests for idle-mode canvas mask selection (bnsreenu issue #75).
+
+Covers the pure hit-testing helpers on ImageLabel (annotation_at /
+annotations_in_rect) and the press→release gesture resolution
+(_finish_selection) that emits canvasSelectionChanged. No main window,
+no model — just the widget.
+"""
+
+import pytest
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QColor, QImage, QPainter, QPixmap
+
+from src.digitalsreeni_image_annotator.widgets.image_label import ImageLabel
+
+
+@pytest.fixture
+def label(qtbot):
+    lbl = ImageLabel(None)
+    qtbot.addWidget(lbl)
+    return lbl
+
+
+def _square(x0, y0, side, name):
+    return {
+        "segmentation": [x0, y0, x0 + side, y0, x0 + side, y0 + side, x0, y0 + side],
+        "category_name": name,
+    }
+
+
+def _bbox(x, y, w, h, name):
+    return {"bbox": [x, y, w, h], "category_name": name}
+
+
+class _FakeEvent:
+    """Minimal stand-in for QMouseEvent — only modifiers() is read."""
+
+    def __init__(self, shift=False):
+        self._shift = shift
+
+    def modifiers(self):
+        if self._shift:
+            return Qt.KeyboardModifier.ShiftModifier
+        return Qt.KeyboardModifier.NoModifier
+
+
+class _FakeCtx:
+    def __init__(self, hidden=()):
+        self._hidden = set(hidden)
+
+    def is_class_visible(self, name):
+        return name not in self._hidden
+
+
+# --- annotation_at ---------------------------------------------------------
+
+def test_annotation_at_smallest_of_nested(label):
+    outer = _square(0, 0, 100, "outer")     # area 10000
+    inner = _square(40, 40, 20, "inner")    # area 400, fully inside outer
+    label.annotations = {"cell": [outer, inner]}
+    assert label.annotation_at((50, 50)) is inner   # inside both → smallest
+    assert label.annotation_at((10, 10)) is outer   # inside outer only
+    assert label.annotation_at((500, 500)) is None  # empty space
+
+
+def test_annotation_at_hits_bbox(label):
+    box = _bbox(0, 0, 100, 100, "box")
+    label.annotations = {"cell": [box]}
+    assert label.annotation_at((50, 50)) is box
+    assert label.annotation_at((150, 150)) is None
+
+
+def test_annotation_at_smallest_across_seg_and_bbox(label):
+    big_box = _bbox(0, 0, 200, 200, "box")   # area 40000
+    small_seg = _square(40, 40, 20, "seg")   # area 400
+    label.annotations = {"cell": [big_box, small_seg]}
+    assert label.annotation_at((45, 45)) is small_seg
+
+
+def test_annotation_at_skips_hidden_class(label):
+    visible = _square(0, 0, 100, "visible")
+    hidden = _square(40, 40, 20, "hidden")   # smaller, but its class is hidden
+    label.annotations = {"visible": [visible], "hidden": [hidden]}
+    label.set_context(_FakeCtx(hidden={"hidden"}))
+    # Without the visibility guard, the smaller hidden square would win.
+    assert label.annotation_at((50, 50)) is visible
+
+
+# --- annotations_in_rect ---------------------------------------------------
+
+def test_annotations_in_rect_returns_intersecting(label):
+    a = _square(0, 0, 20, "a")
+    b = _square(50, 50, 20, "b")
+    far = _square(500, 500, 20, "far")
+    bbox_in = _bbox(10, 10, 30, 30, "c")
+    label.annotations = {"cell": [a, b, far, bbox_in]}
+    hit = label.annotations_in_rect((0, 0, 80, 80))
+    assert a in hit and b in hit and bbox_in in hit
+    assert far not in hit
+
+
+def test_annotations_in_rect_any_corner_order(label):
+    a = _square(0, 0, 20, "a")
+    label.annotations = {"cell": [a]}
+    # Rect given bottom-right → top-left must still match.
+    assert a in label.annotations_in_rect((80, 80, 0, 0))
+
+
+def test_annotations_in_rect_skips_hidden(label):
+    a = _square(0, 0, 20, "a")
+    label.annotations = {"hidden": [a]}
+    label.set_context(_FakeCtx(hidden={"hidden"}))
+    assert label.annotations_in_rect((0, 0, 80, 80)) == []
+
+
+# --- _finish_selection gesture resolution ----------------------------------
+
+@pytest.fixture
+def captured(label):
+    events = []
+    label.canvasSelectionChanged.connect(lambda anns, mode: events.append((anns, mode)))
+    return events
+
+
+def test_click_on_mask_emits_replace(label, captured):
+    inner = _square(40, 40, 20, "inner")
+    label.annotations = {"cell": [inner]}
+    label.selection_origin = (45, 45)
+    label.selecting = False
+    label._finish_selection((45, 45), _FakeEvent(shift=False))
+    assert captured == [([inner], "replace")]
+    # gesture state reset
+    assert label.selection_origin is None and label.selection_rect is None
+
+
+def test_click_empty_emits_replace_empty(label, captured):
+    label.annotations = {"cell": [_square(40, 40, 20, "inner")]}
+    label.selection_origin = (300, 300)
+    label._finish_selection((300, 300), _FakeEvent(shift=False))
+    assert captured == [([], "replace")]
+
+
+def test_shift_click_mask_emits_toggle(label, captured):
+    inner = _square(40, 40, 20, "inner")
+    label.annotations = {"cell": [inner]}
+    label.selection_origin = (45, 45)
+    label._finish_selection((45, 45), _FakeEvent(shift=True))
+    assert captured == [([inner], "toggle")]
+
+
+def test_shift_click_empty_emits_nothing(label, captured):
+    label.annotations = {"cell": [_square(40, 40, 20, "inner")]}
+    label.selection_origin = (300, 300)
+    label._finish_selection((300, 300), _FakeEvent(shift=True))
+    assert captured == []
+
+
+def test_drag_emits_add_when_shift(label, captured):
+    a = _square(0, 0, 20, "a")
+    b = _square(50, 50, 20, "b")
+    label.annotations = {"cell": [a, b]}
+    label.selection_origin = (0, 0)
+    label.selecting = True
+    label.selection_rect = (0, 0, 80, 80)
+    label._finish_selection((80, 80), _FakeEvent(shift=True))
+    anns, mode = captured[-1]
+    assert mode == "add"
+    assert a in anns and b in anns
+
+
+def test_drag_emits_replace_without_shift(label, captured):
+    a = _square(0, 0, 20, "a")
+    label.annotations = {"cell": [a]}
+    label.selection_origin = (0, 0)
+    label.selecting = True
+    label.selection_rect = (0, 0, 80, 80)
+    label._finish_selection((80, 80), _FakeEvent(shift=False))
+    assert captured[-1][1] == "replace"
+    assert a in captured[-1][0]
+
+
+def test_escape_cancels_rubber_band(label):
+    from PyQt6.QtCore import QEvent
+    from PyQt6.QtGui import QKeyEvent
+
+    label.current_tool = None
+    label.selection_origin = (0, 0)
+    label.selecting = True
+    label.selection_rect = (0, 0, 50, 50)
+    label.keyPressEvent(
+        QKeyEvent(QEvent.Type.KeyPress, Qt.Key.Key_Escape, Qt.KeyboardModifier.NoModifier)
+    )
+    assert label.selection_rect is None
+    assert label.selecting is False
+    assert label.selection_origin is None
+
+
+# --- selection rendering: overlay, not recolor ----------------------------
+
+def _setup_canvas(label, class_color):
+    label.set_context(_FakeCtx())
+    px = QPixmap(100, 100)
+    px.fill(QColor("white"))
+    label.original_pixmap = px
+    label.class_colors = {"cell": QColor(class_color)}
+
+
+def _render_center(label):
+    img = QImage(100, 100, QImage.Format.Format_RGB32)
+    img.fill(QColor("white"))
+    p = QPainter(img)
+    label.draw_annotations(p)
+    p.end()
+    return img.pixelColor(50, 50)
+
+
+def test_selection_does_not_recolor_fill(label):
+    # A mask's interior fill must look identical selected vs. unselected — the
+    # old code turned it red, which was invisible on a red-class mask.
+    _setup_canvas(label, "#1F77B4")
+    mask = {"segmentation": [20, 20, 80, 20, 80, 80, 20, 80], "category_name": "cell"}
+    label.annotations = {"cell": [mask]}
+
+    label.highlighted_annotations = []
+    unselected = _render_center(label)
+    label.highlighted_annotations = [mask]
+    selected = _render_center(label)
+    assert selected == unselected  # selection adds an overlay, never recolors
+
+
+def test_selection_overlay_runs_for_seg_and_bbox(label):
+    # Red class = the worst case; outline + marquee must still render fine.
+    _setup_canvas(label, "#D62728")
+    seg = {"segmentation": [10, 10, 40, 10, 40, 40, 10, 40], "category_name": "cell"}
+    box = {"bbox": [50, 50, 30, 30], "category_name": "cell"}
+    label.annotations = {"cell": [seg, box]}
+    label.highlighted_annotations = [seg, box]
+
+    img = QImage(100, 100, QImage.Format.Format_RGB32)
+    img.fill(QColor("white"))
+    p = QPainter(img)
+    label.draw_annotations(p)  # must not raise
+    p.end()

--- a/tests/unit/test_class_colors.py
+++ b/tests/unit/test_class_colors.py
@@ -1,0 +1,35 @@
+"""Default class-colour palette (issue #75 follow-up).
+
+Red must no longer be the first auto-assigned class colour (it collided with
+the selection highlight); it stays in the palette but at the back.
+"""
+
+from src.digitalsreeni_image_annotator.core.constants import (
+    DEFAULT_CLASS_COLORS,
+    default_class_color,
+)
+
+_RED = "#D62728"
+
+
+def test_first_default_color_is_not_red():
+    assert default_class_color(0).upper() != _RED
+    assert default_class_color(0) == DEFAULT_CLASS_COLORS[0]
+
+
+def test_palette_cycles_modulo_length():
+    n = len(DEFAULT_CLASS_COLORS)
+    assert default_class_color(n) == default_class_color(0)
+    assert default_class_color(n + 3) == default_class_color(3)
+
+
+def test_red_present_but_last():
+    upper = [c.upper() for c in DEFAULT_CLASS_COLORS]
+    assert _RED in upper
+    assert upper[-1] == _RED
+
+
+def test_all_entries_distinct_and_valid_hex():
+    assert len(set(DEFAULT_CLASS_COLORS)) == len(DEFAULT_CLASS_COLORS)
+    for c in DEFAULT_CLASS_COLORS:
+        assert c.startswith("#") and len(c) == 7


### PR DESCRIPTION
## What & why

Addresses upstream **bnsreenu#75**. Until now you could only *select* an
existing annotation via the bottom-left list, or by double-clicking a mask —
which jumps straight into vertex-edit. There was no single-click select, no
box/multi-select on the image, and canvas Delete worked only in vertex-edit
mode. This gives the canvas the same selection power the list already had, and
makes the selection clearly visible.

## What's included

**Selection (idle mode — active only when no drawing/SAM tool is selected):**
- Single click selects the smallest mask under the cursor (segmentation **or**
  bbox); click on empty space clears.
- **Shift**+click toggles; **drag** rubber-band box-selects; **Shift**+drag
  adds. **Esc** cancels an in-progress band. **Ctrl** stays pan (untouched).
- **Delete** removes the selected mask(s). Double-click still enters vertex edit.

**One selection, two surfaces.** The canvas emits `canvasSelectionChanged`;
`AnnotationController.apply_canvas_selection` computes replace/add/toggle, sets
the highlight, and mirrors onto the annotation list (`blockSignals` to avoid
recursion), so Delete / Merge / Change Class are reused unchanged. Matching is
by dict value-equality (PyQt round-trips `UserRole` dicts as copies, and
`image_label.annotations` is a deepcopy — identity is never stable). Canvas
Delete gates on the *list* selection so a stale highlight can't pop a spurious
"nothing selected" warning.

**Visible, class-colour-independent selection styling.** Selected masks are no
longer recoloured red — which was invisible on a red-class mask (and red was
the default first class colour). The mask keeps its class colour; an overlay is
drawn last: a dashed selection-blue **bounding box + bright handle squares** at
corners/edge-midpoints, modelled on the sibling open-garden-planner CAD
selection. Handles are visual-only (resize is a separate feature, upstream #40).

**Colour polish (so selection reads and masks don't bury the image).** The
default class palette no longer starts on red — `core/constants.py::default_class_color`
(curated tab10-style, red last, muted) replaces the `Qt.GlobalColor(n % 16 + 7)`
formula at the 4 assignment sites. Default fill opacity 0.3 → 0.2. Saved
projects keep their persisted colours.

**Bundled fix.** Light-mode contrast for the DINO threshold-table headers (inline
`palette()` resolved against the OS palette → dark header in light mode); now
themed via `QHeaderView::section` in both stylesheets. Separate commit.

## Validation

- **204 tests pass, 3 GPU-skipped**; ruff clean on changed files.
- New tests: hit-testing, gesture resolution, Esc-cancel, a render test proving
  selection no longer recolours the fill, the palette helper, the controller
  selection mirror, and the canvas-delete gating.
- Selection look verified by rendering a selected mask (dashed box + handles).
- Senior-reviewer pass: no P0s; the P1 (doc "red" drift) and the worthwhile P2s
  (button-sync on image switch, hidden-class overlay skip, Esc-cancel, import
  grouping) addressed.

## Docs

ADR-022 (+ rendering amendment), runtime view, crosscutting concepts
(canvas↔list selection, value-equality + signal-blocking, selection styling),
glossary, CLAUDE.md patterns + shortcuts.

## Notes / follow-ups

- Selection handles are intentionally non-interactive for now — true
  resize-by-handle is upstream #40.
- The value-equality selection model (two value-equal duplicate masks select
  together) is a pre-existing, documented limitation this PR inherits.