### PR TITLE
ci: add Python 3.14 to test matrix and update version metadata

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v4

--- a/TESTING.md
+++ b/TESTING.md
@@ -56,7 +56,7 @@ This document describes the testing infrastructure for the DigitalSreeni Image A
 6. **CI/CD Pipeline** ✓
    - Created [.github/workflows/tests.yml](.github/workflows/tests.yml)
    - Multi-platform testing: Ubuntu, Windows, macOS
-   - Multi-version testing: Python 3.10, 3.11, 3.12, 3.13
+   - Multi-version testing: Python 3.10, 3.11, 3.12, 3.13, 3.14
    - Automated coverage reporting (Codecov integration)
    - Coverage report artifacts
 

--- a/prd.md
+++ b/prd.md
@@ -229,7 +229,7 @@ tests/
 - [ ] Automatic dependency resolution
 - [ ] Models download automatically on first use
 - [ ] Clear error messages for missing dependencies
-- [ ] Support Python 3.10, 3.11, 3.12
+- [ ] Support Python 3.10, 3.11, 3.12, 3.13, 3.14
 
 ---
 

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,10 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
     ],
     python_requires=">=3.10",
     install_requires=[


### PR DESCRIPTION
## Summary

Extends the GitHub Actions test matrix to cover **Python 3.14**, which the app
already runs on in practice, so CI enforces that guarantee instead of relying on
"works for me". Also brings the project version metadata up to date.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/tests.yml` | Matrix → `['3.10', '3.11', '3.12', '3.13', '3.14']` |
| `setup.py` | Trove classifiers expanded `3.10` → `3.10–3.14` (also fills the pre-existing 3.11–3.13 gap; only `3.10` was listed before) |
| `TESTING.md` | Version enumeration → `…, 3.13, 3.14` |
| `prd.md` | Support checklist → `…, 3.13, 3.14` |

`python_requires=">=3.10"` and the `"3.10+"`-style references (README badge,
CLAUDE.md, `docs/02_architecture_constraints.md`) are intentionally unchanged —
open-ended minimums that already cover 3.14.

## Notes

No workflow plumbing changes needed: `actions/setup-python@v5` supports 3.14,
and the apt deps / `xvfb` / `QT_QPA_PLATFORM=offscreen` steps are
Python-version-agnostic. No runtime code is touched.

## Verification

- `tests.yml` parses as valid YAML and the matrix list contains `'3.14'`.
- `setup.py` exposes all five `Programming Language :: Python :: 3.x` classifiers.
- This PR's CI run exercises the new 3.14 column across Ubuntu/Windows/macOS end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAuJzQW6tYMnto7DZNLEdU)_