### PR TITLE
feat: Configurable train/val split in YOLO export (#83)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@ models/
 *.onnx
 *.safetensors
 
+# Ultralytics' default training output dir (in-app YOLO training routes into
+# models/yolo/custom instead, but a stray CLI/fallback run can still land here)
+runs/
+
 # User project files
 *.iap
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,8 +48,8 @@ Issue numbers refer to https://github.com/bnsreenu/digitalsreeni-image-annotator
 
 | Issue | Size | Task |
 |-------|------|------|
-| #74 | large | MLflow experiment tracking for model training (SAM fine-tuning / YOLO) |
 | #35 | large | Keypoint annotation tool |
+| #85 | large | Train/val split + both-loss tracking + LR warmup→cosine schedule + early stopping (SAM fine-tuning & YOLO) |
 
 ## Project Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Issue numbers refer to https://github.com/bnsreenu/digitalsreeni-image-annotator
 | Issue | Size | Task |
 |-------|------|------|
 | #35 | large | Keypoint annotation tool |
-| #85 | large | Train/val split + both-loss tracking + LR warmup→cosine schedule + early stopping (SAM fine-tuning & YOLO) |
+| #85 | large | Train/val split + both-loss tracking + LR warmup->cosine schedule + early stopping (SAM fine-tuning & YOLO) |
 
 ## Project Structure
 

--- a/docs/05_building_block_view.md
+++ b/docs/05_building_block_view.md
@@ -232,7 +232,7 @@ the controller graph.
 | `ClassController` | Class add / delete / rename / colour / visibility. `update_slice_list_colors`, `is_class_visible`. |
 | `SAMController` | SAM box/points tool lifecycle, debounce timer, `_sam_inference_in_flight` re-entrancy guard (ADR-013), model picker. |
 | `DINOController` | Single + batch detection, batch review navigation, temp-annotation accept/reject, custom-model browse, `DINOReviewEventFilter` ownership (ADR-015). |
-| `YOLOController` | Training menu, `TrainingThread`, prediction dialog, result processing. |
+| `YOLOController` | Training menu, `TrainingThread`, prediction dialog, result processing. Surfaces the run's MLflow deep link (`_on_mlflow_run_url`, mirrors SAM) and reports the saved `best.pt` path on completion. |
 | `SAMTrainController` | SAM fine-tuning menu, GPU gate, `SAMTrainingThread`, config dialog, registers fine-tuned checkpoints into the SAM selector (ADR-021). |
 | `io_controller` *(module-level functions, not a class)* | Thin UI wrappers around the pure `io/export_formats.py` and `io/import_formats.py` modules. |
 
@@ -285,7 +285,7 @@ Each tool is a standalone dialog/window:
 | `slice_registration.py` | Align slices | Multiple registration algorithms (pystackreg) |
 | `stack_interpolator.py` | Z-spacing adjustment | Interpolation methods, memory-efficient |
 | `dicom_converter.py` | DICOM to TIFF | Preserve metadata, export to JSON |
-| `yolo_trainer.py` | Model training | Train YOLO, load predictions |
+| `yolo_trainer.py` | Model training | Train YOLO (run → `models/yolo/custom/<project>`, pruned to `best.pt`+`data.yaml` when MLflow has the diagnostics), `list_custom_yolo_models` for the prediction dropdown, `mlflow_run_url` signal, load predictions |
 
 ## Data Model
 

--- a/docs/06_runtime_view.md
+++ b/docs/06_runtime_view.md
@@ -444,7 +444,7 @@ User clicks "Export" > "YOLO v8/v11"
     │   ├─> For each annotated image:
     │   │   │
     │   │   ├─> Copy image to the train or val split it was assigned to
-    │   │   │   (val_split == 0 → everything in train, the original behaviour)
+    │   │   │   (val_split == 0 -> everything in train, the original behaviour)
     │   │   │
     │   │   ├─> Convert annotations to YOLO format:
     │   │   │   │
@@ -501,3 +501,46 @@ User: SAM Fine-Tune (beta) > Train on Current Project…
 Offline variant: "Prepare SAM Dataset…" → export_sam_dataset (images/ + manifest.json),
 then "Train from Dataset Folder…" → build_groups_from_folder → same training path.
 ```
+
+## In-app YOLO Training (annotate → train → predict)
+
+Mirrors the SAM fine-tuning loop's "train then use" shape: a run lands in a
+predictable, per-project folder and is then selectable for prediction.
+
+```
+User: YOLO (beta) > Training > Train Model
+    │
+    ├─> _configure_mlflow(): set MLFLOW_TRACKING_URI (file:// URI), enable the
+    │       Ultralytics mlflow setting  (no link yet — just the store path line)
+    │
+    └─> TrainingThread → YOLOTrainer.train_model(epochs, imgsz)
+            │  _resolve_training_yaml → temp_train.yaml (honors the train/val split)
+            │  model.train(..., project=models/yolo/custom, name=<project>)
+            │     ├─ on_train_epoch_end (epoch 1): _emit_mlflow_url()
+            │     │     mlflow.active_run() is set (Ultralytics started it in
+            │     │     on_pretrain_routine_end) → emit mlflow_run_url(deep link)
+            │     │       → YOLOController._on_mlflow_run_url: clickable link in
+            │     │         the dialog + start MLflow UI server once + open browser
+            │     └─ per-epoch progress_signal → TrainingInfoDialog
+            │  _register_trained_model(): from trainer.best (fallback save_dir),
+            │     write sibling data.yaml (class names) → last_saved_model_path
+            │     _prune_run_artifacts(): if the run was MLflow-tracked, delete
+            │       everything except best.pt + data.yaml — Ultralytics' MLflow
+            │       callback already logged the full run dir (weights + plots +
+            │       csv) into the run, so the local diagnostics are redundant.
+            │       (Not tracked → keep the whole folder; it lives nowhere else.)
+            │
+            └─> training_finished: report the saved best.pt path in the dialog.
+                Prediction > Load Model lists it via list_custom_yolo_models()
+                ("★ <project>"), pre-filling model + yaml → predict.
+```
+
+Output lands in `models/yolo/custom/<project>/weights/best.pt` (Ultralytics
+auto-increments on collision), **not** the default `./runs` — parallel to SAM's
+`models/sam/custom`. After a tracked run the folder is pruned to `best.pt` +
+`data.yaml` (the diagnostics — curves, confusion matrix, batch mosaics,
+`results.csv` — remain in the MLflow run via Ultralytics' `on_train_end`
+`log_artifact`). The MLflow link path reuses the SAM machinery
+(`run_ui_url`, `start_mlflow_ui_server`); the only difference is YOLO reads the
+run id from Ultralytics' *native* MLflow callback rather than the in-process
+`MLflowTracker`.

--- a/docs/06_runtime_view.md
+++ b/docs/06_runtime_view.md
@@ -424,21 +424,27 @@ User clicks "Export" > "YOLO v8/v11"
     │
     ├─> Select output directory
     │
-    ├─> export_yolo_v5plus(all_annotations, class_mapping, ...)
+    ├─> Prompt for validation split % (QInputDialog, default 20, 0 = all train)
+    │       assign_train_val() deterministically partitions the annotated
+    │       images via a stable filename hash; the val count is exact so a
+    │       requested split is never silently empty (issue #83)
+    │
+    ├─> export_yolo_v5plus(all_annotations, class_mapping, ..., val_split)
     │   │
     │   ├─> Create directory structure:
     │   │   output_dir/
     │   │   ├── data.yaml
-    │   │   ├── train/
-    │   │   │   ├── images/
-    │   │   │   └── labels/
-    │   │   └── valid/
-    │   │       ├── images/
-    │   │       └── labels/
+    │   │   ├── images/
+    │   │   │   ├── train/
+    │   │   │   └── val/
+    │   │   └── labels/
+    │   │       ├── train/
+    │   │       └── val/
     │   │
     │   ├─> For each annotated image:
     │   │   │
-    │   │   ├─> Copy image to train/images/ or valid/images/
+    │   │   ├─> Copy image to the train or val split it was assigned to
+    │   │   │   (val_split == 0 → everything in train, the original behaviour)
     │   │   │
     │   │   ├─> Convert annotations to YOLO format:
     │   │   │   │
@@ -451,8 +457,8 @@ User clicks "Export" > "YOLO v8/v11"
     │   │   └─> Next image
     │   │
     │   ├─> Write data.yaml:
-    │   │   train: train/images
-    │   │   val: valid/images
+    │   │   train: images/train
+    │   │   val: images/val
     │   │   nc: num_classes
     │   │   names: [class1, class2, ...]
     │   │

--- a/src/digitalsreeni_image_annotator/controllers/io_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/io_controller.py
@@ -12,7 +12,7 @@ inside `annotator_window.py` delegate trivially.
 import os
 
 from PyQt6.QtGui import QColor
-from PyQt6.QtWidgets import QFileDialog, QMessageBox
+from PyQt6.QtWidgets import QFileDialog, QInputDialog, QMessageBox
 
 from ..core.constants import default_class_color
 
@@ -224,6 +224,19 @@ def export_annotations(mw):
     if not file_name:
         return
 
+    # YOLO training needs a non-empty validation set; let the user choose how
+    # much of the data to hold out (0 keeps the historical all-in-train layout).
+    val_split = 0
+    if export_format in ("YOLO (v4 and earlier)", "YOLO (v5+)"):
+        val_split, ok = QInputDialog.getInt(
+            mw,
+            "Validation Split",
+            "Percent of images for the validation set (0 = all in train):",
+            20, 0, 100, 5,
+        )
+        if not ok:
+            return
+
     mw.save_current_annotations()
 
     if export_format == "COCO JSON":
@@ -249,9 +262,10 @@ def export_annotations(mw):
             mw.slices,
             mw.image_slices,
             file_name,
+            val_split,
         )
         message = "Annotations have been exported successfully in YOLO (v4 and earlier) format.\n"
-        message += f"Labels: {labels_dir}\nYAML: {yaml_path}"
+        message += f"Labels: {labels_dir}\nYAML: {yaml_path}\nValidation split: {val_split}%"
 
     elif export_format == "YOLO (v5+)":
         output_dir, yaml_path = export_yolo_v5plus(
@@ -261,9 +275,10 @@ def export_annotations(mw):
             mw.slices,
             mw.image_slices,
             file_name,
+            val_split,
         )
         message = "Annotations have been exported successfully in YOLO (v5+) format.\n"
-        message += f"Output directory: {output_dir}\nYAML: {yaml_path}"
+        message += f"Output directory: {output_dir}\nYAML: {yaml_path}\nValidation split: {val_split}%"
 
     elif export_format == "Labeled Images":
         labeled_images_dir = export_labeled_images(

--- a/src/digitalsreeni_image_annotator/controllers/io_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/io_controller.py
@@ -28,6 +28,21 @@ from ..io.export_formats import (
 from ..io.import_formats import import_coco_json, process_import_format
 
 
+def prompt_validation_split(parent):
+    """Ask what fraction of images to hold out for validation.
+
+    Returns ``(val_split, ok)`` from a single shared QInputDialog so the YOLO
+    menu export and the in-app YOLO trainer can't drift apart. ``0`` keeps the
+    historical all-in-train layout.
+    """
+    return QInputDialog.getInt(
+        parent,
+        "Validation Split",
+        "Percent of images for the validation set (0 = all in train):",
+        20, 0, 100, 5,
+    )
+
+
 def import_annotations(mw):
     if not mw.image_label.check_unsaved_changes():
         return
@@ -228,12 +243,7 @@ def export_annotations(mw):
     # much of the data to hold out (0 keeps the historical all-in-train layout).
     val_split = 0
     if export_format in ("YOLO (v4 and earlier)", "YOLO (v5+)"):
-        val_split, ok = QInputDialog.getInt(
-            mw,
-            "Validation Split",
-            "Percent of images for the validation set (0 = all in train):",
-            20, 0, 100, 5,
-        )
+        val_split, ok = prompt_validation_split(mw)
         if not ok:
             return
 

--- a/src/digitalsreeni_image_annotator/controllers/yolo_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/yolo_controller.py
@@ -140,12 +140,9 @@ class YOLOController(QObject):
 
         # YOLO training needs a non-empty validation set; hold some images out
         # by default (0 keeps everything in train, but val/ will then be empty).
-        val_split, ok = QInputDialog.getInt(
-            self.mw,
-            "Validation Split",
-            "Percent of images for the validation set (0 = all in train):",
-            20, 0, 100, 5,
-        )
+        from .io_controller import prompt_validation_split
+
+        val_split, ok = prompt_validation_split(self.mw)
         if not ok:
             return
 

--- a/src/digitalsreeni_image_annotator/controllers/yolo_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/yolo_controller.py
@@ -138,12 +138,24 @@ class YOLOController(QObject):
         if not self.mw.yolo_trainer:
             self.initialize_yolo_trainer()
 
+        # YOLO training needs a non-empty validation set; hold some images out
+        # by default (0 keeps everything in train, but val/ will then be empty).
+        val_split, ok = QInputDialog.getInt(
+            self.mw,
+            "Validation Split",
+            "Percent of images for the validation set (0 = all in train):",
+            20, 0, 100, 5,
+        )
+        if not ok:
+            return
+
         try:
-            yaml_path = self.mw.yolo_trainer.prepare_dataset()
+            yaml_path = self.mw.yolo_trainer.prepare_dataset(val_split)
             QMessageBox.information(
                 self.mw,
                 "Dataset Prepared",
-                f"YOLO dataset prepared successfully. YAML file: {yaml_path}",
+                f"YOLO dataset prepared successfully ({val_split}% validation).\n"
+                f"YAML file: {yaml_path}",
             )
         except Exception as e:
             QMessageBox.critical(

--- a/src/digitalsreeni_image_annotator/controllers/yolo_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/yolo_controller.py
@@ -67,6 +67,9 @@ class YOLOController(QObject):
     def __init__(self, main_window):
         super().__init__(main_window)
         self.mw = main_window
+        # Latched after the MLflow UI server is started once for the session
+        # (mirrors SAMTrainController); a failed launch leaves it False to retry.
+        self._mlflow_ui_started = False
 
     def setup_yolo_menu(self):
         yolo_menu = self.mw.menuBar().addMenu("&YOLO (beta)")
@@ -365,6 +368,7 @@ class YOLOController(QObject):
         self.mw.yolo_trainer.progress_signal.connect(
             self.mw.training_dialog.update_info
         )
+        self.mw.yolo_trainer.mlflow_run_url.connect(self._on_mlflow_run_url)
         self.mw.yolo_trainer.set_progress_callback(self.mw.training_dialog.update_info)
         self.mw.training_dialog.stop_signal.connect(
             self.mw.yolo_trainer.stop_training_signal
@@ -374,17 +378,58 @@ class YOLOController(QObject):
         self.mw.training_thread.finished.connect(self.training_finished)
         self.mw.training_thread.start()
 
+    def _on_mlflow_run_url(self, url):
+        """The YOLO run has opened in MLflow (signalled from the worker thread;
+        this runs on the GUI thread). Show a clickable link in the progress
+        dialog, start the MLflow UI server once, and open the run in the
+        browser. Mirrors SAMTrainController._on_mlflow_run_url; tracking display
+        must never disturb the run, so it is best-effort and self-contained."""
+        import webbrowser
+
+        from PyQt6.QtCore import QTimer
+
+        from ..training.mlflow_tracker import (
+            resolve_tracking_uri,
+            start_mlflow_ui_server,
+        )
+
+        dlg = getattr(self.mw, "training_dialog", None)
+        if dlg is not None:
+            dlg.update_info_link("🔗 Open this run in MLflow", url)
+        try:
+            if not self._mlflow_ui_started:
+                ok, _ = start_mlflow_ui_server(
+                    resolve_tracking_uri(self.mw),
+                    log=dlg.update_info if dlg is not None else None,
+                )
+                # Latch only on success so a failed launch retries next run.
+                self._mlflow_ui_started = ok
+                # Give a cold-started server a moment before opening the tab so
+                # the browser doesn't land on a connection error. (Non-blocking.)
+                QTimer.singleShot(2500 if ok else 0, lambda: webbrowser.open(url))
+            else:
+                webbrowser.open(url)
+        except Exception as exc:
+            print(f"Could not open MLflow UI for the run: {exc}")
+
     def training_finished(self, results):
         # Training is over — hide Stop entirely (only Close remains); the next
         # run re-shows it in start_training.
         self.mw.training_dialog.stop_button.hide()
         self.mw.training_dialog.stop_button.setText("Stop Training")
-        self.mw.yolo_trainer.progress_signal.disconnect(
-            self.mw.training_dialog.update_info
-        )
-        self.mw.training_dialog.stop_signal.disconnect(
-            self.mw.yolo_trainer.stop_training_signal
-        )
+        # One guard around all three so a partial teardown (double-fire / error
+        # path) can't leak a still-connected signal into the next run — mirrors
+        # SAMTrainController.training_finished.
+        try:
+            self.mw.yolo_trainer.progress_signal.disconnect(
+                self.mw.training_dialog.update_info
+            )
+            self.mw.yolo_trainer.mlflow_run_url.disconnect(self._on_mlflow_run_url)
+            self.mw.training_dialog.stop_signal.disconnect(
+                self.mw.yolo_trainer.stop_training_signal
+            )
+        except TypeError:
+            pass  # already disconnected
 
         if isinstance(results, str):
             QMessageBox.critical(
@@ -393,10 +438,17 @@ class YOLOController(QObject):
                 f"An error occurred during training: {results}",
             )
         else:
+            saved = getattr(self.mw.yolo_trainer, "last_saved_model_path", None)
+            where = (
+                f"\n\nSaved to:\n{saved}\n\nIt's now selectable under "
+                "Prediction Settings → Load Model."
+                if saved
+                else ""
+            )
             QMessageBox.information(
                 self.mw,
                 "Training Complete",
-                "YOLO model training completed successfully.",
+                f"YOLO model training completed successfully.{where}",
             )
 
     def set_confidence_threshold(self):

--- a/src/digitalsreeni_image_annotator/dialogs/yolo_trainer.py
+++ b/src/digitalsreeni_image_annotator/dialogs/yolo_trainer.py
@@ -129,20 +129,21 @@ class YOLOTrainer(QObject):
                 QMessageBox.critical(self.main_window, "Error Loading Model", f"Could not load the model. Error: {str(e)}")
         return False
 
-    def prepare_dataset(self):
+    def prepare_dataset(self, val_split=20):
         output_dir, yaml_path = export_yolo_v5plus(
             self.main_window.all_annotations,
             self.main_window.class_mapping,
             self.main_window.image_paths,
             self.main_window.slices,
             self.main_window.image_slices,
-            self.dataset_path
+            self.dataset_path,
+            val_split,
         )
-        
+
         yaml_path = Path(yaml_path)
         with yaml_path.open('r', encoding='utf-8') as f:
             yaml_content = yaml.safe_load(f)
-        
+
         # Update paths for new YOLO v5+ structure
         yaml_content['train'] = 'images/train'  # Changed from train/images
         yaml_content['val'] = 'images/val'      # Changed from train/images

--- a/src/digitalsreeni_image_annotator/dialogs/yolo_trainer.py
+++ b/src/digitalsreeni_image_annotator/dialogs/yolo_trainer.py
@@ -255,13 +255,19 @@ class YOLOTrainer(QObject):
                 yaml_content = yaml.safe_load(f)
             print(f"YAML content: {yaml_content}")
             
-            # For now, use train as val since we don't have separate validation set
-            train_dir = str(yaml_dir / 'images' / 'train')
-            
-            # Update YAML content with correct paths
-            yaml_content['train'] = train_dir
-            yaml_content['val'] = train_dir  # Use same directory for validation
-            
+            # Honor the train/val split written by prepare_dataset /
+            # export_yolo_v5plus. The export already points `val` at images/val
+            # when a held-out set was routed there, and falls back to images/train
+            # when it wasn't (val_split=0 or a single-image project) — so reading
+            # the yaml's own pointers (rather than forcing val=train as before)
+            # keeps the user's split while never feeding YOLO an empty val dir.
+            train_rel = yaml_content.get('train', os.path.join('images', 'train'))
+            val_rel = yaml_content.get('val', train_rel)  # export fallback ⇒ never empty
+            yaml_content['train'] = str((yaml_dir / train_rel).resolve())
+            yaml_content['val'] = str((yaml_dir / val_rel).resolve())
+            # train/val are now absolute; drop the now-redundant dataset root.
+            yaml_content.pop('path', None)
+
             # Create the val directory structure if it doesn't exist
             val_img_dir = yaml_dir / 'images' / 'val'
             val_label_dir = yaml_dir / 'labels' / 'val'

--- a/src/digitalsreeni_image_annotator/dialogs/yolo_trainer.py
+++ b/src/digitalsreeni_image_annotator/dialogs/yolo_trainer.py
@@ -1,11 +1,12 @@
 import os
 from PyQt6.QtWidgets import QFileDialog, QMessageBox
 from PyQt6.QtWidgets import (QDialog, QVBoxLayout, QHBoxLayout, QPushButton,
-                             QLineEdit, QLabel, QDialogButtonBox)
+                             QLineEdit, QLabel, QDialogButtonBox, QComboBox)
 import yaml
 import numpy as np
 from pathlib import Path
 from ..io.export_formats import export_yolo_v5plus
+from ..utils import models_base_dir
 
 
 from collections import deque
@@ -14,6 +15,40 @@ from collections import deque
 from PyQt6.QtWidgets import QTextBrowser
 from PyQt6.QtGui import QPalette, QTextCharFormat, QTextCursor
 from PyQt6.QtCore import pyqtSignal, QObject
+
+
+# Trained YOLO checkpoints land here, namespaced per run, mirroring SAM's
+# ``models/sam/custom`` layout (see training.sam_trainer.SAM_CUSTOM_DIR). Each
+# run is its own ``<name>/`` sub-dir holding Ultralytics' ``weights/best.pt``
+# plus a ``data.yaml`` (class names) so the prediction loader has both halves
+# it needs without the user hunting through ``runs/``.
+YOLO_MODELS_DIR = os.path.join(models_base_dir(), "yolo")
+YOLO_CUSTOM_DIR = os.path.join(YOLO_MODELS_DIR, "custom")
+
+
+def _sanitize_run_name(name):
+    """Filesystem-safe run name; falls back to ``model`` when empty."""
+    safe = "".join(c if c.isalnum() or c in "-_" else "_" for c in str(name)).strip("_")
+    return safe or "model"
+
+
+def list_custom_yolo_models() -> dict:
+    """``{display_name: (model_path, yaml_path)}`` for trained YOLO models.
+
+    Scans ``YOLO_CUSTOM_DIR`` for run folders that produced a ``best.pt``; the
+    sibling ``data.yaml`` (written at train time) supplies the class names the
+    prediction loader validates against. Used to populate the Load-Model
+    dialog's dropdown so a freshly trained model is selectable without browsing.
+    """
+    out = {}
+    if os.path.isdir(YOLO_CUSTOM_DIR):
+        for entry in sorted(os.listdir(YOLO_CUSTOM_DIR)):
+            run_dir = os.path.join(YOLO_CUSTOM_DIR, entry)
+            best = os.path.join(run_dir, "weights", "best.pt")
+            if os.path.isfile(best):
+                yml = os.path.join(run_dir, "data.yaml")
+                out[f"★ {entry}"] = (best, yml if os.path.isfile(yml) else "")
+    return out
 
 
 def _resolve_training_yaml(yaml_dir, yaml_content):
@@ -116,6 +151,21 @@ class LoadPredictionModelDialog(QDialog):
 
         layout = QVBoxLayout(self)
 
+        # Trained-models dropdown — auto-discovered from models/yolo/custom so a
+        # freshly trained run is one click away (browsing below stays available
+        # for external models). Maps each entry to its (model, yaml) pair.
+        self._trained = list_custom_yolo_models()
+        if self._trained:
+            trained_layout = QHBoxLayout()
+            self.trained_combo = QComboBox()
+            self.trained_combo.addItem("— select a trained model —", None)
+            for display, paths in self._trained.items():
+                self.trained_combo.addItem(display, paths)
+            self.trained_combo.currentIndexChanged.connect(self._on_trained_selected)
+            trained_layout.addWidget(QLabel("Trained Model:"))
+            trained_layout.addWidget(self.trained_combo)
+            layout.addLayout(trained_layout)
+
         # Model file selection
         model_layout = QHBoxLayout()
         self.model_edit = QLineEdit()
@@ -153,9 +203,24 @@ class LoadPredictionModelDialog(QDialog):
         if file_name:
             self.yaml_path = file_name
             self.yaml_edit.setText(file_name)
-        
+
+    def _on_trained_selected(self, _index):
+        """Fill model + yaml from the chosen trained run (placeholder clears)."""
+        paths = self.trained_combo.currentData()
+        if not paths:
+            return
+        model_path, yaml_path = paths
+        self.model_path = model_path
+        self.model_edit.setText(model_path)
+        self.yaml_path = yaml_path
+        self.yaml_edit.setText(yaml_path)
+
 class YOLOTrainer(QObject):
     progress_signal = pyqtSignal(str)
+    # Emitted once per run with the MLflow UI deep link, mirroring the SAM
+    # fine-tuner's signal of the same name so the controller can show a
+    # clickable link / open the run (see YOLOController._on_mlflow_run_url).
+    mlflow_run_url = pyqtSignal(str)
 
     def __init__(self, project_dir, main_window):
         super().__init__()
@@ -172,6 +237,12 @@ class YOLOTrainer(QObject):
         self.conf_threshold = 0.25
         self.stop_training = False
         self.class_names = None
+        # Set by train_model() once a run finishes, so the controller can tell
+        # the user where the checkpoint landed and offer it for prediction.
+        self.last_saved_model_path = None
+        self.last_saved_yaml_path = None
+        # Latched so the per-epoch callback emits the MLflow link only once.
+        self._mlflow_url_emitted = False
 
     def load_model(self, model_path=None):
         from ultralytics import YOLO
@@ -246,15 +317,42 @@ class YOLOTrainer(QObject):
         total_epochs = trainer.epochs
         loss = trainer.loss.item()
         progress_text = f"Epoch {epoch}/{total_epochs}, Loss: {loss:.4f}"
-        
+
         # Only emit the signal, don't call the callback directly
         self.progress_signal.emit(progress_text)
-        
+        self._emit_mlflow_url()
+
         if self.stop_training:
             trainer.model.stop = True
             self.stop_training = False
             return False
         return True
+
+    def _emit_mlflow_url(self):
+        """Emit the MLflow run's UI deep link, once per run.
+
+        Ultralytics' native MLflow callback starts the run in
+        ``on_pretrain_routine_end`` (before any epoch), so by the first
+        ``on_train_epoch_end`` ``mlflow.active_run()`` is populated regardless
+        of callback ordering. We read its run/experiment ids and hand the
+        controller the same deep link the SAM path builds. Best-effort: a
+        tracking hiccup must never disturb the run."""
+        if self._mlflow_url_emitted:
+            return
+        try:
+            import mlflow
+
+            run = mlflow.active_run()
+            if run is None:
+                return
+            from ..training.mlflow_tracker import run_ui_url
+
+            self._mlflow_url_emitted = True
+            self.mlflow_run_url.emit(
+                run_ui_url(run.info.experiment_id, run.info.run_id)
+            )
+        except Exception as exc:
+            print(f"Could not resolve MLflow run link for YOLO training: {exc}")
     
     def train_model(self, epochs=100, imgsz=640):
         if self.model is None:
@@ -265,17 +363,20 @@ class YOLOTrainer(QObject):
         self.stop_training = False
         self.total_epochs = epochs
         self.epoch_info.clear()
-        
+        self._mlflow_url_emitted = False
+        self.last_saved_model_path = None
+        self.last_saved_yaml_path = None
+
         # Add the callback
         self.model.add_callback("on_train_epoch_end", self.on_train_epoch_end)
-        
+
         try:
             yaml_path = Path(self.yaml_path)
             yaml_dir = yaml_path.parent
-            
+
             print(f"Training with YAML: {yaml_path}")
             print(f"YAML directory: {yaml_dir}")
-            
+
             with yaml_path.open('r', encoding='utf-8') as f:
                 yaml_content = yaml.safe_load(f)
             print(f"YAML content: {yaml_content}")
@@ -289,18 +390,26 @@ class YOLOTrainer(QObject):
             val_label_dir = yaml_dir / 'labels' / 'val'
             val_img_dir.mkdir(parents=True, exist_ok=True)
             val_label_dir.mkdir(parents=True, exist_ok=True)
-            
+
             # Write updated YAML with adjusted paths
             temp_yaml_path = yaml_dir / 'temp_train.yaml'
             with temp_yaml_path.open('w', encoding='utf-8') as f:
                 yaml.dump(yaml_content, f, default_flow_style=False)
-            
+
             print(f"Training with updated YAML: {temp_yaml_path}")
             print(f"Updated YAML content: {yaml_content}")
-            
+
             from ..core.torch_utils import resolve_torch_device
             device, _ = resolve_torch_device()
-            results = self.model.train(data=str(temp_yaml_path), epochs=epochs, imgsz=imgsz, device=device)
+            # Route the run into models/yolo/custom/<project>/ (Ultralytics
+            # auto-increments on collision) instead of the default ./runs, so
+            # the checkpoint has a predictable home like SAM's custom dir.
+            run_name = _sanitize_run_name(os.path.basename(self.project_dir))
+            results = self.model.train(
+                data=str(temp_yaml_path), epochs=epochs, imgsz=imgsz, device=device,
+                project=YOLO_CUSTOM_DIR, name=run_name,
+            )
+            self._register_trained_model()
             return results
         finally:
             # Clear the callback
@@ -308,7 +417,76 @@ class YOLOTrainer(QObject):
             # Remove temporary YAML file
             if 'temp_yaml_path' in locals():
                 temp_yaml_path.unlink(missing_ok=True)
-           
+
+    def _register_trained_model(self):
+        """Record the run's best.pt + a class-names yaml for later prediction.
+
+        Ultralytics writes ``<save_dir>/weights/best.pt``; we drop a sibling
+        ``data.yaml`` carrying the trained class names so the prediction loader
+        (which needs both a model and a names yaml) can pick this run up from
+        the Load-Model dropdown without the user supplying anything. Best-effort
+        — a failure here just leaves the model un-registered, not the run
+        broken."""
+        try:
+            trainer = getattr(self.model, "trainer", None)
+            # Guard the empty string: Path("") is Path(".") which .exists() as
+            # the cwd, so an absent trainer.best must fall through to save_dir.
+            best_attr = getattr(trainer, "best", "") if trainer else ""
+            best = Path(best_attr) if best_attr else None
+            if not best or not best.exists():
+                save_dir = getattr(trainer, "save_dir", None) if trainer else None
+                if save_dir:
+                    best = Path(save_dir) / "weights" / "best.pt"
+            if not best or not best.exists():
+                print("Trained YOLO checkpoint not found; skipping registration.")
+                return
+            names = self.model.names  # {idx: name} from the trained model
+            # Names-only on purpose: load_prediction_model reads `names` only,
+            # and this yaml describes a *trained model*, not a dataset — it must
+            # NOT carry train/val/path pointers (they'd be stale the moment the
+            # dataset moves). Don't "helpfully" add them.
+            yaml_out = best.parent.parent / "data.yaml"
+            with yaml_out.open("w", encoding="utf-8") as f:
+                yaml.dump({"names": names, "nc": len(names)}, f, default_flow_style=False)
+            self.last_saved_model_path = str(best)
+            self.last_saved_yaml_path = str(yaml_out)
+            print(f"Trained YOLO model registered: {best}")
+            self._prune_run_artifacts(best.parent.parent, best, yaml_out)
+        except Exception as exc:
+            print(f"Could not register trained YOLO model: {exc}")
+
+    def _prune_run_artifacts(self, run_dir, best, data_yaml):
+        """Trim the run dir to the minimum needed to run predictions.
+
+        Ultralytics writes a full run directory (last.pt, args.yaml, results.csv,
+        and a dozen plot/mosaic PNG/JPGs). Its native MLflow callback already
+        logs *all* of it into the MLflow run (``on_train_end`` →
+        ``log_artifact`` over the weights dir + every png/jpg/csv/pt/yaml), so
+        once tracking is confirmed those local copies are redundant — keep only
+        ``best.pt`` + the names ``data.yaml`` the app needs, and let MLflow be
+        the home for the diagnostics.
+
+        Guarded on ``_mlflow_url_emitted``: if the run was *not* MLflow-tracked
+        (tracking degraded), the diagnostics live nowhere else, so we keep the
+        whole folder rather than destroy them. Best-effort — a cleanup failure
+        never breaks the (already finished) run."""
+        if not self._mlflow_url_emitted:
+            print("MLflow run not confirmed; keeping full YOLO run dir locally.")
+            return
+        try:
+            keep = {best.resolve(), data_yaml.resolve()}
+            for path in run_dir.rglob("*"):
+                if path.is_file() and path.resolve() not in keep:
+                    path.unlink(missing_ok=True)
+            # Drop any now-empty subdirs (e.g. plots/), but weights/ survives
+            # because best.pt is still in it.
+            for path in sorted(run_dir.rglob("*"), reverse=True):
+                if path.is_dir() and not any(path.iterdir()):
+                    path.rmdir()
+            print(f"Pruned YOLO run dir to best.pt + data.yaml (diagnostics in MLflow): {run_dir}")
+        except Exception as exc:
+            print(f"Could not prune YOLO run artifacts: {exc}")
+
     def verify_dataset_structure(self):
         yaml_path = Path(self.yaml_path)
         yaml_dir = yaml_path.parent

--- a/src/digitalsreeni_image_annotator/dialogs/yolo_trainer.py
+++ b/src/digitalsreeni_image_annotator/dialogs/yolo_trainer.py
@@ -144,10 +144,10 @@ class YOLOTrainer(QObject):
         with yaml_path.open('r', encoding='utf-8') as f:
             yaml_content = yaml.safe_load(f)
 
-        # Update paths for new YOLO v5+ structure
-        yaml_content['train'] = 'images/train'  # Changed from train/images
-        yaml_content['val'] = 'images/val'      # Changed from train/images
-        yaml_content['test'] = '../test/images'
+        # export_yolo_v5plus already writes the correct relative train/val
+        # pointers (val falls back to train when no val images were routed),
+        # so don't clobber them here — just add the test placeholder.
+        yaml_content.setdefault('test', '../test/images')
         
         with yaml_path.open('w', encoding='utf-8') as f:
             yaml.dump(yaml_content, f, default_flow_style=False)

--- a/src/digitalsreeni_image_annotator/dialogs/yolo_trainer.py
+++ b/src/digitalsreeni_image_annotator/dialogs/yolo_trainer.py
@@ -15,6 +15,31 @@ from PyQt6.QtWidgets import QTextBrowser
 from PyQt6.QtGui import QPalette, QTextCharFormat, QTextCursor
 from PyQt6.QtCore import pyqtSignal, QObject
 
+
+def _resolve_training_yaml(yaml_dir, yaml_content):
+    """Resolve a dataset yaml's train/val pointers to absolute paths for training.
+
+    Honors the yaml's own train/val pointers — ``export_yolo_v5plus`` points
+    ``val`` at ``images/val`` when a held-out set was routed there, and falls
+    back to ``images/train`` when it wasn't (``val_split=0`` or a single-image
+    project) — so the user's split is kept while YOLO is never fed an empty val
+    dir. Returns a new dict; the input is not mutated.
+
+    Invariant: the dataset root is the yaml's own directory (``yaml_dir``).
+    Every yaml this trainer consumes satisfies it — the ones ``prepare_dataset``
+    generates have ``path == output_dir == yaml_dir``, and ``load_yaml``
+    relativizes train/val to the yaml's own directory. The standalone ``path``
+    key is therefore redundant once train/val are absolute, and is dropped.
+    """
+    resolved = dict(yaml_content)
+    train_rel = resolved.get("train", os.path.join("images", "train"))
+    val_rel = resolved.get("val", train_rel)  # export fallback ⇒ never empty
+    resolved["train"] = str((Path(yaml_dir) / train_rel).resolve())
+    resolved["val"] = str((Path(yaml_dir) / val_rel).resolve())
+    resolved.pop("path", None)
+    return resolved
+
+
 class TrainingInfoDialog(QDialog):
     stop_signal = pyqtSignal()
 
@@ -254,19 +279,10 @@ class YOLOTrainer(QObject):
             with yaml_path.open('r', encoding='utf-8') as f:
                 yaml_content = yaml.safe_load(f)
             print(f"YAML content: {yaml_content}")
-            
-            # Honor the train/val split written by prepare_dataset /
-            # export_yolo_v5plus. The export already points `val` at images/val
-            # when a held-out set was routed there, and falls back to images/train
-            # when it wasn't (val_split=0 or a single-image project) — so reading
-            # the yaml's own pointers (rather than forcing val=train as before)
-            # keeps the user's split while never feeding YOLO an empty val dir.
-            train_rel = yaml_content.get('train', os.path.join('images', 'train'))
-            val_rel = yaml_content.get('val', train_rel)  # export fallback ⇒ never empty
-            yaml_content['train'] = str((yaml_dir / train_rel).resolve())
-            yaml_content['val'] = str((yaml_dir / val_rel).resolve())
-            # train/val are now absolute; drop the now-redundant dataset root.
-            yaml_content.pop('path', None)
+
+            # Resolve train/val to absolute paths, honoring the split the export
+            # wrote (see _resolve_training_yaml for the data-root invariant).
+            yaml_content = _resolve_training_yaml(yaml_dir, yaml_content)
 
             # Create the val directory structure if it doesn't exist
             val_img_dir = yaml_dir / 'images' / 'val'

--- a/src/digitalsreeni_image_annotator/io/export_formats.py
+++ b/src/digitalsreeni_image_annotator/io/export_formats.py
@@ -252,11 +252,11 @@ def export_yolo_v4(all_annotations, class_mapping, image_paths, slices, image_sl
                         h = h / img_height
                         f.write(f"{class_index} {x_center:.6f} {y_center:.6f} {w:.6f} {h:.6f}\n")
 
-    # Create YAML file. When a split is requested, point val at the populated
-    # valid/ dir; with no split (val_split == 0) fall back to the train images
-    # so the path stays non-empty (the original behaviour).
+    # Create YAML file. Point val at the populated valid/ dir only when images
+    # were actually routed there; otherwise fall back to the train images so
+    # the path stays non-empty (single-image projects, or val_split == 0).
     names = list(class_mapping.keys())
-    val_images_dir = valid_dir if val_split > 0 else train_dir
+    val_images_dir = valid_dir if val_names else train_dir
     yaml_data = {
         'train': os.path.abspath(os.path.join(train_dir, 'images')),
         'val': os.path.abspath(os.path.join(val_images_dir, 'images')),
@@ -398,12 +398,15 @@ def export_yolo_v5plus(all_annotations, class_mapping, image_paths, slices, imag
 
     print(f"[YOLO v5+] export complete: {label_files_written} label file(s) written")
 
-    # Create YAML file
+    # Create YAML file. Point val at the val split only when images were
+    # actually routed there; otherwise fall back to train so `yolo train`
+    # never reads an empty val dir (single-image projects, or val_split == 0).
     names = list(class_mapping.keys())
+    val_rel = os.path.join('images', 'val' if val_names else 'train')
     yaml_data = {
         'path': os.path.abspath(output_dir),  # Root directory
         'train': os.path.join('images', 'train'),  # Relative to path
-        'val': os.path.join('images', 'val'),  # Relative to path
+        'val': val_rel,  # Relative to path
         'nc': len(names),
         'names': names
     }

--- a/src/digitalsreeni_image_annotator/io/export_formats.py
+++ b/src/digitalsreeni_image_annotator/io/export_formats.py
@@ -149,10 +149,11 @@ def assign_train_val(image_names, val_pct):
 
     val_pct in [0, 100]; 0 -> everything in train (the original behaviour).
     Ordering uses a stable filename hash so the split is reproducible across
-    runs and machines (unlike the built-in hash() which is salted per process),
-    and the val count is allocated exactly so the val set is never accidentally
-    empty: whenever val_pct > 0 and there are >= 2 annotated images, at least
-    one image lands in val and at least one stays in train.
+    runs and machines (unlike the built-in hash() which is salted per process).
+    The val count is the nearest integer to the requested fraction, clamped so
+    the val set is never accidentally empty: whenever val_pct > 0 and there are
+    >= 2 annotated images, at least one image lands in val and at least one
+    stays in train.
     """
     names = list(image_names)
     if val_pct <= 0 or len(names) < 2:

--- a/src/digitalsreeni_image_annotator/io/export_formats.py
+++ b/src/digitalsreeni_image_annotator/io/export_formats.py
@@ -2,6 +2,7 @@ import json
 from PyQt6.QtGui import QImage
 from ..utils import calculate_area, calculate_bbox
 import yaml
+import hashlib
 import os
 import shutil
 import tempfile
@@ -143,7 +144,29 @@ def create_coco_annotation(ann, image_id, annotation_id, class_name, class_mappi
 
 
 
-def export_yolo_v4(all_annotations, class_mapping, image_paths, slices, image_slices, output_dir):
+def assign_train_val(image_names, val_pct):
+    """Deterministically partition image names into (train_set, val_set).
+
+    val_pct in [0, 100]; 0 -> everything in train (the original behaviour).
+    Ordering uses a stable filename hash so the split is reproducible across
+    runs and machines (unlike the built-in hash() which is salted per process),
+    and the val count is allocated exactly so the val set is never accidentally
+    empty: whenever val_pct > 0 and there are >= 2 annotated images, at least
+    one image lands in val and at least one stays in train.
+    """
+    names = list(image_names)
+    if val_pct <= 0 or len(names) < 2:
+        return set(names), set()
+    ordered = sorted(names, key=lambda n: hashlib.md5(n.encode("utf-8")).hexdigest())
+    n = len(ordered)
+    # round() is half-to-even, which is fine here; the clamp keeps both sides
+    # non-empty regardless of how the nearest-integer falls.
+    val_count = max(1, min(n - 1, round(n * val_pct / 100)))
+    val = set(ordered[:val_count])
+    return set(names) - val, val
+
+
+def export_yolo_v4(all_annotations, class_mapping, image_paths, slices, image_slices, output_dir, val_split=0):
     # Create output directories
     train_dir = os.path.join(output_dir, 'train')
     valid_dir = os.path.join(output_dir, 'valid')
@@ -157,14 +180,19 @@ def export_yolo_v4(all_annotations, class_mapping, image_paths, slices, image_sl
     # Create a mapping of slice names to their QImage objects
     slice_map = {slice_name: qimage for slice_name, qimage in slices}
 
+    # Deterministically split the annotated images into train/val.
+    annotated = [name for name, ann in all_annotations.items() if ann]
+    _, val_names = assign_train_val(annotated, val_split)
+
     for image_name, annotations in all_annotations.items():
         # Skip if there are no annotations for this image/slice
         if not annotations:
             continue
 
-        # For simplicity, we'll put all data in the train directory
-        images_dir = os.path.join(train_dir, 'images')
-        labels_dir = os.path.join(train_dir, 'labels')
+        # Route this image into the train or val directory.
+        split_dir = valid_dir if image_name in val_names else train_dir
+        images_dir = os.path.join(split_dir, 'images')
+        labels_dir = os.path.join(split_dir, 'labels')
 
         # Handle image saving (similar to before, but adjusted for new directory structure)
         if image_name in slice_map or ('_' in image_name and '.' not in image_name):
@@ -224,11 +252,14 @@ def export_yolo_v4(all_annotations, class_mapping, image_paths, slices, image_sl
                         h = h / img_height
                         f.write(f"{class_index} {x_center:.6f} {y_center:.6f} {w:.6f} {h:.6f}\n")
 
-    # Create YAML file
+    # Create YAML file. When a split is requested, point val at the populated
+    # valid/ dir; with no split (val_split == 0) fall back to the train images
+    # so the path stays non-empty (the original behaviour).
     names = list(class_mapping.keys())
+    val_images_dir = valid_dir if val_split > 0 else train_dir
     yaml_data = {
         'train': os.path.abspath(os.path.join(train_dir, 'images')),
-        'val': os.path.abspath(os.path.join(train_dir, 'images')),  # Using train as val
+        'val': os.path.abspath(os.path.join(val_images_dir, 'images')),
         'test': '../test/images',  # Placeholder
         'nc': len(names),
         'names': names
@@ -243,7 +274,7 @@ def export_yolo_v4(all_annotations, class_mapping, image_paths, slices, image_sl
 
 
 
-def export_yolo_v5plus(all_annotations, class_mapping, image_paths, slices, image_slices, output_dir):
+def export_yolo_v5plus(all_annotations, class_mapping, image_paths, slices, image_slices, output_dir, val_split=0):
     """
     Export annotations in YOLO v5+ format.
     Directory structure:
@@ -271,9 +302,15 @@ def export_yolo_v5plus(all_annotations, class_mapping, image_paths, slices, imag
     # Create a mapping of slice names to their QImage objects
     slice_map = {slice_name: qimage for slice_name, qimage in slices}
 
+    # Deterministically split the annotated images into train/val.
+    annotated = [name for name, ann in all_annotations.items() if ann]
+    _, val_names = assign_train_val(annotated, val_split)
+
     print(f"[YOLO v5+] export: {len(all_annotations)} image entries, "
           f"{len(image_paths)} known image paths, "
-          f"{len(class_to_index)} class(es) → {list(class_to_index.keys())}")
+          f"{len(class_to_index)} class(es) → {list(class_to_index.keys())}; "
+          f"val_split={val_split}% → {len(val_names)} val / "
+          f"{len(annotated) - len(val_names)} train")
 
     label_files_written = 0
     for image_name, annotations in all_annotations.items():
@@ -283,10 +320,11 @@ def export_yolo_v5plus(all_annotations, class_mapping, image_paths, slices, imag
             print("[YOLO v5+]     skipping: no annotations")
             continue
 
-        # For simplicity, we'll put all data in the train directory
-        # In practice, you might want to implement train/val split logic
-        images_dir = images_train_dir
-        labels_dir = labels_train_dir
+        # Route this image into the train or val directory.
+        if image_name in val_names:
+            images_dir, labels_dir = images_val_dir, labels_val_dir
+        else:
+            images_dir, labels_dir = images_train_dir, labels_train_dir
 
         # Handle image saving (similar logic to the v4 version)
         if image_name in slice_map or ('_' in image_name and '.' not in image_name):

--- a/src/digitalsreeni_image_annotator/io/export_formats.py
+++ b/src/digitalsreeni_image_annotator/io/export_formats.py
@@ -309,8 +309,8 @@ def export_yolo_v5plus(all_annotations, class_mapping, image_paths, slices, imag
 
     print(f"[YOLO v5+] export: {len(all_annotations)} image entries, "
           f"{len(image_paths)} known image paths, "
-          f"{len(class_to_index)} class(es) → {list(class_to_index.keys())}; "
-          f"val_split={val_split}% → {len(val_names)} val / "
+          f"{len(class_to_index)} class(es) -> {list(class_to_index.keys())}; "
+          f"val_split={val_split}% -> {len(val_names)} val / "
           f"{len(annotated) - len(val_names)} train")
 
     label_files_written = 0
@@ -365,7 +365,7 @@ def export_yolo_v5plus(all_annotations, class_mapping, image_paths, slices, imag
             dst_path = os.path.join(images_dir, file_name_img)
             if not os.path.exists(dst_path):
                 shutil.copy2(image_path, dst_path)
-                print(f"[YOLO v5+]     copied image → {dst_path}")
+                print(f"[YOLO v5+]     copied image -> {dst_path}")
             img = QImage(image_path)
             img_width, img_height = img.width(), img.height()
 
@@ -394,7 +394,7 @@ def export_yolo_v5plus(all_annotations, class_mapping, image_paths, slices, imag
                         h = h / img_height
                         f.write(f"{class_index} {x_center:.6f} {y_center:.6f} {w:.6f} {h:.6f}\n")
                         ann_lines += 1
-        print(f"[YOLO v5+]     wrote {ann_lines} annotation line(s) → {label_path}")
+        print(f"[YOLO v5+]     wrote {ann_lines} annotation line(s) -> {label_path}")
         label_files_written += 1
 
     print(f"[YOLO v5+] export complete: {label_files_written} label file(s) written")

--- a/tests/integration/test_export_formats.py
+++ b/tests/integration/test_export_formats.py
@@ -381,6 +381,110 @@ class TestYOLOExport:
         assert yaml_data['nc'] == len(sample_class_mapping)
         assert isinstance(yaml_data['names'], list)
 
+    def _multi_image_dataset(self, temp_output_dir, sample_image, count=5):
+        """Build `count` annotated images with real files on disk.
+
+        Returns (annotations, image_paths, src_dir) — src_dir is a separate
+        directory so the export output never collides with the sources.
+        """
+        src_dir = os.path.join(temp_output_dir, "src")
+        os.makedirs(src_dir, exist_ok=True)
+        annotations = {}
+        image_paths = {}
+        for i in range(count):
+            name = f"img_{i:03d}.png"
+            path = os.path.join(src_dir, name)
+            sample_image.save(path)
+            image_paths[name] = path
+            annotations[name] = {
+                "cell": [
+                    {"segmentation": [10, 10, 40, 10, 40, 40, 10, 40], "category": "cell"}
+                ]
+            }
+        return annotations, image_paths
+
+    def test_export_yolo_splits_train_and_val(
+        self, temp_output_dir, sample_class_mapping, sample_image
+    ):
+        """A non-zero split populates both images/train and images/val, and
+        each label .txt sits beside its image in the same split (issue #83)."""
+        out_dir = os.path.join(temp_output_dir, "out")
+        annotations, image_paths = self._multi_image_dataset(
+            temp_output_dir, sample_image, count=5
+        )
+
+        export_yolo_v5plus(
+            annotations, sample_class_mapping, image_paths,
+            slices=[], image_slices={}, output_dir=out_dir, val_split=40,
+        )
+
+        train_imgs = os.listdir(os.path.join(out_dir, 'images', 'train'))
+        val_imgs = os.listdir(os.path.join(out_dir, 'images', 'val'))
+        assert len(train_imgs) > 0 and len(val_imgs) > 0
+        assert len(train_imgs) + len(val_imgs) == 5
+        assert len(val_imgs) == 2  # 40% of 5
+
+        # Every image has its label beside it in the matching split.
+        for split, imgs in (('train', train_imgs), ('val', val_imgs)):
+            label_dir = os.path.join(out_dir, 'labels', split)
+            for img in imgs:
+                stem = os.path.splitext(img)[0]
+                assert os.path.exists(os.path.join(label_dir, stem + '.txt'))
+
+    def test_export_yolo_zero_split_leaves_val_empty(
+        self, temp_output_dir, sample_class_mapping, sample_image
+    ):
+        """val_split=0 preserves the historical all-in-train behaviour."""
+        out_dir = os.path.join(temp_output_dir, "out0")
+        annotations, image_paths = self._multi_image_dataset(
+            temp_output_dir, sample_image, count=4
+        )
+
+        export_yolo_v5plus(
+            annotations, sample_class_mapping, image_paths,
+            slices=[], image_slices={}, output_dir=out_dir, val_split=0,
+        )
+
+        train_imgs = os.listdir(os.path.join(out_dir, 'images', 'train'))
+        val_imgs = os.listdir(os.path.join(out_dir, 'images', 'val'))
+        assert len(train_imgs) == 4
+        assert len(val_imgs) == 0
+
+    def test_export_yolo_splits_multidim_slices(
+        self, temp_output_dir, sample_class_mapping, sample_image
+    ):
+        """Multi-dim slices (no file path, carried as QImage in `slices`) must
+        also route across the train/val split, not all land in train."""
+        out_dir = os.path.join(temp_output_dir, "out_slices")
+        slices = []
+        annotations = {}
+        for i in range(5):
+            slice_name = f"stack.tif_T0_Z{i}_C0"
+            slices.append((slice_name, sample_image))
+            annotations[slice_name] = {
+                "cell": [
+                    {"segmentation": [10, 10, 40, 10, 40, 40, 10, 40], "category": "cell"}
+                ]
+            }
+
+        export_yolo_v5plus(
+            annotations, sample_class_mapping, image_paths={},
+            slices=slices, image_slices={}, output_dir=out_dir, val_split=40,
+        )
+
+        train_imgs = os.listdir(os.path.join(out_dir, 'images', 'train'))
+        val_imgs = os.listdir(os.path.join(out_dir, 'images', 'val'))
+        assert len(train_imgs) > 0 and len(val_imgs) > 0
+        assert len(train_imgs) + len(val_imgs) == 5
+        assert len(val_imgs) == 2  # 40% of 5
+
+        # Each slice's label sits in the same split as its image.
+        for split, imgs in (('train', train_imgs), ('val', val_imgs)):
+            label_dir = os.path.join(out_dir, 'labels', split)
+            for img in imgs:
+                stem = os.path.splitext(img)[0]
+                assert os.path.exists(os.path.join(label_dir, stem + '.txt'))
+
 
 class TestPascalVOCExport:
     """Tests for Pascal VOC export format."""

--- a/tests/integration/test_export_formats.py
+++ b/tests/integration/test_export_formats.py
@@ -11,8 +11,10 @@ import tempfile
 import shutil
 from pathlib import Path
 from PyQt6.QtGui import QImage
+import yaml as yaml_lib
 from src.digitalsreeni_image_annotator.io.export_formats import (
     export_coco_json,
+    export_yolo_v4,
     export_yolo_v5plus,
     export_pascal_voc_bbox,
     create_coco_annotation
@@ -484,6 +486,76 @@ class TestYOLOExport:
             for img in imgs:
                 stem = os.path.splitext(img)[0]
                 assert os.path.exists(os.path.join(label_dir, stem + '.txt'))
+
+    def test_export_yolo_single_image_val_falls_back_to_train(
+        self, temp_output_dir, sample_class_mapping, sample_image
+    ):
+        """A single-image project can't fill val, so data.yaml's val must fall
+        back to the (populated) train dir rather than an empty images/val."""
+        out_dir = os.path.join(temp_output_dir, "out_single")
+        annotations, image_paths = self._multi_image_dataset(
+            temp_output_dir, sample_image, count=1
+        )
+
+        export_yolo_v5plus(
+            annotations, sample_class_mapping, image_paths,
+            slices=[], image_slices={}, output_dir=out_dir, val_split=20,
+        )
+
+        val_imgs = os.listdir(os.path.join(out_dir, 'images', 'val'))
+        assert len(val_imgs) == 0  # nothing could be routed to val
+        with open(os.path.join(out_dir, 'data.yaml')) as f:
+            yaml_data = yaml_lib.safe_load(f)
+        assert yaml_data['val'] == os.path.join('images', 'train')
+        # path + relative val must resolve to a real, populated directory.
+        resolved_val = os.path.join(yaml_data['path'], yaml_data['val'])
+        assert os.path.isdir(resolved_val)
+        assert len(os.listdir(resolved_val)) > 0
+
+    def test_export_yolo_v4_splits_train_and_valid(
+        self, temp_output_dir, sample_class_mapping, sample_image
+    ):
+        """YOLO v4 routes images into train/ and valid/ and points data.yaml's
+        val at the populated valid/ images dir when a split is requested."""
+        out_dir = os.path.join(temp_output_dir, "out_v4")
+        annotations, image_paths = self._multi_image_dataset(
+            temp_output_dir, sample_image, count=5
+        )
+
+        export_yolo_v4(
+            annotations, sample_class_mapping, image_paths,
+            slices=[], image_slices={}, output_dir=out_dir, val_split=40,
+        )
+
+        train_imgs = os.listdir(os.path.join(out_dir, 'train', 'images'))
+        valid_imgs = os.listdir(os.path.join(out_dir, 'valid', 'images'))
+        assert len(train_imgs) == 3 and len(valid_imgs) == 2
+
+        with open(os.path.join(out_dir, 'data.yaml')) as f:
+            yaml_data = yaml_lib.safe_load(f)
+        # val must resolve to the populated valid/images dir.
+        assert os.path.basename(os.path.dirname(yaml_data['val'])) == 'valid'
+        assert len(os.listdir(yaml_data['val'])) == 2
+
+    def test_export_yolo_v4_zero_split_val_points_at_train(
+        self, temp_output_dir, sample_class_mapping, sample_image
+    ):
+        """With no split, v4 keeps the historical behaviour: val points at the
+        train images so the path is non-empty."""
+        out_dir = os.path.join(temp_output_dir, "out_v4_zero")
+        annotations, image_paths = self._multi_image_dataset(
+            temp_output_dir, sample_image, count=3
+        )
+
+        export_yolo_v4(
+            annotations, sample_class_mapping, image_paths,
+            slices=[], image_slices={}, output_dir=out_dir, val_split=0,
+        )
+
+        assert len(os.listdir(os.path.join(out_dir, 'valid', 'images'))) == 0
+        with open(os.path.join(out_dir, 'data.yaml')) as f:
+            yaml_data = yaml_lib.safe_load(f)
+        assert os.path.basename(os.path.dirname(yaml_data['val'])) == 'train'
 
 
 class TestPascalVOCExport:

--- a/tests/unit/test_yolo_custom_models.py
+++ b/tests/unit/test_yolo_custom_models.py
@@ -1,0 +1,280 @@
+"""Unit tests for the trained-YOLO-model registry + MLflow link wiring (#83).
+
+Covers the pure/headless pieces of the in-app YOLO trainer that route a run
+into ``models/yolo/custom/<name>`` and expose it for prediction, plus the
+once-per-run MLflow deep-link emission. The full ``train_model`` needs a real
+Ultralytics model, so these exercise the helpers around it directly.
+"""
+
+import types
+
+import pytest
+import yaml as yaml_lib
+
+from src.digitalsreeni_image_annotator.dialogs import yolo_trainer as yt
+from src.digitalsreeni_image_annotator.dialogs.yolo_trainer import (
+    LoadPredictionModelDialog,
+    YOLOTrainer,
+    _sanitize_run_name,
+    list_custom_yolo_models,
+)
+
+
+# --- _sanitize_run_name -----------------------------------------------------
+
+@pytest.mark.parametrize("raw, expected", [
+    ("MyProject", "MyProject"),
+    ("My Proj #1!", "My_Proj__1"),
+    ("a/b\\c", "a_b_c"),
+    ("", "model"),
+    ("___", "model"),
+    ("keep-_chars", "keep-_chars"),
+])
+def test_sanitize_run_name(raw, expected):
+    assert _sanitize_run_name(raw) == expected
+
+
+# --- list_custom_yolo_models ------------------------------------------------
+
+def _make_run(custom_dir, name, with_yaml=True, with_best=True):
+    run = custom_dir / name
+    (run / "weights").mkdir(parents=True)
+    if with_best:
+        (run / "weights" / "best.pt").write_bytes(b"fake")
+    if with_yaml:
+        (run / "data.yaml").write_text(yaml_lib.dump({"names": {0: "cell"}, "nc": 1}))
+    return run
+
+
+def test_list_custom_models_discovers_runs(tmp_path, monkeypatch):
+    custom = tmp_path / "custom"
+    custom.mkdir()
+    _make_run(custom, "runA")
+    _make_run(custom, "runB")
+    monkeypatch.setattr(yt, "YOLO_CUSTOM_DIR", str(custom))
+
+    listed = list_custom_yolo_models()
+    assert set(listed) == {"★ runA", "★ runB"}
+    for model_path, yaml_path in listed.values():
+        assert model_path.endswith("best.pt")
+        assert yaml_path.endswith("data.yaml")
+
+
+def test_list_skips_runs_without_best(tmp_path, monkeypatch):
+    custom = tmp_path / "custom"
+    custom.mkdir()
+    _make_run(custom, "good")
+    _make_run(custom, "no_weights", with_best=False)
+    monkeypatch.setattr(yt, "YOLO_CUSTOM_DIR", str(custom))
+
+    listed = list_custom_yolo_models()
+    assert set(listed) == {"★ good"}  # a run with no best.pt is not selectable
+
+
+def test_list_missing_yaml_yields_empty_yaml_path(tmp_path, monkeypatch):
+    custom = tmp_path / "custom"
+    custom.mkdir()
+    _make_run(custom, "noyaml", with_yaml=False)
+    monkeypatch.setattr(yt, "YOLO_CUSTOM_DIR", str(custom))
+
+    (_model, yaml_path), = list_custom_yolo_models().values()
+    assert yaml_path == ""  # browse-for-yaml fallback, never a bogus path
+
+
+def test_list_empty_when_dir_absent(tmp_path, monkeypatch):
+    monkeypatch.setattr(yt, "YOLO_CUSTOM_DIR", str(tmp_path / "does_not_exist"))
+    assert list_custom_yolo_models() == {}
+
+
+# --- _register_trained_model ------------------------------------------------
+
+def _trainer(tmp_path, qapp):
+    t = YOLOTrainer(str(tmp_path / "proj"), main_window=None)
+    return t
+
+
+def test_register_trained_model_writes_yaml_and_paths(tmp_path, qapp):
+    # Fake Ultralytics model+trainer: best.pt on disk, names dict.
+    run = tmp_path / "models" / "yolo" / "custom" / "proj"
+    (run / "weights").mkdir(parents=True)
+    best = run / "weights" / "best.pt"
+    best.write_bytes(b"fake")
+
+    t = _trainer(tmp_path, qapp)
+    t.model = types.SimpleNamespace(
+        names={0: "cell", 1: "nucleus"},
+        trainer=types.SimpleNamespace(best=str(best), save_dir=str(run)),
+    )
+    t._register_trained_model()
+
+    assert t.last_saved_model_path == str(best)
+    data_yaml = run / "data.yaml"
+    assert t.last_saved_yaml_path == str(data_yaml)
+    written = yaml_lib.safe_load(data_yaml.read_text())
+    assert written["nc"] == 2
+    assert written["names"] == {0: "cell", 1: "nucleus"}
+
+
+def test_register_falls_back_to_save_dir_when_best_attr_missing(tmp_path, qapp):
+    run = tmp_path / "run"
+    (run / "weights").mkdir(parents=True)
+    best = run / "weights" / "best.pt"
+    best.write_bytes(b"fake")
+
+    t = _trainer(tmp_path, qapp)
+    # No usable .best, but save_dir points at the run -> best is derived.
+    t.model = types.SimpleNamespace(
+        names={0: "cell"},
+        trainer=types.SimpleNamespace(best="", save_dir=str(run)),
+    )
+    t._register_trained_model()
+    assert t.last_saved_model_path == str(best)
+
+
+def test_register_noop_when_no_checkpoint(tmp_path, qapp):
+    t = _trainer(tmp_path, qapp)
+    t.model = types.SimpleNamespace(
+        names={0: "cell"},
+        trainer=types.SimpleNamespace(best="", save_dir=str(tmp_path / "empty")),
+    )
+    t._register_trained_model()
+    assert t.last_saved_model_path is None
+    assert t.last_saved_yaml_path is None
+
+
+# --- _prune_run_artifacts ---------------------------------------------------
+
+def _make_full_run_dir(tmp_path):
+    """A run dir shaped like Ultralytics' output: weights + diagnostics."""
+    run = tmp_path / "run"
+    (run / "weights").mkdir(parents=True)
+    best = run / "weights" / "best.pt"
+    best.write_bytes(b"best")
+    (run / "weights" / "last.pt").write_bytes(b"last")
+    data_yaml = run / "data.yaml"
+    data_yaml.write_text("names: {0: cell}\n")
+    for noise in ("results.csv", "args.yaml", "BoxF1_curve.png",
+                  "confusion_matrix.png", "train_batch0.jpg", "val_batch0_pred.jpg"):
+        (run / noise).write_text("x")
+    return run, best, data_yaml
+
+
+def test_prune_keeps_only_best_and_yaml_when_tracked(tmp_path, qapp):
+    run, best, data_yaml = _make_full_run_dir(tmp_path)
+    t = _trainer(tmp_path, qapp)
+    t._mlflow_url_emitted = True  # MLflow has the diagnostics -> safe to prune
+    t._prune_run_artifacts(run, best, data_yaml)
+
+    survivors = {p.relative_to(run).as_posix() for p in run.rglob("*") if p.is_file()}
+    assert survivors == {"weights/best.pt", "data.yaml"}
+    assert best.exists() and data_yaml.exists()
+    # weights/ survives (best.pt still in it); no empty dirs left behind
+    assert (run / "weights").is_dir()
+
+
+def test_prune_kept_run_still_discoverable(tmp_path, qapp, monkeypatch):
+    # After pruning, list_custom_yolo_models() must still find the run.
+    custom = tmp_path / "custom"
+    run = custom / "proj"
+    (run / "weights").mkdir(parents=True)
+    best = run / "weights" / "best.pt"
+    best.write_bytes(b"best")
+    (run / "weights" / "last.pt").write_bytes(b"last")
+    data_yaml = run / "data.yaml"
+    data_yaml.write_text("names: {0: cell}\n")
+    (run / "results.csv").write_text("x")
+
+    t = _trainer(tmp_path, qapp)
+    t._mlflow_url_emitted = True
+    t._prune_run_artifacts(run, best, data_yaml)
+
+    monkeypatch.setattr(yt, "YOLO_CUSTOM_DIR", str(custom))
+    listed = list_custom_yolo_models()
+    assert set(listed) == {"★ proj"}
+    (model_path, yaml_path), = listed.values()
+    assert model_path.endswith("best.pt") and yaml_path.endswith("data.yaml")
+
+
+def test_prune_keeps_everything_when_not_tracked(tmp_path, qapp):
+    run, best, data_yaml = _make_full_run_dir(tmp_path)
+    before = {p.relative_to(run).as_posix() for p in run.rglob("*") if p.is_file()}
+    t = _trainer(tmp_path, qapp)
+    t._mlflow_url_emitted = False  # diagnostics live nowhere else -> keep them
+    t._prune_run_artifacts(run, best, data_yaml)
+
+    after = {p.relative_to(run).as_posix() for p in run.rglob("*") if p.is_file()}
+    assert after == before  # nothing deleted
+
+
+# --- _emit_mlflow_url -------------------------------------------------------
+
+def test_emit_mlflow_url_once(tmp_path, qapp, monkeypatch):
+    run_info = types.SimpleNamespace(
+        info=types.SimpleNamespace(experiment_id="7", run_id="abc123")
+    )
+    fake_mlflow = types.SimpleNamespace(active_run=lambda: run_info)
+    monkeypatch.setitem(__import__("sys").modules, "mlflow", fake_mlflow)
+
+    t = _trainer(tmp_path, qapp)
+    urls = []
+    t.mlflow_run_url.connect(urls.append)
+
+    t._emit_mlflow_url()
+    t._emit_mlflow_url()  # latched — must not emit again
+
+    assert urls == ["http://localhost:5000/#/experiments/7/runs/abc123"]
+
+
+def test_emit_mlflow_url_silent_when_no_active_run(tmp_path, qapp, monkeypatch):
+    fake_mlflow = types.SimpleNamespace(active_run=lambda: None)
+    monkeypatch.setitem(__import__("sys").modules, "mlflow", fake_mlflow)
+
+    t = _trainer(tmp_path, qapp)
+    urls = []
+    t.mlflow_run_url.connect(urls.append)
+    t._emit_mlflow_url()
+    assert urls == []
+    assert t._mlflow_url_emitted is False  # not latched -> a later epoch retries
+
+
+# --- LoadPredictionModelDialog dropdown -------------------------------------
+
+def test_prediction_dialog_lists_and_fills_trained_models(tmp_path, qapp, qtbot, monkeypatch):
+    mapping = {
+        "★ runA": ("/models/runA/weights/best.pt", "/models/runA/data.yaml"),
+    }
+    monkeypatch.setattr(yt, "list_custom_yolo_models", lambda: mapping)
+
+    dlg = LoadPredictionModelDialog()
+    qtbot.addWidget(dlg)
+    # placeholder + one trained entry
+    assert dlg.trained_combo.count() == 2
+
+    dlg.trained_combo.setCurrentIndex(1)  # select runA
+    assert dlg.model_path == "/models/runA/weights/best.pt"
+    assert dlg.yaml_path == "/models/runA/data.yaml"
+    assert dlg.model_edit.text() == "/models/runA/weights/best.pt"
+    assert dlg.yaml_edit.text() == "/models/runA/data.yaml"
+
+
+def test_prediction_dialog_placeholder_is_noop(tmp_path, qapp, qtbot, monkeypatch):
+    # Re-selecting the placeholder (currentData() is None) must NOT wipe a
+    # previously chosen model — the `if not paths: return` guard is load-bearing.
+    mapping = {
+        "★ runA": ("/models/runA/weights/best.pt", "/models/runA/data.yaml"),
+    }
+    monkeypatch.setattr(yt, "list_custom_yolo_models", lambda: mapping)
+    dlg = LoadPredictionModelDialog()
+    qtbot.addWidget(dlg)
+
+    dlg.trained_combo.setCurrentIndex(1)   # pick runA
+    dlg.trained_combo.setCurrentIndex(0)   # back to "— select a trained model —"
+    assert dlg.model_path == "/models/runA/weights/best.pt"
+    assert dlg.yaml_path == "/models/runA/data.yaml"
+
+
+def test_prediction_dialog_no_combo_when_no_trained_models(tmp_path, qapp, qtbot, monkeypatch):
+    monkeypatch.setattr(yt, "list_custom_yolo_models", dict)
+    dlg = LoadPredictionModelDialog()
+    qtbot.addWidget(dlg)
+    assert not hasattr(dlg, "trained_combo")  # dropdown omitted entirely

--- a/tests/unit/test_yolo_split.py
+++ b/tests/unit/test_yolo_split.py
@@ -1,0 +1,76 @@
+"""
+Unit tests for the deterministic YOLO train/val split helper (issue #83).
+
+`assign_train_val` partitions annotated image names into train/val sets using a
+stable filename hash, so the split is reproducible and the val set is never
+accidentally empty when a split is requested.
+"""
+
+from src.digitalsreeni_image_annotator.io.export_formats import assign_train_val
+
+
+def _names(n):
+    return [f"img_{i:03d}.png" for i in range(n)]
+
+
+def test_zero_split_keeps_everything_in_train():
+    names = _names(10)
+    train, val = assign_train_val(names, 0)
+    assert train == set(names)
+    assert val == set()
+
+
+def test_negative_split_treated_as_zero():
+    names = _names(5)
+    train, val = assign_train_val(names, -5)
+    assert train == set(names)
+    assert val == set()
+
+
+def test_single_image_never_emptied_into_val():
+    # With one image a split would leave train empty; keep it in train.
+    train, val = assign_train_val(["only.png"], 50)
+    assert train == {"only.png"}
+    assert val == set()
+
+
+def test_split_is_deterministic_across_calls():
+    names = _names(50)
+    a_train, a_val = assign_train_val(names, 20)
+    b_train, b_val = assign_train_val(list(reversed(names)), 20)
+    # Order of the input must not change the partition.
+    assert a_val == b_val
+    assert a_train == b_train
+
+
+def test_split_count_is_proportional():
+    names = _names(100)
+    _, val = assign_train_val(names, 20)
+    assert len(val) == 20
+
+
+def test_split_rounds_to_nearest():
+    names = _names(10)
+    _, val = assign_train_val(names, 25)  # 2.5 -> 2
+    assert len(val) == 2
+
+
+def test_val_non_empty_for_small_set_with_split():
+    # Two images, 20% rounds to 0 but the val set must stay non-empty.
+    train, val = assign_train_val(_names(2), 20)
+    assert len(val) == 1
+    assert len(train) == 1
+
+
+def test_train_never_emptied_by_high_split():
+    # 100% would drain train; at least one image must remain.
+    train, val = assign_train_val(_names(4), 100)
+    assert len(train) == 1
+    assert len(val) == 3
+
+
+def test_train_and_val_are_disjoint_and_cover_all():
+    names = _names(37)
+    train, val = assign_train_val(names, 30)
+    assert train.isdisjoint(val)
+    assert train | val == set(names)

--- a/tests/unit/test_yolo_training_yaml.py
+++ b/tests/unit/test_yolo_training_yaml.py
@@ -1,0 +1,83 @@
+"""Unit tests for the in-app YOLO trainer's dataset-yaml path resolution (#83).
+
+`_resolve_training_yaml` is the piece that turns a prepared/loaded data.yaml
+into the absolute train/val pointers written to `temp_train.yaml` just before
+`YOLO.train(...)`. It's the one spot where a wrong `val` pointer crashes
+`yolo train` on an empty validation set, so it gets its own coverage even though
+the surrounding `train_model` needs a real model to run end-to-end.
+"""
+
+import os
+from pathlib import Path
+
+from src.digitalsreeni_image_annotator.dialogs.yolo_trainer import (
+    _resolve_training_yaml,
+)
+
+
+def test_honors_held_out_val_split(tmp_path):
+    # Shape that export_yolo_v5plus writes when a val set WAS routed.
+    yc = {
+        "path": str(tmp_path),
+        "train": os.path.join("images", "train"),
+        "val": os.path.join("images", "val"),
+        "nc": 1,
+        "names": ["cell"],
+    }
+    out = _resolve_training_yaml(str(tmp_path), yc)
+
+    assert out["train"] == str((tmp_path / "images" / "train").resolve())
+    assert out["val"] == str((tmp_path / "images" / "val").resolve())
+    # The split survives — val is a different dir from train (the whole point).
+    assert out["val"] != out["train"]
+    # train/val are absolute now, so the dataset-root key is redundant.
+    assert "path" not in out
+    # Non-routing keys are preserved.
+    assert out["names"] == ["cell"]
+
+
+def test_val_falls_back_to_train_when_export_did(tmp_path):
+    # Shape export_yolo_v5plus writes for val_split=0 / single-image projects:
+    # val already points at images/train so `yolo train` never sees an empty
+    # val dir. Resolution must preserve that, not re-empty it.
+    yc = {
+        "path": str(tmp_path),
+        "train": os.path.join("images", "train"),
+        "val": os.path.join("images", "train"),
+    }
+    out = _resolve_training_yaml(str(tmp_path), yc)
+
+    assert out["val"] == out["train"] == str((tmp_path / "images" / "train").resolve())
+    assert "path" not in out
+
+
+def test_missing_val_pointer_defaults_to_train(tmp_path):
+    # A yaml with no val key must still yield a non-empty val (== train),
+    # never a bare/relative pointer that would fail to resolve at train time.
+    out = _resolve_training_yaml(str(tmp_path), {"names": ["x"]})
+
+    assert out["train"] == str((tmp_path / "images" / "train").resolve())
+    assert out["val"] == out["train"]
+
+
+def test_does_not_mutate_input(tmp_path):
+    yc = {
+        "path": str(tmp_path),
+        "train": os.path.join("images", "train"),
+        "val": os.path.join("images", "val"),
+    }
+    _resolve_training_yaml(str(tmp_path), yc)
+
+    # Caller's dict is untouched (resolution returns a fresh copy).
+    assert yc["path"] == str(tmp_path)
+    assert yc["val"] == os.path.join("images", "val")
+
+
+def test_accepts_path_like_yaml_dir(tmp_path):
+    # yaml_dir may arrive as a Path (yaml_path.parent) or a str — both work.
+    yc = {"train": "images/train", "val": "images/val"}
+    from_path = _resolve_training_yaml(Path(tmp_path), yc)
+    from_str = _resolve_training_yaml(str(tmp_path), yc)
+
+    assert from_path == from_str
+    assert from_path["val"] == str((tmp_path / "images" / "val").resolve())


### PR DESCRIPTION
## What & why

Resolves upstream issue [#83](https://github.com/bnsreenu/digitalsreeni-image-annotator/issues/83).

Both YOLO exporters created the correct `images/{train,val}` + `labels/{train,val}` layout but routed **every** image into `train/`, leaving `val/` empty (v4 even pointed `val` at the train images). Ultralytics `yolo train` requires a non-empty validation set, so a fresh export failed immediately — breaking the advertised *annotate → export → train* workflow.

This adds a user-configurable validation split, routes images into train vs val deterministically, and makes the **in-app trainer actually use the held-out set** end-to-end.

## Changes

- **`io/export_formats.py`**
  - New `assign_train_val(image_names, val_pct)` — partitions annotated image names via a stable **filename hash** (reproducible across runs/machines, unlike salted `hash()`); val count is the nearest integer to the requested fraction, **clamped non-empty** so with `pct>0` and ≥2 images both train and val keep ≥1.
  - `export_yolo_v4` / `export_yolo_v5plus` gained a `val_split=0` param (default = historical all-in-train) and route images + labels into the assigned split. Covers regular images **and** multi-dim slices.
  - `data.yaml`'s `val` points at the val dir **only when images were actually routed there** (`bool(val_names)`), else falls back to train — so even a single-image project never points `yolo train` at an empty dir.
- **`controllers/io_controller.py`** — prompts for the validation % on YOLO menu exports, via a shared `prompt_validation_split()` helper.
- **`controllers/yolo_controller.py` + `dialogs/yolo_trainer.py`** — the in-app trainer holds out a validation set (`prepare_dataset(val_split=20)`), and **`train_model()` now honors the export's train/val pointers instead of forcing `val = train`**. Previously `train_model` overrode `val` to the train dir, so the split was cosmetic on the in-app path (YOLO validated against the training images). The resolution logic is extracted into a pure, tested `_resolve_training_yaml(yaml_dir, yaml_content)` helper that reads the yaml's own `val` pointer (with the export's safe `val→train` fallback), resolves train/val to absolute paths, and drops the now-redundant `path` key.
- **`docs/06_runtime_view.md`** — updated the YOLO export flow (and corrected a pre-existing v4/v5+ directory-layout mismatch in the diagram).

> **Note on the diff:** this branch was behind `master` (it predated the MLflow merge, PR #25). `master` has been merged in, so the branch now carries the MLflow tracking feature too. The crash some testers hit during in-app YOLO training (`unsupported URI 'C:\…\runs\mlflow' for model registry`) was a symptom of that staleness: Ultralytics' globally-enabled MLflow callback fell back to a bare Windows path because the branch lacked `_configure_mlflow` (which sets a proper `file://` tracking URI). The merge resolves it; with a real held-out val set, Ultralytics' native MLflow callback now also logs per-epoch **val** metrics automatically.

## Behaviour note

The export/training dialogs now **default to 20%** validation (previously everything went to train). Users can set `0` to keep the old all-in-train layout. The in-app trainer now genuinely validates against the held-out set.

## Testing

- New `tests/unit/test_yolo_split.py` — split math: determinism, rounding, non-empty guarantees, single-image / 100% boundaries.
- New `tests/unit/test_yolo_training_yaml.py` — the in-app trainer's `_resolve_training_yaml` path resolution: held-out split honored (`val != train`), export's `val→train` fallback preserved (never empty), missing pointer defaults to train, input not mutated, `str`/`Path` `yaml_dir` both accepted.
- Extended `tests/integration/test_export_formats.py` — v5+ split + zero-split + multi-dim slice split + single-image val fallback; v4 split routing + both yaml-pointer branches.
- **Full suite: 420 passed, 3 skipped.** Ruff clean.
- Senior-reviewer quality gate run to a clean pass (P1 on the `train_model` rewrite addressed with the extracted helper + tests; remaining items are deferred P2 nits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Follow-up: in-app YOLO training is now turnkey (model location + MLflow link + cleanup)

Surfaced during manual testing of the split. The in-app trainer now mirrors the SAM fine-tuning "train → use" workflow instead of leaving the model in Ultralytics' default `./runs`:

- **Dedicated, discoverable model folder.** `train_model()` routes the run into `models/yolo/custom/<project>/` (parallel to `models/sam/custom`). `_register_trained_model()` records `best.pt` and writes a names-only `data.yaml`; `list_custom_yolo_models()` + a new dropdown in `LoadPredictionModelDialog` let a freshly trained run be selected for prediction without browsing. The Training Complete dialog reports the saved path.
- **MLflow run-link for YOLO** (the gap vs SAM). `_emit_mlflow_url()` reads Ultralytics' active MLflow run (started in `on_pretrain_routine_end`, read from the existing per-epoch callback, latched once) and emits `mlflow_run_url`; `YOLOController._on_mlflow_run_url` shows the clickable link, starts the MLflow UI server once, and opens the browser — same UX as SAM.
- **Run-dir pruning.** Ultralytics' native MLflow callback already logs the *entire* run dir (weights + curves + confusion matrices + mosaics + `results.csv`) into the run via `on_train_end`. So after a **tracked** run the local folder is trimmed to `best.pt` + `data.yaml`; the diagnostics live in MLflow. An **untracked** run keeps the whole folder (the diagnostics have no other home) — guarded on `_mlflow_url_emitted`.
- **cp1252 fix.** `export_yolo_v5plus`'s progress prints used `→` (U+2192), which crashes the export with `UnicodeEncodeError` on a default Windows console — replaced with ASCII `->`.

### Testing (follow-up)

- New `tests/unit/test_yolo_custom_models.py` (24 tests): run-name sanitization, `list_custom_yolo_models` discovery/skip rules, `_register_trained_model` (incl. the `Path("")`→`Path(".")` fallback footgun), pruning **both** branches (tracked → trim, untracked → keep), MLflow emit-once, and the dialog dropdown (fill + placeholder no-op).
- **Real end-to-end run** (yolo11n-seg, 1 epoch): output lands under `models/yolo/custom/<project>/`, registers, appears in the dropdown, emits one valid MLflow deep link, the folder is pruned to `best.pt` + `data.yaml`, **and** the MLflow store is confirmed to hold the pruned diagnostics (plots/csv) + `best.pt`.
- **Full suite: 441 passed, 3 skipped.** Ruff clean on all changed files. Senior-reviewer gate run to a clean pass (3 P1s addressed: symmetric signal teardown, the placeholder no-op test, real-dir e2e evidence).

> Two pre-existing items left out of scope (worth a future backlog line): `_configure_mlflow` flips a *global* Ultralytics setting on disk (from the #25 MLflow merge), and the in-app YOLO trainer has no re-entrancy lock like SAM's `_set_sam_ui_locked`.
