### PR TITLE
feat: Reversible per-annotation mask complexity (Detail %) — closes #24

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,13 +44,12 @@ entire section so CLAUDE.md returns to its clean state. Never let a finished
 item linger here.
 
 Issue numbers refer to https://github.com/bnsreenu/digitalsreeni-image-annotator/issues
-(validated 2026-06-12; already-fixed issues have close-request comments posted, not listed here).
+(validated 2026-06-22; already-fixed issues have close-request comments posted, not listed here).
 
 | Issue | Size | Task |
 |-------|------|------|
-| #63 | blocked | SAM 3 support — blocked on Ultralytics shipping SAM 3; re-check their releases before attempting |
+| #74 | large | MLflow experiment tracking for model training (SAM fine-tuning / YOLO) |
 | #35 | large | Keypoint annotation tool |
-| #24 | large | Magic-wand-style point add/remove mask refinement (partially covered by SAM point prompts) |
 
 ## Project Structure
 
@@ -194,6 +193,7 @@ See [Runtime View](docs/06_runtime_view.md#multi-dimensional-image-loading) for 
 | Selection rendering | Don't recolour a selected mask. Keep its class colour; draw a class-colour-independent overlay (dashed `_SELECTION_COLOR` blue bounding box + bright handle squares at corners/edge-midpoints, OGP-style) in a final pass — `_draw_selection_overlay`. For a single selected shape those handles are draggable (resize/move, any shape). Default class colours come from `core/constants.py::default_class_color` (red last, muted) | Red selection was invisible on a red-class mask; a thin dashed outline alone was too faint; the handles carry the visibility. See ADR-022 amendment. |
 | Shape editing (#40) | Direct manipulation on the selection handles for **any** single selected shape (`_single_selected_shape()` — most shapes are `"segmentation"`, not `"bbox"`; gating on a bbox key made it unreachable). `_begin_shape_edit` records `kind`: a `"seg"` polygon **scales** its vertices (`_scale_segmentation`) / translates them; a `"bbox"` edits `[x,y,w,h]`. `_draw_selection_overlay` + `_bbox_handle_at` share `_bbox_handle_points` (visual == grab); resize anchors the opposite side (`_resize_bbox`); interior drag moves, **drag-gated**. `_sync_bbox_key` keeps an imported bbox consistent. Clamp + `bboxEditCommitted` → `commit_bbox_edit` on release; Esc reverts | Handles drawn since #75 were visual-only; dispatch sits before the rubber-band branch but stays gated on `_is_select_mode()`. Names keep the `bbox_edit` prefix = "edit via the bounding-box handles". See [ADR-023](docs/09_architecture_decisions.md). |
 | Bounds enforcement (#32/#36) | No commit may persist coords outside the image. **Clamp** manual edits (`clamp_segmentation`/`clamp_bbox`, per-coordinate, count-preserving) at edit commit; **clip** augmented polygons (`clip_polygon_to_bounds`, shapely intersection, may drop → `None`, augmenter must `continue`). Drawn shapes already clip in `finish_polygon`/`finish_rectangle` | Clamp keeps vertex correspondence mid-edit; clip is geometrically correct for batch augmentation. See [ADR-024](docs/09_architecture_decisions.md). |
+| Annotations table + Detail % (#24) | The Annotations panel is a **`QTableWidget`** (ID \| Class \| Area \| Detail %), not a list — col 0's UserRole holds the annotation (the #75 value-equality marker). Selection-mirror uses **`setRangeSelected`** (additive); `selectRow()` replaces in `ExtendedSelection`. Per-row Detail % spinbox → `on_detail_pct_changed` resolves the live obj (`_live_annotation`), simplifies from a lazy-captured `segmentation_raw` (`simplify_polygon`, 100=raw), refreshes Area+UserRole in place, saves. Connect `valueChanged` **after** the initial `setValue` so building the table doesn't fire it | Re-homing the selection bridge onto a table is the risk; reversibility needs the raw preserved. See [ADR-025](docs/09_architecture_decisions.md). |
 
 ## Development Workflow
 

--- a/docs/06_runtime_view.md
+++ b/docs/06_runtime_view.md
@@ -128,6 +128,27 @@ One shape selected → handles are grab targets (hover shows resize/move cursors
 Polygon vertex edits (double-click) are likewise clamped into the image on Enter.
 See ADR-023 (shape editing) and ADR-024 (bounds enforcement).
 
+## Adjusting Mask Complexity — Detail % (issue #24)
+
+The Annotations table carries a per-row **Detail %** spinbox (100 = raw). Dialing
+it down thins a dense SAM/DINO mask; dialing back to 100 restores it exactly.
+
+```
+User changes a row's Detail % spinbox (1..100)
+    │
+    └─> AnnotationController.on_detail_pct_changed(row, pct)
+        ├─> resolve the live drawn object (value-equality, _live_annotation)
+        ├─> pct == 100 → segmentation = segmentation_raw (restore)
+        │   pct  < 100 → lazy-init segmentation_raw (first time);
+        │                segmentation = simplify_polygon(raw, pct)  [Douglas-Peucker]
+        ├─> recompute bbox key if present
+        ├─> refresh the row's Area cell + UserRole in place (no rebuild)
+        └─> image_label.update() → save_current_annotations() → auto_save()
+```
+
+The effective (simplified) `segmentation` renders and exports; `segmentation_raw`
++ `detail_pct` persist in the `.iap`. See ADR-025.
+
 ## SAM-Assisted Annotation (SAM-box / SAM-points)
 
 ```

--- a/docs/08_crosscutting_concepts.md
+++ b/docs/08_crosscutting_concepts.md
@@ -46,6 +46,16 @@ exits the frame and should be cut at the edge; a fully-outside polygon is droppe
 *Drawn* shapes were already shapely-clipped in `finish_polygon` /
 `finish_rectangle`. See ADR-024.
 
+### Polygon simplification — Detail % (issue #24)
+
+SAM/DINO masks are dense (hundreds of vertices). The Annotations table's per-row
+**Detail %** spinbox (100 = raw) thins a mask via `utils.simplify_polygon`
+(Douglas-Peucker, `cv2.approxPolyDP`, binary-searched to a vertex budget). It is
+**reversible**: the dense original is lazy-captured into `segmentation_raw` on
+first simplify, and 100 % restores it exactly. The effective (possibly simplified)
+`segmentation` is what renders and exports; `segmentation_raw` + `detail_pct` ride
+along in `.iap`. See ADR-025.
+
 ### Pan + Zoom Reference Frames
 
 Two non-obvious gotchas live in `ImageLabel.mouseMoveEvent` /
@@ -699,6 +709,14 @@ Two non-obvious rules make this correct:
   Without it, `setSelected` fires `itemSelectionChanged` →
   `update_highlighted_annotations`, which would overwrite the freshly-computed
   set with the list items' own objects (and clobber a `toggle`).
+
+**The Annotations panel is a `QTableWidget`** (ID | Class | Area | Detail %), not
+a `QListWidget` (issue #24, ADR-025). The bridge above is unchanged in spirit but
+the API maps to table calls: the annotation dict lives in **column 0's UserRole**;
+`count()/item(i)/selectedItems()` become `rowCount()/item(r, ANNOT_COL_ID)/row-
+deduped `selectedIndexes()`; and the mirror uses **`setRangeSelected` (additive)**,
+because `selectRow()` *replaces* the selection in `ExtendedSelection` mode and
+would drop all but the last row. `blockSignals` + value-equality are preserved.
 
 **Ctrl is reserved for pan.** Multi-select uses **Shift**, not Ctrl, because
 Ctrl+drag is the pan gesture (whose reference-frame handling is deliberately

--- a/docs/09_architecture_decisions.md
+++ b/docs/09_architecture_decisions.md
@@ -978,6 +978,60 @@ path:
 
 ---
 
+## ADR-025: Reversible Per-Annotation Polygon Simplification (Detail %)
+
+**Status**: Accepted (issue bnsreenu#24)
+
+**Context**: SAM/DINO masks are stored as raw dense polygons — `_mask_to_polygon`
+returns the flattened `cv2.findContours` boundary with no simplification, so a
+single mask can carry hundreds of vertices, bloating label files. Issue #24 asked
+for a "mask complexity — less ↔ more points" control. The point add/remove half of
+#24 was already covered by the SAM-points tool; this is the remaining piece.
+
+**Decision**: A **per-annotation, reversible Detail %** control, surfaced as a
+column in the Annotations panel:
+
+- **Detail % (1–100, 100 = raw).** `utils.simplify_polygon(raw, pct)` thins via
+  Douglas-Peucker (`cv2.approxPolyDP`), binary-searching the epsilon for the
+  richest polygon whose vertex count is still ≤ `round(raw_count × pct/100)`.
+- **Reversible via a preserved raw.** The dense original is **lazy-captured** into
+  `segmentation_raw` the first time a mask is thinned (nothing simplifies it
+  before that, so the live `segmentation` *is* the raw at capture). 100 % copies
+  `segmentation_raw` back into `segmentation` exactly. No edits to the SAM/DINO/
+  manual accept paths were needed.
+- **Two new annotation keys** (`segmentation_raw`, `detail_pct`) ride along: they
+  round-trip through `.iap` for free (project save does `ann.copy()` →
+  `convert_to_serializable` → JSON), and exports read only the effective
+  `segmentation`, so the *simplified* polygon is what's exported. Imported/old
+  annotations have neither key → handled by lazy-init.
+- **Live + in place.** The change handler resolves the selected row to the live
+  drawn object by value-equality (`image_label._live_annotation`, reused from
+  #40), mutates `segmentation` in place, refreshes the Area cell + the row's
+  UserRole, redraws, and saves. The `bbox` key (if present) is recomputed.
+
+**The Annotations panel became a `QTableWidget`** (ID | Class | Area | Detail %),
+mirroring `dialogs/dino_phrase_editor.ClassThresholdTable` (per-row spinbox via
+`setCellWidget`, `SelectRows`, `NoEditTriggers`, stylesheet-only header). This
+re-homes the #75 canvas↔list selection bridge onto a table:
+
+- The annotation dict lives in **column 0's UserRole** (the value-equality marker).
+- `count()/item(i)/selectedItems()` → `rowCount()/item(r, 0)/row-deduped
+  selectedIndexes()`; the mirror uses **`setRangeSelected` (additive)** because
+  `selectRow()` *replaces* the selection in ExtendedSelection mode and would drop
+  all but the last row. `blockSignals` + value-equality are preserved verbatim.
+
+**Consequences**:
+- Closing #24 with a small, contained change: the feature is the table UI + one
+  controller handler + one pure util; the accept paths are untouched.
+- ✅ Fully reversible per annotation; raw never lost (until simplified-then-saved,
+  the raw is the segmentation itself).
+- ⚠️ The spinbox `valueChanged` is connected **after** the initial `setValue`, so
+  building/rebuilding the table never fires the simplification handler.
+- ⚠️ The dead `core/annotation_utils.py` still references the old QListWidget API
+  but is unimported (confirmed) — left as-is to keep the diff contained.
+
+---
+
 ## Decisions Under Consideration
 
 ### Consider pytest-qt for Utility Testing

--- a/docs/09_architecture_decisions.md
+++ b/docs/09_architecture_decisions.md
@@ -1023,8 +1023,14 @@ re-homes the #75 canvas↔list selection bridge onto a table:
 **Consequences**:
 - Closing #24 with a small, contained change: the feature is the table UI + one
   controller handler + one pure util; the accept paths are untouched.
-- ✅ Fully reversible per annotation; raw never lost (until simplified-then-saved,
-  the raw is the segmentation itself).
+- ✅ Fully reversible per annotation: Detail %=100 restores `segmentation_raw`
+  exactly. **Exception:** reshaping a polygon with the #40 handles invalidates the
+  baseline — `_clamp_edited_shape` drops `segmentation_raw` and resets
+  `detail_pct=100`, so the *edited* geometry becomes the new raw (the old dense
+  outline no longer describes the reshaped polygon, and a later 100 % must not
+  silently revert the edit). The detail handler also re-points
+  `highlighted_annotations` at the mutated object so the overlay + a subsequent
+  handle drag stay coherent.
 - ⚠️ The spinbox `valueChanged` is connected **after** the initial `setValue`, so
   building/rebuilding the table never fires the simplification handler.
 - ⚠️ The dead `core/annotation_utils.py` still references the old QListWidget API

--- a/docs/12_glossary.md
+++ b/docs/12_glossary.md
@@ -217,7 +217,7 @@ Functions under `ui/` that construct widget trees at startup. Each takes the `Im
 |-----------|-------------|
 | Tool Section | Buttons for Polygon, Rectangle, Paint Brush, Eraser, SAM tools |
 | Class List | QListWidget showing all classes with colors |
-| Annotation List | QListWidget showing all annotations for current image |
+| Annotation List | QTableWidget (ID \| Class \| Area \| Detail %) of all annotations for the current image |
 | Image Label | Central QLabel displaying image with zoom/pan |
 | Slice Slider | Navigate through multi-dimensional image slices |
 | Menu Bar | File, Edit, View, Tools, Help menus |

--- a/docs/12_glossary.md
+++ b/docs/12_glossary.md
@@ -74,6 +74,18 @@ polygon scales its vertices); dragging the interior moves the whole shape.
 Reshaping a polygon vertex-by-vertex is still double-click vertex edit. See
 ADR-023.
 
+### Detail % (Mask Complexity)
+A per-annotation control (1–100, **100 = raw/full precision**) in the Annotations
+table that reversibly thins a polygon's vertex count via Douglas-Peucker, for
+smaller label files. Lower keeps proportionally fewer vertices; 100 restores the
+raw polygon exactly. See ADR-025 and [[segmentation-raw]].
+
+### segmentation_raw
+The dense, full-precision polygon kept alongside a (possibly simplified)
+`segmentation` so **Detail %** simplification is reversible. Lazy-captured the
+first time a mask is thinned; absent on raw/imported annotations. Persists in
+`.iap` but is not exported (exports emit the effective `segmentation`).
+
 ### Clamp vs Clip
 Two ways to keep annotation coordinates inside the image. **Clamp** snaps each
 coordinate into `[0,w]×[0,h]` and preserves the vertex count — used for live manual

--- a/src/digitalsreeni_image_annotator/annotator_window.py
+++ b/src/digitalsreeni_image_annotator/annotator_window.py
@@ -745,7 +745,7 @@ class ImageAnnotator(QMainWindow):
 
         # Clear annotations
         self.all_annotations.clear()
-        self.annotation_list.clear()
+        self.annotation_list.setRowCount(0)
         self.image_label.annotations.clear()
         self.image_label.highlighted_annotations.clear()
 

--- a/src/digitalsreeni_image_annotator/annotator_window.py
+++ b/src/digitalsreeni_image_annotator/annotator_window.py
@@ -1031,9 +1031,6 @@ class ImageAnnotator(QMainWindow):
     def finish_polygon(self):
         return self.annotation_controller.finish_polygon()
 
-    def delete_annotation(self):
-        return self.annotation_controller.delete_annotation()
-
     def add_annotation_to_list(self, annotation):
         return self.annotation_controller.add_annotation_to_list(annotation)
 

--- a/src/digitalsreeni_image_annotator/controllers/annotation_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/annotation_controller.py
@@ -548,23 +548,6 @@ class AnnotationController(QObject):
 
     # --- Delete / merge / change-class ---
 
-    def delete_annotation(self):
-        tbl = self.mw.annotation_list
-        row = tbl.currentRow()
-        if row < 0:
-            return
-        id_item = tbl.item(row, ANNOT_COL_ID)
-        if id_item is None:
-            return
-        annotation = id_item.data(Qt.ItemDataRole.UserRole)
-        category_name = annotation["category_name"]
-        anns = self.mw.image_label.annotations.get(category_name, [])
-        if annotation in anns:
-            anns.remove(annotation)
-        tbl.removeRow(row)
-        self.mw.image_label.highlighted_annotations.clear()
-        self.mw.image_label.update()
-
     def delete_selected_annotations(self):
         selected_items = self._selected_row_items()
         if not selected_items:

--- a/src/digitalsreeni_image_annotator/controllers/annotation_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/annotation_controller.py
@@ -31,13 +31,22 @@ from PyQt6.QtWidgets import (
     QFileDialog,
     QListWidgetItem,
     QMessageBox,
+    QSpinBox,
+    QTableWidgetItem,
+    QTableWidgetSelectionRange,
     QVBoxLayout,
 )
 from shapely.geometry import MultiPolygon, Polygon
 from shapely.ops import unary_union
 
-from ..core.constants import default_class_color
-from ..utils import calculate_area, calculate_bbox
+from ..core.constants import (
+    ANNOT_COL_AREA,
+    ANNOT_COL_CLASS,
+    ANNOT_COL_DETAIL,
+    ANNOT_COL_ID,
+    default_class_color,
+)
+from ..utils import calculate_area, calculate_bbox, simplify_polygon
 
 
 class AnnotationController(QObject):
@@ -71,8 +80,59 @@ class AnnotationController(QObject):
             self.update_annotation_list(image_name)
         self.update_annotation_list()
 
+    # --- Annotations table (issue #24): ID | Class | Area | Detail % ---
+    # The table replaces the old QListWidget. Column 0 (ID) carries the
+    # annotation dict in its UserRole — the value-equality marker the canvas ↔
+    # list selection bridge reads (ADR-022). The Detail % spinbox per row drives
+    # reversible polygon simplification (ADR-025).
+
+    def _make_detail_spin(self, annotation):
+        """A per-row 1..100 Detail % spinbox (100 = raw). Disabled for
+        annotations with no polygon to simplify (bbox-only imports)."""
+        sp = QSpinBox()
+        sp.setRange(1, 100)
+        sp.setSuffix(" %")
+        has_seg = bool(annotation.get("segmentation"))
+        sp.setValue(int(annotation.get("detail_pct", 100)) if has_seg else 100)
+        sp.setEnabled(has_seg)
+        sp.setFrame(True)
+        return sp
+
+    def _insert_annotation_row(self, annotation, color):
+        """Append one annotation as a table row. valueChanged is connected
+        *after* the initial setValue so building the table never fires the
+        simplification handler."""
+        tbl = self.mw.annotation_list
+        row = tbl.rowCount()
+        tbl.insertRow(row)
+
+        id_item = QTableWidgetItem(str(annotation.get("number", 0)))
+        id_item.setData(Qt.ItemDataRole.UserRole, annotation)
+        id_item.setForeground(color)
+        tbl.setItem(row, ANNOT_COL_ID, id_item)
+
+        class_item = QTableWidgetItem(annotation["category_name"])
+        class_item.setForeground(color)
+        tbl.setItem(row, ANNOT_COL_CLASS, class_item)
+
+        area_item = QTableWidgetItem(f"{calculate_area(annotation):.2f}")
+        area_item.setForeground(color)
+        tbl.setItem(row, ANNOT_COL_AREA, area_item)
+
+        spin = self._make_detail_spin(annotation)
+        spin.valueChanged.connect(lambda val, r=row: self.on_detail_pct_changed(r, val))
+        tbl.setCellWidget(row, ANNOT_COL_DETAIL, spin)
+
+    def _selected_row_items(self):
+        """Col-0 items of the selected rows, deduped. The table selects whole
+        rows, but selectedItems()/selectedIndexes() yield a cell per column."""
+        tbl = self.mw.annotation_list
+        rows = sorted({idx.row() for idx in tbl.selectedIndexes()})
+        items = [tbl.item(r, ANNOT_COL_ID) for r in rows]
+        return [it for it in items if it is not None]
+
     def update_annotation_list(self, image_name=None):
-        self.mw.annotation_list.clear()
+        self.mw.annotation_list.setRowCount(0)
         current_name = image_name or self.mw.current_slice or self.mw.image_file_name
         annotations = self.mw.all_annotations.get(current_name, {})
         for class_name, class_annotations in annotations.items():
@@ -81,20 +141,15 @@ class AnnotationController(QObject):
                     class_name, QColor(Qt.GlobalColor.white)
                 )
                 for annotation in class_annotations:
-                    number = annotation.get("number", 0)
-                    area = calculate_area(annotation)
-                    item_text = f"{class_name} - {number:<3} Area: {area:.2f}"
-                    item = QListWidgetItem(item_text)
-                    item.setData(Qt.ItemDataRole.UserRole, annotation)
-                    item.setForeground(color)
-                    self.mw.annotation_list.addItem(item)
-
-        self.mw.annotation_list.repaint()
+                    self._insert_annotation_row(annotation, color)
 
     def update_annotation_list_colors(self, class_name=None, color=None):
-        for i in range(self.mw.annotation_list.count()):
-            item = self.mw.annotation_list.item(i)
-            annotation = item.data(Qt.ItemDataRole.UserRole)
+        tbl = self.mw.annotation_list
+        for i in range(tbl.rowCount()):
+            id_item = tbl.item(i, ANNOT_COL_ID)
+            if id_item is None:
+                continue
+            annotation = id_item.data(Qt.ItemDataRole.UserRole)
             if class_name is None or annotation["category_name"] == class_name:
                 item_color = (
                     color
@@ -103,25 +158,63 @@ class AnnotationController(QObject):
                         annotation["category_name"], QColor(Qt.GlobalColor.white)
                     )
                 )
-                item.setForeground(item_color)
+                for c in (ANNOT_COL_ID, ANNOT_COL_CLASS, ANNOT_COL_AREA):
+                    cell = tbl.item(i, c)
+                    if cell is not None:
+                        cell.setForeground(item_color)
 
     def update_annotation_list_with_sorted(self, sorted_annotations):
-        self.mw.annotation_list.clear()
+        self.mw.annotation_list.setRowCount(0)
         for annotation in sorted_annotations:
             class_name = annotation["category_name"]
             if not class_name.startswith("Temp-"):
-                number = annotation.get("number", 0)
-                area = calculate_area(annotation)
-                item_text = f"{class_name} - {number:<3} Area: {area:.2f}"
-                item = QListWidgetItem(item_text)
-                item.setData(Qt.ItemDataRole.UserRole, annotation)
                 color = self.mw.image_label.class_colors.get(
                     class_name, QColor(Qt.GlobalColor.white)
                 )
-                item.setForeground(color)
-                self.mw.annotation_list.addItem(item)
+                self._insert_annotation_row(annotation, color)
 
         self.mw.image_label.update()
+
+    def on_detail_pct_changed(self, row, pct):
+        """A row's Detail % spinbox changed → re-simplify that annotation's
+        polygon from its raw (full-precision) copy. Reversible: 100 % restores
+        raw exactly; the raw is lazy-captured the first time a mask is thinned.
+        (issue #24)"""
+        tbl = self.mw.annotation_list
+        id_item = tbl.item(row, ANNOT_COL_ID)
+        if id_item is None:
+            return
+        captured = id_item.data(Qt.ItemDataRole.UserRole)
+        # Resolve to the live drawn object so the in-place edit is what gets
+        # rendered + saved (a list/table copy would be lost — see #40).
+        live = self.mw.image_label._live_annotation(captured)
+        if live is None or not live.get("segmentation"):
+            return
+
+        if pct >= 100:
+            raw = live.get("segmentation_raw")
+            if raw:
+                live["segmentation"] = list(raw)
+            live["detail_pct"] = 100
+        else:
+            if not live.get("segmentation_raw"):
+                live["segmentation_raw"] = list(live["segmentation"])
+            live["segmentation"] = simplify_polygon(live["segmentation_raw"], pct)
+            live["detail_pct"] = pct
+        if live.get("bbox") is not None:
+            live["bbox"] = calculate_bbox(live["segmentation"])
+
+        # Refresh this row in place (no rebuild — keeps the spinbox stable): the
+        # UserRole + Area must track the new value so repeated edits resolve and
+        # the selection bridge keeps matching.
+        id_item.setData(Qt.ItemDataRole.UserRole, dict(live))
+        area_item = tbl.item(row, ANNOT_COL_AREA)
+        if area_item is not None:
+            area_item.setText(f"{calculate_area(live):.2f}")
+
+        self.mw.image_label.update()
+        self.save_current_annotations()
+        self.mw.auto_save()
 
     # --- Per-image annotation cache sync ---
 
@@ -340,7 +433,7 @@ class AnnotationController(QObject):
         self.mw.image_label.update()
 
     def update_highlighted_annotations(self):
-        selected_items = self.mw.annotation_list.selectedItems()
+        selected_items = self._selected_row_items()
         self.mw.image_label.highlighted_annotations = [
             item.data(Qt.ItemDataRole.UserRole) for item in selected_items
         ]
@@ -383,18 +476,23 @@ class AnnotationController(QObject):
 
         self.mw.image_label.highlighted_annotations = new
 
-        # Mirror onto the list widget. Block signals so the programmatic
-        # selection doesn't retrigger itemSelectionChanged →
-        # update_highlighted_annotations, which would overwrite `new` with
-        # the list items' own (all_annotations) object identities.
-        lst = self.mw.annotation_list
-        lst.blockSignals(True)
-        lst.clearSelection()
-        for i in range(lst.count()):
-            item = lst.item(i)
-            if contains(new, item.data(Qt.ItemDataRole.UserRole)):
-                item.setSelected(True)
-        lst.blockSignals(False)
+        # Mirror onto the table. Block signals so the programmatic selection
+        # doesn't retrigger itemSelectionChanged → update_highlighted_annotations,
+        # which would overwrite `new` with the table items' own (all_annotations)
+        # object identities. Match by value-equality on col 0's UserRole.
+        tbl = self.mw.annotation_list
+        tbl.blockSignals(True)
+        tbl.clearSelection()
+        last_col = tbl.columnCount() - 1
+        for i in range(tbl.rowCount()):
+            item = tbl.item(i, ANNOT_COL_ID)
+            if item is not None and contains(new, item.data(Qt.ItemDataRole.UserRole)):
+                # setRangeSelected is additive; selectRow() would *replace* the
+                # selection in ExtendedSelection mode, dropping all but the last.
+                tbl.setRangeSelected(
+                    QTableWidgetSelectionRange(i, 0, i, last_col), True
+                )
+        tbl.blockSignals(False)
 
         self._sync_selection_buttons(len(new))
         self.mw.image_label.update()
@@ -412,17 +510,19 @@ class AnnotationController(QObject):
         self.mw.auto_save()
 
     def highlight_annotation_in_list(self, annotation):
-        for i in range(self.mw.annotation_list.count()):
-            item = self.mw.annotation_list.item(i)
-            if item.data(Qt.ItemDataRole.UserRole) == annotation:
-                self.mw.annotation_list.setCurrentItem(item)
+        tbl = self.mw.annotation_list
+        for i in range(tbl.rowCount()):
+            item = tbl.item(i, ANNOT_COL_ID)
+            if item is not None and item.data(Qt.ItemDataRole.UserRole) == annotation:
+                tbl.selectRow(i)
                 break
 
     def select_annotation_in_list(self, annotation):
-        for i in range(self.mw.annotation_list.count()):
-            item = self.mw.annotation_list.item(i)
-            if item.data(Qt.ItemDataRole.UserRole) == annotation:
-                self.mw.annotation_list.setCurrentItem(item)
+        tbl = self.mw.annotation_list
+        for i in range(tbl.rowCount()):
+            item = tbl.item(i, ANNOT_COL_ID)
+            if item is not None and item.data(Qt.ItemDataRole.UserRole) == annotation:
+                tbl.selectRow(i)
                 break
 
     # --- Annotation numbering ---
@@ -440,19 +540,24 @@ class AnnotationController(QObject):
     # --- Delete / merge / change-class ---
 
     def delete_annotation(self):
-        current_item = self.mw.annotation_list.currentItem()
-        if current_item:
-            annotation = current_item.data(Qt.ItemDataRole.UserRole)
-            category_name = annotation["category_name"]
-            self.mw.image_label.annotations[category_name].remove(annotation)
-            self.mw.annotation_list.takeItem(
-                self.mw.annotation_list.row(current_item)
-            )
-            self.mw.image_label.highlighted_annotations.clear()
-            self.mw.image_label.update()
+        tbl = self.mw.annotation_list
+        row = tbl.currentRow()
+        if row < 0:
+            return
+        id_item = tbl.item(row, ANNOT_COL_ID)
+        if id_item is None:
+            return
+        annotation = id_item.data(Qt.ItemDataRole.UserRole)
+        category_name = annotation["category_name"]
+        anns = self.mw.image_label.annotations.get(category_name, [])
+        if annotation in anns:
+            anns.remove(annotation)
+        tbl.removeRow(row)
+        self.mw.image_label.highlighted_annotations.clear()
+        self.mw.image_label.update()
 
     def delete_selected_annotations(self):
-        selected_items = self.mw.annotation_list.selectedItems()
+        selected_items = self._selected_row_items()
         if not selected_items:
             QMessageBox.warning(
                 self.mw, "No Selection", "Please select an annotation to delete."
@@ -510,7 +615,7 @@ class AnnotationController(QObject):
             )
             return
 
-        selected_items = self.mw.annotation_list.selectedItems()
+        selected_items = self._selected_row_items()
         if len(selected_items) < 2:
             QMessageBox.warning(
                 self.mw,
@@ -642,7 +747,7 @@ class AnnotationController(QObject):
         self.mw.auto_save()
 
     def change_annotation_class(self):
-        selected_items = self.mw.annotation_list.selectedItems()
+        selected_items = self._selected_row_items()
         if not selected_items:
             QMessageBox.warning(
                 self.mw,
@@ -864,13 +969,8 @@ class AnnotationController(QObject):
         annotations = self.mw.image_label.annotations.get(class_name, [])
         number = max([ann.get("number", 0) for ann in annotations] + [0]) + 1
         annotation["number"] = number
-        area = calculate_area(annotation)
-        item_text = f"{class_name} - {number:<3} Area: {area:.2f}"
 
-        item = QListWidgetItem(item_text)
-        item.setData(Qt.ItemDataRole.UserRole, annotation)
-        item.setForeground(color)
-        self.mw.annotation_list.addItem(item)
+        self._insert_annotation_row(annotation, color)
 
         self.mw.annotation_list.clearSelection()
         self.mw.image_label.highlighted_annotations.clear()

--- a/src/digitalsreeni_image_annotator/controllers/annotation_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/annotation_controller.py
@@ -212,6 +212,15 @@ class AnnotationController(QObject):
         if area_item is not None:
             area_item.setText(f"{calculate_area(live):.2f}")
 
+        # Re-point the canvas selection at the mutated live object. Otherwise
+        # highlighted_annotations still holds the pre-simplify value, so the
+        # selection overlay draws stale geometry and a subsequent #40 handle
+        # drag (_live_annotation) can't re-match the row → edit lost.
+        hl = self.mw.image_label.highlighted_annotations
+        for i, a in enumerate(hl):
+            if a == captured:
+                hl[i] = live
+
         self.mw.image_label.update()
         self.save_current_annotations()
         self.mw.auto_save()

--- a/src/digitalsreeni_image_annotator/controllers/image_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/image_controller.py
@@ -895,7 +895,7 @@ class ImageController(QObject):
                 self.mw.image_file_name = ""
                 self.mw.current_slice = None
                 self.mw.image_label.clear()
-                self.mw.annotation_list.clear()
+                self.mw.annotation_list.setRowCount(0)
 
             if self.mw.image_list.count() > 0:
                 next_item = self.mw.image_list.item(0)
@@ -906,7 +906,7 @@ class ImageController(QObject):
                 self.mw.image_file_name = ""
                 self.mw.current_slice = None
                 self.mw.image_label.clear()
-                self.mw.annotation_list.clear()
+                self.mw.annotation_list.setRowCount(0)
                 self.mw.slice_list.clear()
 
             self.mw.update_ui()
@@ -947,7 +947,7 @@ class ImageController(QObject):
                     self.mw.image_file_name = ""
                     self.mw.current_slice = None
                     self.mw.image_label.clear()
-                    self.mw.annotation_list.clear()
+                    self.mw.annotation_list.setRowCount(0)
 
                 if self.mw.image_list.count() > 0:
                     next_item = self.mw.image_list.item(0)
@@ -958,7 +958,7 @@ class ImageController(QObject):
                     self.mw.image_file_name = ""
                     self.mw.current_slice = None
                     self.mw.image_label.clear()
-                    self.mw.annotation_list.clear()
+                    self.mw.annotation_list.setRowCount(0)
                     self.mw.slice_list.clear()
 
                 self.mw.update_ui()

--- a/src/digitalsreeni_image_annotator/core/constants.py
+++ b/src/digitalsreeni_image_annotator/core/constants.py
@@ -25,6 +25,14 @@ DEFAULT_ZOOM = 100
 # overlapping masks (the border still carries the class colour).
 DEFAULT_FILL_OPACITY = 0.2
 
+# Annotations panel table columns (issue #24). Column 0 (ID) carries the
+# annotation dict in its UserRole — the value-equality marker the canvas ↔ list
+# selection bridge (ADR-022) reads.
+ANNOT_COL_ID = 0
+ANNOT_COL_CLASS = 1
+ANNOT_COL_AREA = 2
+ANNOT_COL_DETAIL = 3
+
 # Default class colour palette (tab10-style, moderately muted so masks don't
 # overpower the image). Red is intentionally LAST so a fresh project's first
 # class isn't red — selection highlighting is class-colour-independent, but

--- a/src/digitalsreeni_image_annotator/ui/default_stylesheet.py
+++ b/src/digitalsreeni_image_annotator/ui/default_stylesheet.py
@@ -45,6 +45,19 @@ QListWidget::item:selected {
 }
 
 
+QTableWidget {
+    background-color: #FFFFFF;
+    color: #333333;
+    gridline-color: #CCCCCC;
+}
+
+
+QTableWidget::item:selected {
+    background-color: #CCE5FF;
+    color: #333333;
+}
+
+
 QHeaderView::section {
     background-color: #E0E0E0;
     color: #333333;

--- a/src/digitalsreeni_image_annotator/ui/sidebar.py
+++ b/src/digitalsreeni_image_annotator/ui/sidebar.py
@@ -13,15 +13,23 @@ from PyQt6.QtWidgets import (
     QButtonGroup,
     QComboBox,
     QHBoxLayout,
+    QHeaderView,
     QLabel,
     QListWidget,
     QPushButton,
     QScrollArea,
     QSlider,
+    QTableWidget,
     QVBoxLayout,
     QWidget,
 )
 
+from ..core.constants import (
+    ANNOT_COL_AREA,
+    ANNOT_COL_CLASS,
+    ANNOT_COL_DETAIL,
+    ANNOT_COL_ID,
+)
 from ..dialogs.dino_phrase_editor import ClassThresholdTable, PhraseEditorPanel
 
 
@@ -221,12 +229,29 @@ def build_sidebar(window):
     window.paint_brush_button.clicked.connect(window.toggle_tool)
     window.eraser_button.clicked.connect(window.toggle_tool)
 
-    # Annotations list subsection
+    # Annotations table subsection (issue #24). A 4-column table — ID | Class |
+    # Area | Detail % — mirroring the DINO ClassThresholdTable idiom (per-row
+    # spinbox via setCellWidget, stylesheet-only header). Column 0 holds the
+    # annotation dict in UserRole for the value-equality selection bridge.
     annotation_layout.addWidget(QLabel("Annotations"))
-    window.annotation_list = QListWidget()
-    window.annotation_list.setSelectionMode(
-        QAbstractItemView.SelectionMode.ExtendedSelection
+    table = QTableWidget(0, 4)
+    table.setHorizontalHeaderLabels(["ID", "Class", "Area", "Detail %"])
+    table.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
+    table.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
+    table.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
+    table.verticalHeader().setVisible(False)
+    table.verticalHeader().setSectionResizeMode(
+        QHeaderView.ResizeMode.ResizeToContents
     )
+    header = table.horizontalHeader()
+    header.setSectionResizeMode(ANNOT_COL_CLASS, QHeaderView.ResizeMode.Stretch)
+    for col in (ANNOT_COL_ID, ANNOT_COL_AREA, ANNOT_COL_DETAIL):
+        header.setSectionResizeMode(col, QHeaderView.ResizeMode.ResizeToContents)
+    # Structural only — header colours come from the active stylesheet's
+    # QHeaderView::section rule (No Hardcoded Colors Rule), so it matches both
+    # themes. See dino_phrase_editor.ClassThresholdTable.
+    table.setStyleSheet("QHeaderView::section { font-weight: bold; padding: 2px; }")
+    window.annotation_list = table
     window.annotation_list.itemSelectionChanged.connect(
         window.update_highlighted_annotations
     )

--- a/src/digitalsreeni_image_annotator/utils.py
+++ b/src/digitalsreeni_image_annotator/utils.py
@@ -169,8 +169,9 @@ def simplify_polygon(raw_segmentation, detail_pct):
     if perimeter <= 0:
         return raw
 
-    # Binary-search the approxPolyDP epsilon for the smallest polygon whose
-    # vertex count is still <= target (and >= 3). Higher epsilon -> fewer points.
+    # Binary-search the approxPolyDP epsilon for the *richest* polygon whose
+    # vertex count is still <= target (i.e. the smallest epsilon meeting the
+    # budget; >= 3 points). Higher epsilon -> fewer points.
     lo, hi = 0.0, perimeter
     best = None
     for _ in range(24):

--- a/src/digitalsreeni_image_annotator/utils.py
+++ b/src/digitalsreeni_image_annotator/utils.py
@@ -141,6 +141,54 @@ def clip_polygon_to_bounds(segmentation, width, height):
         coords = coords[:-1]
     return [c for point in coords for c in point]
 
+
+def simplify_polygon(raw_segmentation, detail_pct):
+    """Reduce the vertex count of a flat ``[x1, y1, ...]`` polygon (Douglas-
+    Peucker via ``cv2.approxPolyDP``) so users can trade detail for smaller
+    label files. ``detail_pct`` is 1..100 where **100 = the raw polygon
+    unchanged** and lower keeps proportionally fewer vertices. Operates on the
+    *raw* (dense) polygon so the result is always derived from full precision
+    and is reversible. (upstream #24)
+
+    Returns a flat list (>= 6 coords). Falls back to the raw polygon if it's
+    already tiny or simplification can't keep a valid triangle.
+    """
+    import cv2
+
+    raw = list(raw_segmentation)
+    n = len(raw) // 2
+    if detail_pct >= 100 or n <= 4:
+        return raw
+
+    target = max(3, round(n * detail_pct / 100.0))
+    if target >= n:
+        return raw
+
+    contour = np.array(raw, dtype=np.float32).reshape(-1, 1, 2)
+    perimeter = cv2.arcLength(contour, True)
+    if perimeter <= 0:
+        return raw
+
+    # Binary-search the approxPolyDP epsilon for the smallest polygon whose
+    # vertex count is still <= target (and >= 3). Higher epsilon -> fewer points.
+    lo, hi = 0.0, perimeter
+    best = None
+    for _ in range(24):
+        mid = (lo + hi) / 2.0
+        approx = cv2.approxPolyDP(contour, mid, True)
+        count = len(approx)
+        if count <= target:
+            if count >= 3:
+                best = approx
+            hi = mid  # try to keep more detail (smaller epsilon)
+        else:
+            lo = mid  # need more simplification
+    if best is None:
+        return raw
+    flat = best.flatten().tolist()
+    return flat if len(flat) >= 6 else raw
+
+
 def normalize_image(image_array):
     """Normalize image array to 8-bit range."""
     if image_array.dtype != np.uint8:

--- a/src/digitalsreeni_image_annotator/widgets/image_label.py
+++ b/src/digitalsreeni_image_annotator/widgets/image_label.py
@@ -1323,6 +1323,12 @@ class ImageLabel(QLabel):
                 )
             ann["segmentation"] = clamp_segmentation(seg, width, height)
             self._sync_bbox_key(ann)
+            # The polygon was reshaped — its old dense "raw" (issue #24) no
+            # longer describes it, so a later Detail %=100 must not revert this
+            # edit. Reset the simplification baseline to the edited geometry.
+            if ann.get("segmentation_raw"):
+                ann.pop("segmentation_raw", None)
+                ann["detail_pct"] = 100
         elif edit["mode"] == "move":
             ann["bbox"] = fit_bbox_inside(ann["bbox"], width, height)
         else:

--- a/tests/integration/test_annotation_table.py
+++ b/tests/integration/test_annotation_table.py
@@ -1,0 +1,118 @@
+"""Annotations table + reversible polygon simplification (issue #24).
+
+The bottom-left Annotations panel is a QTableWidget (ID | Class | Area |
+Detail %). Each row's Detail % spinbox re-simplifies that annotation's polygon
+from a lazily-captured raw copy; 100 % restores raw exactly. The simplified
+polygon persists (.iap) and is what exports emit; the raw is kept for reverting.
+
+One real offscreen ImageAnnotator; no model weights.
+"""
+
+import copy
+import json
+import math
+
+import pytest
+from PyQt6.QtWidgets import QSpinBox
+
+from digitalsreeni_image_annotator.core import image_utils
+from digitalsreeni_image_annotator.core.constants import (
+    ANNOT_COL_AREA,
+    ANNOT_COL_CLASS,
+    ANNOT_COL_DETAIL,
+    ANNOT_COL_ID,
+)
+from digitalsreeni_image_annotator.utils import calculate_area
+
+
+@pytest.fixture
+def window(qt_application):
+    from digitalsreeni_image_annotator.annotator_window import ImageAnnotator
+
+    w = ImageAnnotator()
+    yield w
+    w.deleteLater()
+
+
+def _circle(cx, cy, r, n):
+    seg = []
+    for i in range(n):
+        a = 2 * math.pi * i / n
+        seg += [round(cx + r * math.cos(a)), round(cy + r * math.sin(a))]
+    return seg
+
+
+def _seed(window, anns, monkeypatch):
+    monkeypatch.setattr(window, "auto_save", lambda: None)
+    window.image_file_name = "img.png"
+    window.current_slice = None
+    window.class_mapping = {"cell": 1}
+    window.all_annotations = {"img.png": {"cell": copy.deepcopy(anns)}}
+    window.image_label.annotations = copy.deepcopy(window.all_annotations["img.png"])
+    window.update_annotation_list()
+    return window.image_label.annotations["cell"]
+
+
+def _dense(number=1):
+    return {"segmentation": _circle(50, 50, 30, 60), "category_name": "cell",
+            "category_id": 1, "number": number}
+
+
+def test_table_populates_columns(window, monkeypatch):
+    _seed(window, [_dense(1)], monkeypatch)
+    tbl = window.annotation_list
+    assert tbl.rowCount() == 1
+    assert tbl.item(0, ANNOT_COL_ID).text() == "1"
+    assert tbl.item(0, ANNOT_COL_CLASS).text() == "cell"
+    float(tbl.item(0, ANNOT_COL_AREA).text())            # area is numeric
+    spin = tbl.cellWidget(0, ANNOT_COL_DETAIL)
+    assert isinstance(spin, QSpinBox) and spin.value() == 100
+
+
+def test_detail_change_simplifies_live_and_refreshes_area(window, monkeypatch):
+    (live,) = _seed(window, [_dense(1)], monkeypatch)
+    tbl = window.annotation_list
+    raw_len = len(live["segmentation"])
+
+    tbl.cellWidget(0, ANNOT_COL_DETAIL).setValue(30)      # fires the handler
+
+    assert len(live["segmentation"]) < raw_len            # thinned
+    assert live["segmentation_raw"] and len(live["segmentation_raw"]) == raw_len
+    assert live["detail_pct"] == 30
+    # Area cell tracks the (now simplified) polygon.
+    assert tbl.item(0, ANNOT_COL_AREA).text() == f"{calculate_area(live):.2f}"
+
+
+def test_back_to_100_restores_raw_exactly(window, monkeypatch):
+    (live,) = _seed(window, [_dense(1)], monkeypatch)
+    spin = window.annotation_list.cellWidget(0, ANNOT_COL_DETAIL)
+    spin.setValue(25)
+    assert len(live["segmentation"]) < len(live["segmentation_raw"])
+
+    spin.setValue(100)
+    assert live["segmentation"] == live["segmentation_raw"]  # raw restored exactly
+    assert live["detail_pct"] == 100
+
+
+def test_simplified_persists_and_exports_simplified(window, monkeypatch):
+    (live,) = _seed(window, [_dense(1)], monkeypatch)
+    window.annotation_list.cellWidget(0, ANNOT_COL_DETAIL).setValue(40)
+
+    # Persistence: project save does ann.copy() -> convert_to_serializable ->
+    # json. Both new keys must survive the round-trip.
+    roundtripped = json.loads(json.dumps(image_utils.convert_to_serializable(live)))
+    assert roundtripped["detail_pct"] == 40
+    assert roundtripped["segmentation_raw"] == live["segmentation_raw"]
+
+    # Export emits the *effective* (simplified) polygon, not the raw.
+    coco = window.annotation_controller.create_coco_annotation(live, 1, 1)
+    assert coco["segmentation"] == [live["segmentation"]]
+    assert coco["segmentation"][0] != live["segmentation_raw"]
+
+
+def test_bbox_only_row_has_disabled_spinbox(window, monkeypatch):
+    _seed(window, [{"bbox": [10, 10, 40, 40], "segmentation": None,
+                    "category_name": "cell", "category_id": 1, "number": 1}],
+          monkeypatch)
+    spin = window.annotation_list.cellWidget(0, ANNOT_COL_DETAIL)
+    assert isinstance(spin, QSpinBox) and not spin.isEnabled()

--- a/tests/integration/test_annotation_table.py
+++ b/tests/integration/test_annotation_table.py
@@ -13,6 +13,8 @@ import json
 import math
 
 import pytest
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QPixmap
 from PyQt6.QtWidgets import QSpinBox
 
 from digitalsreeni_image_annotator.core import image_utils
@@ -25,6 +27,11 @@ from digitalsreeni_image_annotator.core.constants import (
 from digitalsreeni_image_annotator.utils import calculate_area
 
 
+class _FakeEvent:
+    def modifiers(self):
+        return Qt.KeyboardModifier.NoModifier
+
+
 @pytest.fixture
 def window(qt_application):
     from digitalsreeni_image_annotator.annotator_window import ImageAnnotator
@@ -32,6 +39,16 @@ def window(qt_application):
     w = ImageAnnotator()
     yield w
     w.deleteLater()
+
+
+def _arm_canvas(window, live):
+    """Set up the image label for #40-style handle edits + select the mask."""
+    il = window.image_label
+    il.original_pixmap = QPixmap(100, 100)
+    il.zoom_factor = 1.0
+    il.ui_scale = 1.0
+    window.annotation_controller.apply_canvas_selection([live], "replace")
+    return il
 
 
 def _circle(cx, cy, r, n):
@@ -108,6 +125,35 @@ def test_simplified_persists_and_exports_simplified(window, monkeypatch):
     coco = window.annotation_controller.create_coco_annotation(live, 1, 1)
     assert coco["segmentation"] == [live["segmentation"]]
     assert coco["segmentation"][0] != live["segmentation_raw"]
+
+
+def test_reshape_invalidates_simplification_baseline(window, monkeypatch):
+    # #24 × #40 seam: thinning then reshaping a polygon must reset the raw
+    # baseline, so a later Detail %=100 can't silently revert the reshape.
+    (live,) = _seed(window, [_dense(1)], monkeypatch)
+    il = _arm_canvas(window, live)
+    window.annotation_list.cellWidget(0, ANNOT_COL_DETAIL).setValue(40)
+    assert live.get("segmentation_raw")               # raw captured by the thin
+
+    bb = il._annotation_bbox(live)                     # (x0, y0, x1, y1)
+    il._begin_shape_edit(live, "resize", "br", (bb[2], bb[3]))
+    il._update_bbox_drag((bb[2] + 8, bb[3] + 8))
+    il._commit_bbox_drag((bb[2] + 8, bb[3] + 8), _FakeEvent())
+
+    assert not live.get("segmentation_raw")           # baseline invalidated
+    assert live.get("detail_pct") == 100              # edited geometry is the new raw
+
+
+def test_detail_change_keeps_selection_resolvable_for_handle_drag(window, monkeypatch):
+    # #24 × #40 seam: after a detail change, the canvas selection must point at
+    # the mutated live object so the overlay + a later handle drag resolve it.
+    (live,) = _seed(window, [_dense(1)], monkeypatch)
+    il = _arm_canvas(window, live)
+    window.annotation_list.cellWidget(0, ANNOT_COL_DETAIL).setValue(30)
+
+    assert il.highlighted_annotations and il.highlighted_annotations[0] is live
+    shape = il._single_selected_shape()
+    assert il._live_annotation(shape) is live          # not a stale pre-thin copy
 
 
 def test_bbox_only_row_has_disabled_spinbox(window, monkeypatch):

--- a/tests/integration/test_annotation_table.py
+++ b/tests/integration/test_annotation_table.py
@@ -147,11 +147,22 @@ def test_reshape_invalidates_simplification_baseline(window, monkeypatch):
 def test_detail_change_keeps_selection_resolvable_for_handle_drag(window, monkeypatch):
     # #24 × #40 seam: after a detail change, the canvas selection must point at
     # the mutated live object so the overlay + a later handle drag resolve it.
+    # The bug only manifests for a LIST-driven selection, where
+    # update_highlighted_annotations stores a UserRole *copy* (not the live
+    # object) — so select through the table, not via apply_canvas_selection.
     (live,) = _seed(window, [_dense(1)], monkeypatch)
-    il = _arm_canvas(window, live)
+    il = window.image_label
+    il.original_pixmap = QPixmap(100, 100)
+    il.zoom_factor = 1.0
+    il.ui_scale = 1.0
+    window.annotation_list.selectRow(0)                # → update_highlighted_annotations
+    window.annotation_controller.update_highlighted_annotations()
+    assert il.highlighted_annotations[0] is not live   # a UserRole copy, by value
+
     window.annotation_list.cellWidget(0, ANNOT_COL_DETAIL).setValue(30)
 
-    assert il.highlighted_annotations and il.highlighted_annotations[0] is live
+    # The re-point loop must now make the selection the live, mutated object.
+    assert il.highlighted_annotations[0] is live
     shape = il._single_selected_shape()
     assert il._live_annotation(shape) is live          # not a stale pre-thin copy
 

--- a/tests/integration/test_bbox_edit_controller.py
+++ b/tests/integration/test_bbox_edit_controller.py
@@ -53,10 +53,11 @@ def _seed(window, anns):
 
 
 def _selected_data(window):
-    return [
-        item.data(Qt.ItemDataRole.UserRole)
-        for item in window.annotation_list.selectedItems()
-    ]
+    # The annotations widget is now a QTableWidget; selection is per-row, with
+    # the annotation dict in column 0's UserRole. Dedupe selected cells to rows.
+    tbl = window.annotation_list
+    rows = sorted({idx.row() for idx in tbl.selectedIndexes()})
+    return [tbl.item(r, 0).data(Qt.ItemDataRole.UserRole) for r in rows]
 
 
 def test_resize_persists_into_all_annotations(window, monkeypatch):
@@ -87,7 +88,7 @@ def test_list_selected_bbox_resize_persists(window, monkeypatch):
 
     # Select through the list widget — drives update_highlighted_annotations,
     # which stores item.data(UserRole) (a copy, distinct from `live`).
-    window.annotation_list.item(0).setSelected(True)
+    window.annotation_list.selectRow(0)
     window.annotation_controller.update_highlighted_annotations()
     assert il.highlighted_annotations and il.highlighted_annotations[0] is not live
 

--- a/tests/integration/test_canvas_selection_controller.py
+++ b/tests/integration/test_canvas_selection_controller.py
@@ -41,10 +41,11 @@ def _seed(window, anns):
 
 
 def _selected_data(window):
-    return [
-        item.data(Qt.ItemDataRole.UserRole)
-        for item in window.annotation_list.selectedItems()
-    ]
+    # The annotations widget is now a QTableWidget; selection is per-row, with
+    # the annotation dict in column 0's UserRole. Dedupe selected cells to rows.
+    tbl = window.annotation_list
+    rows = sorted({idx.row() for idx in tbl.selectedIndexes()})
+    return [tbl.item(r, 0).data(Qt.ItemDataRole.UserRole) for r in rows]
 
 
 def test_replace_selects_one(window):

--- a/tests/unit/test_polygon_simplify.py
+++ b/tests/unit/test_polygon_simplify.py
@@ -1,0 +1,67 @@
+"""Unit tests for reversible polygon simplification (issue #24).
+
+simplify_polygon (Douglas-Peucker via cv2.approxPolyDP) thins a dense polygon
+to a Detail % of its vertices, where 100 = the raw polygon unchanged. Pure, no
+Qt.
+"""
+
+import math
+
+from src.digitalsreeni_image_annotator.utils import simplify_polygon
+
+
+def _circle(cx, cy, r, n):
+    """A flat [x1,y1,...] polygon approximating a circle with n vertices."""
+    seg = []
+    for i in range(n):
+        a = 2 * math.pi * i / n
+        seg += [cx + r * math.cos(a), cy + r * math.sin(a)]
+    return seg
+
+
+def _npts(seg):
+    return len(seg) // 2
+
+
+def test_detail_100_returns_raw_unchanged():
+    seg = _circle(50, 50, 30, 60)
+    assert simplify_polygon(seg, 100) == seg
+
+
+def test_lower_detail_reduces_vertex_count_within_budget():
+    seg = _circle(50, 50, 30, 60)
+    out = simplify_polygon(seg, 50)
+    assert _npts(out) <= 30                 # <= round(60 * 50/100)
+    assert _npts(out) >= 3
+    assert len(out) % 2 == 0 and len(out) >= 6
+
+
+def test_more_aggressive_keeps_fewer_points():
+    seg = _circle(50, 50, 30, 60)
+    coarse = simplify_polygon(seg, 15)
+    fine = simplify_polygon(seg, 60)
+    assert _npts(coarse) <= _npts(fine)
+
+
+def test_does_not_mutate_input():
+    seg = _circle(50, 50, 30, 40)
+    snapshot = list(seg)
+    simplify_polygon(seg, 30)
+    assert seg == snapshot                   # raw is preserved for reversibility
+
+
+def test_tiny_polygon_unchanged():
+    tri = [0, 0, 10, 0, 5, 10]               # 3 points — nothing to simplify
+    assert simplify_polygon(tri, 10) == tri
+    square = [0, 0, 10, 0, 10, 10, 0, 10]    # 4 points
+    assert simplify_polygon(square, 10) == square
+
+
+def test_result_is_a_valid_subset_shape():
+    # A coarse simplification of a circle should still be a sensible polygon
+    # bounded by the original extent.
+    seg = _circle(50, 50, 30, 60)
+    out = simplify_polygon(seg, 20)
+    xs, ys = out[0::2], out[1::2]
+    assert min(xs) >= 19 and max(xs) <= 81   # within the circle's bounds (+/- 1)
+    assert min(ys) >= 19 and max(ys) <= 81


### PR DESCRIPTION
## Summary

Closes the remaining piece of upstream **#24** — the *"mask complexity — less ↔ more points"* control. (The add-point / remove-point half of #24 was already covered by the SAM-points tool, confirmed by GUI testing.)

SAM/DINO masks are stored as raw dense polygons (`_mask_to_polygon` returns the full `cv2.findContours` boundary, hundreds of vertices). This adds a **per-annotation, reversible Detail %** control so users can thin a mask for smaller label files and return to full precision at any time.

## What's new

- **Annotations panel is now a table** (ID | Class | Area | **Detail %**), mirroring the DINO threshold-table idiom (per-row spinbox, `SelectRows`, `NoEditTriggers`, stylesheet-only header). Per the requested design — tune each annotation independently.
- **Detail % spinbox per row** (1–100, **100 = raw**). Lower keeps proportionally fewer vertices via Douglas-Peucker (`utils.simplify_polygon`). The mask thins live and the Area updates; set back to 100 to restore the raw polygon **exactly**.
- **Reversible**: the dense original is lazy-captured into `segmentation_raw` the first time a mask is thinned; nothing simplifies it before that, so no accept-path changes were needed. `segmentation_raw` + `detail_pct` round-trip through `.iap`; exports emit the effective (simplified) `segmentation`.

## Implementation notes

- The annotations widget conversion (`QListWidget` → `QTableWidget`) re-homes the #75 canvas↔list selection bridge: the annotation lives in **column 0's UserRole** (value-equality marker); the mirror uses **`setRangeSelected`** (additive — `selectRow()` *replaces* in `ExtendedSelection`); `blockSignals` + value-equality preserved.
- `on_detail_pct_changed` resolves the live drawn object (`_live_annotation`, reused from #40), mutates in place, refreshes Area + UserRole + the canvas selection, and saves.
- **#24 × #40 seam handled**: reshaping a thinned polygon with the #40 handles invalidates the stale raw baseline (the edited geometry becomes the new raw), and the detail handler re-points `highlighted_annotations` so the overlay + a later handle drag stay coherent.

## Testing
- **261 passed, 3 skipped**; ruff clean on changed files; smoke green.
- New: `test_polygon_simplify.py` (simplify math, reversibility, no-mutation) + `test_annotation_table.py` (table populate, live simplify + area refresh, restore-to-raw, `.iap` round-trip, export-emits-simplified, bbox-only disabled spinbox, and the two #24×#40 seam guards). Existing #75/#40 selection tests adapted to the table.
- **Two senior-review rounds**: R1 caught two P1s at the #24×#40 seam (orphaned raw on reshape; stale highlight) — fixed. R2 confirmed the fixes and flagged a weak guard test + dead `delete_annotation` — both addressed.

## Docs
ADR-025 (reversible simplification + the table re-homing of the selection bridge), runtime view, crosscutting concepts, glossary; CLAUDE.md pattern row. The temp **Upstream Issue Backlog** section was reconciled per your standing request — dropped the now-closed #24 and the already-closed #63, added the new #74 (MLflow), leaving #74 + #35.

> ℹ️ Interactive feature — worth a GUI pass before merge: SAM/DINO a mask → Annotations table → dial Detail % down (mask thins, Area updates) → back to 100 (raw restored); save/reopen `.iap`; light + dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
