### PR TITLE
Phase B (persistence + guards): unsaved-project recovery, portable .iap paths, pose-class guards (#41, #42, #44)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,7 +198,7 @@ See [Runtime View](docs/06_runtime_view.md#multi-dimensional-image-loading) for 
 | 4 | Update arc42 docs if behavior changed | `docs/` — see Documentation section |
 | 5 | **Run senior reviewer agent** | `.claude/agents/senior-reviewer.md` — mandatory quality gate before every PR |
 | 6 | Commit: `feat: Description` or `fix: Description` | Clear, descriptive messages |
-| 7 | Push & create PR | `git push origin feature/branch` |
+| 7 | Push & create PR | `git push origin feature/branch`; open with `gh pr create --repo cofade/…` (the default targets the upstream parent!). **The PR body MUST include `Closes #NN` for every issue it resolves** — GitHub only auto-closes issues on merge when the body references them, and PR #52 forgot this, leaving #33–#40 open to be closed by hand. |
 
 ### Testing Checklist
 

--- a/docs/06_runtime_view.md
+++ b/docs/06_runtime_view.md
@@ -521,6 +521,32 @@ User clicks "Open" or Ctrl+O
     └─> Return
 ```
 
+## Unsaved-Project Recovery (issue #41, ADR-032)
+
+Before a project has ever been saved, every mutation still calls `auto_save()`. With no
+`current_project_file`, `ProjectController.auto_save()` writes a **silent** snapshot
+(`build_project_data()` → atomic temp-file + `os.replace`) to
+`AppDataLocation/recovery/unsaved.iap.recovery`, remembering its path in QSettings
+(`recovery/pending_path`). A trivially empty session writes nothing.
+
+On the next launch, `main()` calls `ProjectController.offer_recovery()` after the window
+is shown:
+
+```
+main() → window.show() → offer_recovery()
+    │
+    ├─ pending_recovery() finds a snapshot?
+    │     ├─ No  → return
+    │     └─ Yes → "Restore unsaved work from <mtime>?"
+    │                ├─ No  → clear_recovery()
+    │                └─ Yes → is_loading_project = True → load_project_data(snapshot)
+    │                          → current_project_file left UNSET (user still saves)
+    │                          → clear_recovery() on success
+```
+
+A real save (or New Project) calls `clear_recovery()`, so a stale snapshot is never
+offered once the project is disk-backed.
+
 ## Multi-dimensional Image Loading
 
 ```

--- a/docs/08_crosscutting_concepts.md
+++ b/docs/08_crosscutting_concepts.md
@@ -146,6 +146,22 @@ for contour in contours:
         # Accept annotation
 ```
 
+## Project Portability & Unsaved-Project Recovery (#41 / #42)
+
+**Relative image paths (ADR-033).** `build_project_data()` writes `image_paths_rel`
+(POSIX separators, project-relative) alongside the absolute `image_paths`, but only when
+a project dir exists. `resolve_image_path()` resolves in order relative → absolute →
+`<project_dir>/images/` → missing, so a moved project folder opens cleanly and v1 files
+still resolve. `core/project_schema.validate_project_data` (pure) runs after `json.load`
+and raises `ValueError` on a structurally broken `.iap`.
+
+**Unsaved-project recovery (ADR-032).** With no `current_project_file`, `auto_save()`
+never prompts — it writes a silent snapshot (`build_project_data()` → atomic temp +
+`os.replace`) to `AppDataLocation/recovery/`, path stored under QSettings
+`recovery/pending_path`. `main()` calls `ProjectController.offer_recovery()` after
+`window.show()` (never the constructor, so tests don't trigger it); a real save clears it.
+The snapshot is exactly the `.iap` shape, so restore reuses `load_project_data`.
+
 ## Autosave and Project Corruption Prevention
 
 ### Critical: Disable Autosave During Load
@@ -917,6 +933,12 @@ to keep the image legible — see the No Hardcoded Colors Rule for the broader
 "don't fight the theme/colours" theme.
 
 ## Tool Activation — One Choke-Point, Mutually Exclusive
+
+**Pose classes admit only the keypoint tool (#44).** Activating a shape tool
+(`toggle_tool`) or a SAM tool (`SAMController.toggle_sam_*`) while a pose class is
+selected is refused (button unchecked); selecting a pose class while a shape/SAM tool is
+active deactivates it (`ClassController.on_class_selected`). Editing a schema is still
+allowed on a legacy-mixed class. See ADR-029 Guards.
 
 All six canvas tools (Polygon, Rectangle, Paint, Eraser, SAM-box, SAM-points)
 go through a **single** activation method, `ImageAnnotator.activate_tool(name)`

--- a/docs/09_architecture_decisions.md
+++ b/docs/09_architecture_decisions.md
@@ -1612,6 +1612,12 @@ Project) calls `clear_recovery()`.
 **Consequences**:
 - ✅ Work is never silently lost before the first save; no modal ever fires from `auto_save`.
 - ✅ Restore reuses `load_project_data` unchanged (the snapshot has the `.iap` shape).
+- ✅ **Failure-path policy:** a *successful* restore **keeps** the snapshot (the project is
+  still unsaved) until the first real save retires it via `clear_recovery`, so a re-crash
+  before that save can still re-offer the work; a *corrupt or partially-loaded* snapshot is
+  **dropped** on the failed restore (with the UI reset to empty) so it can't nag on every
+  launch. A user who restores and then quits cleanly without editing is re-offered it next
+  launch — intentional, since the work is genuinely still unsaved.
 - ⚠️ The recovery pointer lives in per-user QSettings, so it is machine-local — acceptable,
   since a restore is always on the same machine that crashed.
 

--- a/docs/09_architecture_decisions.md
+++ b/docs/09_architecture_decisions.md
@@ -40,7 +40,7 @@ documented against, capped below the next major. The SAM fine-tuning loop
 
 ## ADR-003: Store Absolute Paths in Project Files
 
-**Status**: Accepted
+**Status**: Superseded by ADR-033 (dual absolute + relative paths for portability, #42)
 
 **Context**: Project files need to reference image locations
 
@@ -1353,6 +1353,17 @@ visibility, and (later PRs) COCO/YOLO-pose export-import + YOLO-pose training. T
   annotation can't become a pose instance and vice versa; a keypoint instance only
   moves to a pose class with an identical `names` list). The schema-definition dialog
   locks the keypoint count K once instances exist (only K can corrupt them).
+  **A class is pose OR regular, not both, enforced at the UI (#44):** defining a schema
+  on a class that already holds plain annotations is blocked
+  (`ClassController.define_keypoint_schema`, only for a *new* conversion — editing an
+  existing/legacy-mixed schema stays allowed so names/skeleton can still be fixed);
+  activating a shape tool (`toggle_tool`) or a SAM tool (`SAMController.toggle_sam_*`)
+  while a pose class is selected is refused (button unchecked); selecting a pose class
+  while a shape/SAM tool is active deactivates it (`on_class_selected`); and DINO
+  detection skips pose classes at the one config builder both paths share
+  (`_build_dino_class_configs`). Legacy-mixed classes from older projects still load,
+  render, and save — the guards only stop *new* mixing; `_pose_export_check` remains the
+  backstop for imported/legacy data.
 - **Area = bbox area (not 0).** `calculate_area` returns the stored box's `w*h` for a
   keypoint instance — deliberate, so sort-by-area behaves consistently with imported
   bbox annotations rather than dumping all poses to the end.
@@ -1578,9 +1589,72 @@ both reset the model selector.
 
 ## Decisions Under Consideration
 
+## ADR-032: Silent Recovery Autosave for Unsaved Projects via a QSettings-Known Location
+
+**Status**: Accepted (issue #41)
+
+**Context**: Autosave is event-driven — every mutation calls `auto_save()`. Before a
+project has ever been saved there is no `.iap` to write to, so the old code popped a
+modal "save now?" from inside the mutation handler. Declining it (or a crash) lost all
+work, and a modal raised from deep in a mutation re-enters the event loop mid-edit.
+Tracked as the "Autosave Doesn't Ask for File Location" debt. Related: ADR-005 (load
+guard), ADR-020 (QSettings precedent).
+
+**Decision**: With no `current_project_file`, `auto_save()` writes a **silent** recovery
+snapshot instead of prompting. The snapshot is exactly a `build_project_data()` dict — a
+new pure serializer factored out of `save_project()` (no dialogs, no file I/O, no image
+copying) — serialized like a real `.iap`, written atomically (temp file + `os.replace`)
+to `QStandardPaths.AppDataLocation/recovery/unsaved.iap.recovery`, its path stored under
+the QSettings key `recovery/pending_path` (same org/app as `app_settings`). A trivially
+empty session writes nothing. On the next launch, `main()` — after `window.show()`, never
+the constructor, so tests that build `ImageAnnotator()` don't trigger it — calls
+`ProjectController.offer_recovery()`, which offers to restore it. A real save (or New
+Project) calls `clear_recovery()`.
+
+**Consequences**:
+- ✅ Work is never silently lost before the first save; no modal ever fires from `auto_save`.
+- ✅ Restore reuses `load_project_data` unchanged (the snapshot has the `.iap` shape).
+- ⚠️ The recovery pointer lives in per-user QSettings, so it is machine-local — acceptable,
+  since a restore is always on the same machine that crashed.
+
+---
+
+## ADR-033: Dual Absolute + Relative Image Paths in `.iap`; Relative-First Resolution; Load-Time Validation
+
+**Status**: Accepted (issue #42; supersedes ADR-003)
+
+**Context**: `.iap` stored only absolute image paths, so a project folder couldn't be
+moved or shared (ADR-003). In practice the loader already rebuilt paths from
+`<project_dir>/images/<file_name>` and ignored the stored absolutes — they were dead data
+on load and merely leaked the author's machine paths.
+
+**Decision**: `build_project_data()` writes a portable `image_paths_rel` map (POSIX
+separators via `PurePath(os.path.relpath(...)).as_posix()`; a cross-drive `ValueError`
+just omits that entry) **alongside** the unchanged absolute `image_paths` (dual storage,
+so older app versions still open new files). `image_paths_rel` is written only when a
+project dir exists — recovery snapshots (ADR-032) for an unsaved project have none and
+rely on the absolutes. On load, `ProjectController.resolve_image_path()` returns the first
+that exists: relative → absolute (revives the old dead data, fixing images referenced
+outside `images/`) → the historical `images/` convention → missing. A new pure
+`core/project_schema.py::validate_project_data` runs right after `json.load` in
+`open_specific_project`, raising `ValueError` (surfaced by the existing backup-restore +
+error dialog) on a structurally broken file; it is deliberately lenient about unknown keys
+(the format keeps growing — keypoint schemas, DINO config, relative paths).
+
+**Consequences**:
+- ✅ A project folder (`.iap` + `images/`) is portable across machines/OSes.
+- ✅ v1 projects (no `image_paths_rel`) resolve exactly as before via the `images/` fallback.
+- ✅ A broken `.iap` fails with an actionable message instead of a random traceback.
+- ⚠️ Dual storage means the absolute paths still appear in the file; they are kept only for
+  backward-compatible opening, and relative paths win on load.
+
+---
+
 ### Consider Relative Paths with Image Copying
 
-**Status**: Under Consideration
+**Status**: Resolved by ADR-033 (#42) — implemented as dual absolute+relative paths
+*without* forced image copying (the copy-into-`images/` prompt already existed), so the
+"disk duplication" con below does not apply.
 
 **Proposal**: Copy images to project folder, store relative paths
 

--- a/docs/09_architecture_decisions.md
+++ b/docs/09_architecture_decisions.md
@@ -1587,8 +1587,6 @@ both reset the model selector.
 
 ---
 
-## Decisions Under Consideration
-
 ## ADR-032: Silent Recovery Autosave for Unsaved Projects via a QSettings-Known Location
 
 **Status**: Accepted (issue #41)
@@ -1649,6 +1647,8 @@ error dialog) on a structurally broken file; it is deliberately lenient about un
   backward-compatible opening, and relative paths win on load.
 
 ---
+
+## Decisions Under Consideration
 
 ### Consider Relative Paths with Image Copying
 

--- a/docs/11_risks_and_technical_debt.md
+++ b/docs/11_risks_and_technical_debt.md
@@ -49,11 +49,16 @@
 
 ### Project File Portability
 
-**Risk Level**: Low-Medium
+**Status**: Resolved (#42, ADR-033)
 
-**Description**: Projects store absolute paths, not portable between machines
+**Risk Level**: Low-Medium (historical)
 
-**Impact**:
+**Description**: ~~Projects store absolute paths, not portable between machines.~~
+`.iap` now stores portable `image_paths_rel` (POSIX separators) alongside the absolutes;
+`resolve_image_path()` resolves relative-first, so a moved or shared project folder opens
+without a missing-images prompt. v1 projects still resolve via the `images/` convention.
+
+**Original impact** (pre-#42):
 - Cannot share projects easily
 - Moving images breaks projects
 - Collaboration difficult
@@ -298,12 +303,12 @@ the orchestrator wires each to the matching controller slot.
 - A schema is **per class** (the COCO rule); all instances of a class share it.
 - A point set to *not labelled* (v=0) via "finish early" doesn't render and can't be
   relabelled with a right-click in PR-1 (only v>0 points are hit-testable).
-- **Defining a schema on a class that already holds normal (polygon/bbox) annotations
-  is unguarded** — nothing forbids a mixed pose + non-pose class. It renders/saves
-  fine, but the change-class guard then treats it inconsistently (a normal annotation
-  can no longer move into that class once it has a schema, even alongside its own
-  kind). Not fixed in PR-1; either forbid schema definition on a non-empty class or
-  explicitly relax the guard for the mixed case.
+- ~~**Defining a schema on a class that already holds normal (polygon/bbox) annotations
+  is unguarded**~~ **— Resolved (#44).** The UI now blocks *new* mixing in both
+  directions (schema-on-plain-class; shape/SAM-tool-on-pose-class;
+  pose-class-selection-while-a-tool-is-active; DINO skips pose classes); see ADR-029
+  Guards. Legacy-mixed classes still load/render/save, and `_pose_export_check` remains
+  the export backstop.
 - **Forthcoming** (PR-2/PR-3): YOLO-pose export requires a **single `kpt_shape` per
   dataset**, so a project mixing pose classes of different K (or pose + non-pose) can't
   export to YOLO-pose (COCO has no such limit). YOLO-pose *training* stays unsupported
@@ -327,13 +332,12 @@ the orchestrator wires each to the matching controller slot.
 
 ### Autosave Doesn't Ask for File Location
 
-**Status**: Known Behavior
+**Status**: Resolved (#41, ADR-032)
 
-**Description**: Autosave only works after first manual save
-
-**Impact**: New projects lose autosave protection until first save
-
-**Priority**: Low
+**Description**: ~~Autosave only works after first manual save.~~ Before the first save,
+`auto_save()` now writes a silent recovery snapshot (no dialog) that the app offers to
+restore on next launch; a real save clears it. New projects are protected from the first
+mutation.
 
 ---
 

--- a/src/digitalsreeni_image_annotator/annotator_window.py
+++ b/src/digitalsreeni_image_annotator/annotator_window.py
@@ -1037,6 +1037,25 @@ class ImageAnnotator(QMainWindow):
             self.keypoint_button: "keypoint",
         }
 
+        # A pose class admits only the keypoint tool. Block activating any shape
+        # tool on it (gate activation only — unchecking falls through, same
+        # discipline as the keypoint guard below). SAM buttons are guarded in
+        # SAMController.toggle_sam_*. (#44)
+        if (
+            sender in (self.polygon_button, self.rectangle_button,
+                       self.paint_brush_button, self.eraser_button)
+            and sender.isChecked()
+            and self.current_class in self.keypoint_schemas
+        ):
+            QMessageBox.warning(
+                self,
+                "Pose Class",
+                f"'{self.current_class}' is a pose class — only the Keypoint "
+                "tool can annotate it.",
+            )
+            sender.setChecked(False)
+            return
+
         # The keypoint tool needs a pose schema on the current class (#35). Only
         # gate activation — unchecking must always fall through to deactivate, or
         # button state and current_tool would drift on a schemaless class.

--- a/src/digitalsreeni_image_annotator/controllers/class_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/class_controller.py
@@ -270,6 +270,15 @@ class ClassController(QObject):
                 and self.mw.current_class not in self.mw.keypoint_schemas
             ):
                 self.mw.activate_tool(None)
+            # Conversely, a pose class admits only the keypoint tool: if a
+            # shape/SAM tool is active when a pose class is selected, deactivate
+            # it so a tool can't stay active-but-invalid on a pose class. (#44)
+            elif (
+                self.mw.current_class in self.mw.keypoint_schemas
+                and self.mw.image_label.current_tool is not None
+                and self.mw.image_label.current_tool != "keypoint"
+            ):
+                self.mw.activate_tool(None)
         else:
             self.mw.current_class = None
             self.mw.disable_annotation_tools()
@@ -326,6 +335,21 @@ class ClassController(QObject):
         from ..dialogs.keypoint_schema_dialog import KeypointSchemaDialog
 
         class_name = item.text()
+        # A class is pose OR regular, not both (ADR-029). Refuse to turn a class
+        # that already holds plain annotations into a pose class; editing the
+        # schema of an existing pose class (even a legacy-mixed one) stays
+        # allowed so names/skeleton can still be fixed. (#44)
+        is_new_pose_class = class_name not in self.mw.keypoint_schemas
+        if is_new_pose_class and self._class_has_plain_annotations(class_name):
+            QMessageBox.warning(
+                self.mw,
+                "Cannot Define Keypoint Schema",
+                f"'{class_name}' already has regular (polygon/box/paint) "
+                "annotations. A class can be a pose class or a regular class, "
+                "not both. Move or delete those annotations first, or create a "
+                "new class for poses.",
+            )
+            return
         has_instances = self._class_has_keypoint_instances(class_name)
         dialog = KeypointSchemaDialog(
             self.mw,
@@ -354,6 +378,15 @@ class ClassController(QObject):
         self.mw.image_label.update()
         if not self.mw.is_loading_project:
             self.mw.auto_save()
+
+    def _class_has_plain_annotations(self, class_name):
+        """True if the class holds any non-keypoint (polygon/box/paint)
+        annotation. A class is pose OR regular, not both (ADR-029 / #44)."""
+        for image_annotations in self.mw.all_annotations.values():
+            for ann in image_annotations.get(class_name, []):
+                if "keypoints" not in ann:
+                    return True
+        return False
 
     def _class_has_keypoint_instances(self, class_name):
         for image_annotations in self.mw.all_annotations.values():

--- a/src/digitalsreeni_image_annotator/controllers/dino_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/dino_controller.py
@@ -178,9 +178,22 @@ class DINOController(QObject):
         self.mw.dino_phrase_panel.set_active_class(name)
 
     def _build_dino_class_configs(self):
-        """Build class_configs from threshold table + phrase panel."""
+        """Build class_configs from threshold table + phrase panel.
+
+        Pose classes are skipped: DINO produces plain (box/mask) annotations,
+        which must never land in a pose class — a class is pose OR regular, not
+        both (ADR-029 / #44). Honored here, the one builder both the single and
+        batch detection paths share.
+        """
         configs = []
         for cfg in self.mw.dino_class_table.get_class_configs():
+            if cfg["name"] in self.mw.keypoint_schemas:
+                logger.info(
+                    "Skipping pose class '%s' for DINO detection "
+                    "(pose classes take keypoints only).",
+                    cfg["name"],
+                )
+                continue
             phrases = self.mw.dino_phrase_panel.get_phrases_for(cfg["name"])
             configs.append({
                 "name": cfg["name"],

--- a/src/digitalsreeni_image_annotator/controllers/project_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/project_controller.py
@@ -648,6 +648,8 @@ class ProjectController(QObject):
             not self.mw.all_images
             and not self.mw.image_label.class_colors
             and not any(self.mw.all_annotations.values())
+            and not self.mw.dino_phrase_panel.get_all_phrases()
+            and not self.mw.dino_class_table.get_thresholds_dict()
         )
 
     def offer_recovery(self, settings=None):
@@ -680,7 +682,6 @@ class ProjectController(QObject):
             recovery.clear_recovery(settings)
             return
 
-        restored = False
         try:
             self.mw.is_loading_project = True
             with open(path, "r", encoding="utf-8") as f:
@@ -690,9 +691,13 @@ class ProjectController(QObject):
                 raise ValueError("\n".join(problems))
             self.mw.clear_all(show_messages=False)
             self.load_project_data(project_data)
-            restored = True
         except Exception:
+            # A decode/validation failure (or a partial load) means the snapshot
+            # is unusable — drop it so it isn't re-offered on every launch, and
+            # reset to a clean empty state rather than a half-loaded one.
             logger.exception("Failed to restore recovery snapshot.")
+            self.mw.clear_all(show_messages=False)
+            recovery.clear_recovery(settings)
             QMessageBox.warning(
                 self.mw,
                 "Restore Failed",
@@ -701,7 +706,7 @@ class ProjectController(QObject):
         finally:
             self.mw.is_loading_project = False
 
-        # Only drop the snapshot once it has been successfully consumed; a failed
-        # restore keeps the file so the data isn't lost to a transient error.
-        if restored:
-            recovery.clear_recovery(settings)
+        # On success the snapshot is deliberately KEPT: the restored project is
+        # still unsaved (current_project_file is unset), so the first real save
+        # retires it (save_project -> clear_recovery). Keeping it until then means
+        # a re-crash before that save can still re-offer the recovered work.

--- a/src/digitalsreeni_image_annotator/controllers/project_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/project_controller.py
@@ -15,13 +15,15 @@ import json
 import os
 import shutil
 from datetime import datetime
+from pathlib import PurePath
 
 from PyQt6.QtCore import QObject
 from PyQt6.QtGui import QColor
 from PyQt6.QtWidgets import QFileDialog, QInputDialog, QMessageBox
 
-from ..core import image_utils
+from ..core import image_utils, recovery
 from ..core.keypoint_schema import sanitize_schema as _sanitize_keypoint_schema
+from ..core.project_schema import validate_project_data
 
 from ..core.logging_config import get_logger
 
@@ -124,6 +126,12 @@ class ProjectController(QObject):
                 with open(project_file, "r", encoding='utf-8') as f:
                     project_data = json.load(f)
 
+                problems = validate_project_data(project_data)
+                if problems:
+                    raise ValueError(
+                        "This project file is not valid:\n- " + "\n- ".join(problems)
+                    )
+
                 self.mw.clear_all(show_messages=False)
                 self.mw.current_project_file = project_file
                 self.mw.current_project_dir = os.path.dirname(project_file)
@@ -197,11 +205,9 @@ class ProjectController(QObject):
 
         missing_images = []
         for image_info in project_data["images"]:
-            image_path = os.path.join(
-                self.mw.current_project_dir, "images", image_info["file_name"]
-            )
+            image_path = self.resolve_image_path(image_info["file_name"], project_data)
 
-            if not os.path.exists(image_path):
+            if image_path is None:
                 missing_images.append(image_info["file_name"])
                 continue
 
@@ -250,6 +256,36 @@ class ProjectController(QObject):
         if self.mw.class_list.count() > 0:
             self.mw.class_list.setCurrentRow(0)
             self.mw.on_class_selected()
+
+    def resolve_image_path(self, file_name, project_data):
+        """Resolve a stored image reference to an existing absolute path (#42).
+
+        Tries, in order, the first that exists on disk:
+          1. the project-relative path (portable across machines/OSes);
+          2. the stored absolute path (covers images referenced outside the
+             project's ``images/`` dir — previously dead data on load);
+          3. the historical ``<project_dir>/images/<file_name>`` convention
+             (so v1 projects with neither key resolve exactly as before).
+        Returns None when none exist — the caller reports it as missing.
+        """
+        project_dir = getattr(self.mw, "current_project_dir", None)
+
+        rel = (project_data.get("image_paths_rel") or {}).get(file_name)
+        if rel and project_dir:
+            candidate = os.path.normpath(os.path.join(project_dir, rel))
+            if os.path.exists(candidate):
+                return candidate
+
+        abs_path = (project_data.get("image_paths") or {}).get(file_name)
+        if abs_path and os.path.exists(abs_path):
+            return abs_path
+
+        if project_dir:
+            candidate = os.path.join(project_dir, "images", file_name)
+            if os.path.exists(candidate):
+                return candidate
+
+        return None
 
     def handle_missing_images(self, missing_images):
         message = "The following images have annotations but were not found in the project directory:\n\n"
@@ -392,55 +428,14 @@ class ProjectController(QObject):
 
         self.update_window_title()
 
-    def save_project(self, show_message=True):
-        if not hasattr(self.mw, "current_project_file") or not self.mw.current_project_file:
-            self.mw.current_project_file, _ = QFileDialog.getSaveFileName(
-                self.mw, "Save Project", "", "Image Annotator Project (*.iap)"
-            )
-            if not self.mw.current_project_file:
-                return
+    def build_project_data(self):
+        """Assemble the full project dict for serialization.
 
-        self.mw.current_project_dir = os.path.dirname(self.mw.current_project_file)
-
-        images_dir = os.path.join(self.mw.current_project_dir, "images")
-        os.makedirs(images_dir, exist_ok=True)
-
-        images_to_copy = []
-        for file_name, src_path in self.mw.image_paths.items():
-            dst_path = os.path.join(images_dir, file_name)
-            if os.path.abspath(src_path) != os.path.abspath(dst_path):
-                if not os.path.exists(dst_path):
-                    images_to_copy.append((file_name, src_path, dst_path))
-
-        if images_to_copy:
-            reply = QMessageBox.question(
-                self.mw,
-                "Image Directory Structure",
-                f"The project structure requires all images to be in an 'images' subdirectory. "
-                f"{len(images_to_copy)} images need to be copied to the correct location. "
-                f"Do you want to copy these images?",
-                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
-                QMessageBox.StandardButton.Yes,
-            )
-
-            if reply == QMessageBox.StandardButton.Yes:
-                for file_name, src_path, dst_path in images_to_copy:
-                    try:
-                        shutil.copy2(src_path, dst_path)
-                        self.mw.image_paths[file_name] = dst_path
-                    except Exception as e:
-                        QMessageBox.warning(
-                            self.mw, "Copy Failed", f"Failed to copy {file_name}: {str(e)}"
-                        )
-                        return
-            else:
-                QMessageBox.warning(
-                    self.mw,
-                    "Save Cancelled",
-                    "Project cannot be saved without the correct directory structure.",
-                )
-                return
-
+        Pure data-building only: no dialogs, no file I/O, no image copying — so
+        it can be reused by both save_project() and the silent unsaved-project
+        recovery writer (issue #41). For a saved project the output matches the
+        previous inline block, plus the portable ``image_paths_rel`` key (#42).
+        """
         images_data = []
         for image_info in self.mw.all_images:
             file_name = image_info["file_name"]
@@ -506,12 +501,84 @@ class ProjectController(QObject):
             "last_modified": datetime.now().isoformat(),
         }
 
+        # Portable, project-relative image paths alongside the absolutes (#42).
+        # Only when a project dir exists — recovery snapshots for an unsaved
+        # project have none and rely on the absolute paths (restore is
+        # same-machine). The absolute entries stay so older app versions still
+        # open the file; resolve_image_path() prefers the relative ones on load.
+        project_dir = getattr(self.mw, "current_project_dir", None)
+        if project_dir:
+            rel = {}
+            for file_name, abs_path in project_data["image_paths"].items():
+                try:
+                    rel[file_name] = PurePath(
+                        os.path.relpath(abs_path, project_dir)
+                    ).as_posix()
+                except ValueError:
+                    # Different drive (Windows): no relative path exists; the
+                    # absolute entry remains the fallback.
+                    pass
+            project_data["image_paths_rel"] = rel
+
         dino_cfg = {
             "phrases": self.mw.dino_phrase_panel.get_all_phrases(),
             "thresholds": self.mw.dino_class_table.get_thresholds_dict(),
         }
         if dino_cfg["phrases"] or dino_cfg["thresholds"]:
             project_data["dino_config"] = dino_cfg
+
+        return project_data
+
+    def save_project(self, show_message=True):
+        if not hasattr(self.mw, "current_project_file") or not self.mw.current_project_file:
+            self.mw.current_project_file, _ = QFileDialog.getSaveFileName(
+                self.mw, "Save Project", "", "Image Annotator Project (*.iap)"
+            )
+            if not self.mw.current_project_file:
+                return
+
+        self.mw.current_project_dir = os.path.dirname(self.mw.current_project_file)
+
+        images_dir = os.path.join(self.mw.current_project_dir, "images")
+        os.makedirs(images_dir, exist_ok=True)
+
+        images_to_copy = []
+        for file_name, src_path in self.mw.image_paths.items():
+            dst_path = os.path.join(images_dir, file_name)
+            if os.path.abspath(src_path) != os.path.abspath(dst_path):
+                if not os.path.exists(dst_path):
+                    images_to_copy.append((file_name, src_path, dst_path))
+
+        if images_to_copy:
+            reply = QMessageBox.question(
+                self.mw,
+                "Image Directory Structure",
+                f"The project structure requires all images to be in an 'images' subdirectory. "
+                f"{len(images_to_copy)} images need to be copied to the correct location. "
+                f"Do you want to copy these images?",
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                QMessageBox.StandardButton.Yes,
+            )
+
+            if reply == QMessageBox.StandardButton.Yes:
+                for file_name, src_path, dst_path in images_to_copy:
+                    try:
+                        shutil.copy2(src_path, dst_path)
+                        self.mw.image_paths[file_name] = dst_path
+                    except Exception as e:
+                        QMessageBox.warning(
+                            self.mw, "Copy Failed", f"Failed to copy {file_name}: {str(e)}"
+                        )
+                        return
+            else:
+                QMessageBox.warning(
+                    self.mw,
+                    "Save Cancelled",
+                    "Project cannot be saved without the correct directory structure.",
+                )
+                return
+
+        project_data = self.build_project_data()
 
         with open(self.mw.current_project_file, "w", encoding='utf-8') as f:
             json.dump(image_utils.convert_to_serializable(project_data), f, indent=2)
@@ -520,6 +587,11 @@ class ProjectController(QObject):
             self.mw.show_info(
                 "Project Saved", f"Project saved to {self.mw.current_project_file}"
             )
+
+        # The project now has a real `.iap`; drop any unsaved-project recovery
+        # snapshot so a stale one is never offered on next launch (issue #41).
+        # Covers new_project() too, which saves immediately after creation.
+        recovery.clear_recovery()
 
         self.update_window_title()
 
@@ -553,19 +625,83 @@ class ProjectController(QObject):
         if self.mw.is_loading_project:
             return
 
-        if not hasattr(self.mw, "current_project_file"):
-            reply = QMessageBox.question(
-                self.mw,
-                "No Project",
-                "You need to save the project before auto-saving. Would you like to save now?",
-                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
-                QMessageBox.StandardButton.Yes,
-            )
-            if reply == QMessageBox.StandardButton.Yes:
-                self.save_project()
-            else:
+        if not getattr(self.mw, "current_project_file", None):
+            # No project file yet. NEVER pop a dialog here — auto_save fires from
+            # deep inside mutation handlers, and a modal there re-enters the event
+            # loop mid-edit. Instead write a silent recovery snapshot the app
+            # offers to restore on next launch (issue #41). Skip a trivially empty
+            # session so a fresh launch never creates a recovery file.
+            if self._project_is_trivially_empty():
                 return
+            try:
+                recovery.write_recovery(self.build_project_data())
+            except Exception:
+                logger.exception("Failed to write unsaved-project recovery snapshot.")
+            return
 
-        if hasattr(self.mw, "current_project_file"):
-            self.save_project(show_message=False)
-            logger.info("Project auto-saved.")
+        self.save_project(show_message=False)
+        logger.info("Project auto-saved.")
+
+    def _project_is_trivially_empty(self):
+        """True when nothing worth recovering has been done yet (#41)."""
+        return (
+            not self.mw.all_images
+            and not self.mw.image_label.class_colors
+            and not any(self.mw.all_annotations.values())
+        )
+
+    def offer_recovery(self, settings=None):
+        """On launch, offer to restore an unsaved-project recovery snapshot (#41).
+
+        Fired from ``main()`` after the window is shown — never from the
+        constructor, so tests that build ``ImageAnnotator()`` don't trigger it.
+        On accept, the snapshot loads through the normal ``load_project_data``
+        path but ``current_project_file`` is left unset, so the user still does a
+        first real save (and continued edits keep writing fresh snapshots).
+        """
+        path = recovery.pending_recovery(settings)
+        if not path:
+            return
+        try:
+            mtime = datetime.fromtimestamp(os.path.getmtime(path)).strftime(
+                "%Y-%m-%d %H:%M:%S"
+            )
+        except OSError:
+            mtime = "an earlier session"
+        reply = QMessageBox.question(
+            self.mw,
+            "Restore Unsaved Work",
+            f"An unsaved project from a previous session was found "
+            f"(last modified {mtime}). Restore it?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.Yes,
+        )
+        if reply != QMessageBox.StandardButton.Yes:
+            recovery.clear_recovery(settings)
+            return
+
+        restored = False
+        try:
+            self.mw.is_loading_project = True
+            with open(path, "r", encoding="utf-8") as f:
+                project_data = json.load(f)
+            problems = validate_project_data(project_data)
+            if problems:
+                raise ValueError("\n".join(problems))
+            self.mw.clear_all(show_messages=False)
+            self.load_project_data(project_data)
+            restored = True
+        except Exception:
+            logger.exception("Failed to restore recovery snapshot.")
+            QMessageBox.warning(
+                self.mw,
+                "Restore Failed",
+                "The unsaved-project recovery file could not be restored.",
+            )
+        finally:
+            self.mw.is_loading_project = False
+
+        # Only drop the snapshot once it has been successfully consumed; a failed
+        # restore keeps the file so the data isn't lost to a transient error.
+        if restored:
+            recovery.clear_recovery(settings)

--- a/src/digitalsreeni_image_annotator/controllers/sam_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/sam_controller.py
@@ -172,15 +172,36 @@ class SAMController(QObject):
         # Route through the unified tool choke-point so SAM-box is mutually
         # exclusive with the manual tools and with SAM-points (F).
         if self.mw.sam_box_button.isChecked():
+            if self._pose_class_blocks_tool(self.mw.sam_box_button):
+                return
             self.mw.activate_tool("sam_box")
         else:
             self.mw.activate_tool(None)
 
     def toggle_sam_points(self):
         if self.mw.sam_points_button.isChecked():
+            if self._pose_class_blocks_tool(self.mw.sam_points_button):
+                return
             self.mw.activate_tool("sam_points")
         else:
             self.mw.activate_tool(None)
+
+    def _pose_class_blocks_tool(self, button):
+        """A pose class admits only the keypoint tool; refuse SAM on it (#44).
+
+        Unchecks the button and returns True when blocked, mirroring the
+        manual-tool guard in ImageAnnotator.toggle_tool.
+        """
+        if self.mw.current_class in self.mw.keypoint_schemas:
+            QMessageBox.warning(
+                self.mw,
+                "Pose Class",
+                f"'{self.mw.current_class}' is a pose class — only the "
+                "Keypoint tool can annotate it.",
+            )
+            button.setChecked(False)
+            return True
+        return False
 
     def change_sam_model(self, model_name):
         try:

--- a/src/digitalsreeni_image_annotator/core/project_schema.py
+++ b/src/digitalsreeni_image_annotator/core/project_schema.py
@@ -1,0 +1,67 @@
+"""Lightweight structural validation of loaded `.iap` project data (issue #42).
+
+Pure — no Qt imports — so it is unit-testable in isolation and reusable by the
+unsaved-project recovery restore path. It answers one question: "is this dict
+shaped enough like a project to load without a mid-load crash?" It deliberately
+does NOT reject unknown keys — the `.iap` format grows over time (keypoint
+schemas, DINO config, relative paths), and a strict whitelist would break
+forward compatibility.
+"""
+
+
+def _is_str(x):
+    return isinstance(x, str)
+
+
+def validate_project_data(data):
+    """Return a list of human-readable problems; empty list means OK.
+
+    Checks only load-critical shape, leniently:
+      - top level is a dict
+      - ``images`` is a list of dicts, each with a string ``file_name``
+      - ``classes`` (if present) is a list of dicts with string ``name``/``color``
+      - ``image_paths`` / ``image_paths_rel`` (if present) are dict[str, str]
+      - ``notes`` (if present) is a string
+    """
+    problems = []
+
+    if not isinstance(data, dict):
+        return ["Project data is not a JSON object."]
+
+    images = data.get("images")
+    if not isinstance(images, list):
+        problems.append("'images' must be a list.")
+    else:
+        for i, img in enumerate(images):
+            if not isinstance(img, dict):
+                problems.append(f"images[{i}] must be an object.")
+            elif not _is_str(img.get("file_name")):
+                problems.append(f"images[{i}] is missing a string 'file_name'.")
+
+    classes = data.get("classes")
+    if classes is not None:
+        if not isinstance(classes, list):
+            problems.append("'classes' must be a list.")
+        else:
+            for i, cls in enumerate(classes):
+                if not isinstance(cls, dict):
+                    problems.append(f"classes[{i}] must be an object.")
+                else:
+                    if not _is_str(cls.get("name")):
+                        problems.append(f"classes[{i}] is missing a string 'name'.")
+                    if not _is_str(cls.get("color")):
+                        problems.append(f"classes[{i}] is missing a string 'color'.")
+
+    for key in ("image_paths", "image_paths_rel"):
+        val = data.get(key)
+        if val is not None:
+            if not isinstance(val, dict) or not all(
+                _is_str(k) and _is_str(v) for k, v in val.items()
+            ):
+                problems.append(f"'{key}' must be an object of string→string.")
+
+    notes = data.get("notes")
+    if notes is not None and not _is_str(notes):
+        problems.append("'notes' must be a string.")
+
+    return problems

--- a/src/digitalsreeni_image_annotator/core/recovery.py
+++ b/src/digitalsreeni_image_annotator/core/recovery.py
@@ -1,0 +1,89 @@
+"""Silent recovery-file autosave for unsaved projects (issue #41).
+
+Work done before a project has ever been saved to disk is otherwise lost on a
+crash or an accidental quit: ``auto_save()`` has no ``.iap`` to write to. This
+module writes a snapshot of the current project state to an app-owned location
+and remembers its path in QSettings, so the app can offer to restore it on the
+next launch.
+
+The snapshot is exactly a ``build_project_data()`` dict serialized like a real
+``.iap`` (see ``ProjectController``), so restoring it needs no format-specific
+code. Kept free of any main-window / Qt-widget coupling so it stays
+unit-testable; every function accepts an optional ``QSettings`` instance,
+mirroring ``app_settings``.
+"""
+
+import json
+import os
+
+from PyQt6.QtCore import QSettings, QStandardPaths
+
+from . import image_utils
+from .logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# One stable recovery filename per install — a session overwrites it rather
+# than accumulating stale snapshots. The `.iap.recovery` suffix keeps it from
+# being mistaken for (or double-clicked as) a real project file.
+_RECOVERY_FILENAME = "unsaved.iap.recovery"
+_KEY_PENDING_PATH = "recovery/pending_path"
+
+
+def _settings(settings=None) -> QSettings:
+    # Same org/app as app_settings._settings() so every preference and the
+    # recovery pointer live in one store.
+    if settings is not None:
+        return settings
+    return QSettings("DigitalSreeni", "ImageAnnotator")
+
+
+def recovery_dir() -> str:
+    """App-owned writable dir for recovery snapshots, created on demand."""
+    base = QStandardPaths.writableLocation(
+        QStandardPaths.StandardLocation.AppDataLocation
+    )
+    path = os.path.join(base, "recovery")
+    os.makedirs(path, exist_ok=True)
+    return path
+
+
+def write_recovery(project_data, settings=None) -> str:
+    """Atomically write ``project_data`` as a recovery snapshot; remember its path.
+
+    Written to a temp file then ``os.replace``d into place, so a crash mid-write
+    can never truncate a previously-good snapshot. Returns the snapshot path.
+    """
+    path = os.path.join(recovery_dir(), _RECOVERY_FILENAME)
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(image_utils.convert_to_serializable(project_data), f, indent=2)
+    os.replace(tmp, path)
+    _settings(settings).setValue(_KEY_PENDING_PATH, path)
+    return path
+
+
+def pending_recovery(settings=None):
+    """Return the pending snapshot path iff the key and the file both exist.
+
+    Otherwise clear a stale key and return ``None``.
+    """
+    s = _settings(settings)
+    path = s.value(_KEY_PENDING_PATH, "", type=str)
+    if path and os.path.exists(path):
+        return path
+    if path:
+        s.remove(_KEY_PENDING_PATH)
+    return None
+
+
+def clear_recovery(settings=None) -> None:
+    """Delete the snapshot (best-effort) and forget its path. Idempotent."""
+    s = _settings(settings)
+    path = s.value(_KEY_PENDING_PATH, "", type=str)
+    if path:
+        try:
+            os.remove(path)
+        except OSError:
+            pass  # already gone / never written — nothing to reclaim
+    s.remove(_KEY_PENDING_PATH)

--- a/src/digitalsreeni_image_annotator/main.py
+++ b/src/digitalsreeni_image_annotator/main.py
@@ -45,6 +45,10 @@ def main():
     app = QApplication(sys.argv)
     window = ImageAnnotator()
     window.show()
+    # Offer to restore an unsaved-project recovery snapshot from a previous
+    # session (issue #41). Done here — after show(), never in the constructor —
+    # so tests that build ImageAnnotator() directly never trigger the modal.
+    window.project_controller.offer_recovery()
     sys.exit(app.exec())
 
 if __name__ == "__main__":

--- a/tests/integration/test_keypoint_controller.py
+++ b/tests/integration/test_keypoint_controller.py
@@ -345,3 +345,120 @@ def test_switching_to_non_pose_class_deactivates_keypoint_tool(window):
 
     assert window.image_label.current_tool is None
     assert not window.keypoint_button.isChecked()
+
+
+# --- #44: a class is pose OR regular, not both (mixed-class guards) ---
+
+
+def test_define_schema_blocked_on_class_with_plain_annotations(window, monkeypatch):
+    # Turning a class that already holds polygons into a pose class is refused.
+    window.add_class("cell")
+    window.all_annotations["img.png"] = {
+        "cell": [{"segmentation": [0.0, 0.0, 1.0, 1.0, 1.0, 0.0],
+                  "category_name": "cell"}]
+    }
+    warned = []
+    monkeypatch.setattr(
+        "digitalsreeni_image_annotator.controllers.class_controller.QMessageBox.warning",
+        lambda *a, **k: warned.append(a),
+    )
+    item = window.class_list.findItems("cell", Qt.MatchFlag.MatchExactly)[0]
+    window.class_controller.define_keypoint_schema(item)
+    assert warned
+    assert "cell" not in window.keypoint_schemas
+
+
+def test_define_schema_allowed_editing_existing_pose_class(window, monkeypatch):
+    # Editing the schema of an existing pose class stays allowed even if it is
+    # a legacy-mixed class (has plain annotations) — only *new* conversions are
+    # blocked, so names/skeleton can still be fixed.
+    _pose_class(window, name="person")
+    window.all_annotations["img.png"] = {
+        "person": [{"segmentation": [0.0, 0.0, 1.0, 1.0, 1.0, 0.0],
+                    "category_name": "person"}]
+    }
+    from PyQt6.QtWidgets import QDialog
+
+    constructed = {"yes": False}
+
+    class _FakeDialog:
+        DialogCode = QDialog.DialogCode
+
+        def __init__(self, *a, **k):
+            constructed["yes"] = True
+
+        def exec(self):
+            return QDialog.DialogCode.Rejected  # cancel — no schema change
+
+    monkeypatch.setattr(
+        "digitalsreeni_image_annotator.dialogs.keypoint_schema_dialog.KeypointSchemaDialog",
+        _FakeDialog,
+    )
+    item = window.class_list.findItems("person", Qt.MatchFlag.MatchExactly)[0]
+    window.class_controller.define_keypoint_schema(item)
+    assert constructed["yes"]  # the editor opened; the guard did not block
+
+
+def test_shape_tool_blocked_on_pose_class(window, monkeypatch):
+    _pose_class(window, name="person")
+    window.enable_annotation_tools()  # tools are enabled once a class is selected
+    monkeypatch.setattr(window.image_label, "check_unsaved_changes", lambda: True)
+    warned = []
+    monkeypatch.setattr(
+        "digitalsreeni_image_annotator.annotator_window.QMessageBox.warning",
+        lambda *a, **k: warned.append(a),
+    )
+    window.polygon_button.click()  # user clicks Polygon while a pose class is selected
+    assert warned
+    assert not window.polygon_button.isChecked()
+    assert window.image_label.current_tool is None
+
+
+def test_sam_box_blocked_on_pose_class(window, monkeypatch):
+    _pose_class(window, name="person")
+    warned = []
+    monkeypatch.setattr(
+        "digitalsreeni_image_annotator.controllers.sam_controller.QMessageBox.warning",
+        lambda *a, **k: warned.append(a),
+    )
+    window.sam_box_button.setChecked(True)
+    window.sam_controller.toggle_sam_box()
+    assert warned
+    assert not window.sam_box_button.isChecked()
+    assert window.image_label.current_tool is None
+
+
+def test_keypoint_tool_still_activates_on_pose_class(window, monkeypatch):
+    _pose_class(window, name="person")
+    window.enable_annotation_tools()
+    monkeypatch.setattr(window.image_label, "check_unsaved_changes", lambda: True)
+    window.keypoint_button.click()
+    assert window.image_label.current_tool == "keypoint"
+    assert window.keypoint_button.isChecked()
+
+
+def test_selecting_pose_class_deactivates_active_shape_tool(window, monkeypatch):
+    _pose_class(window, name="person")
+    window.add_class("cell")  # normal class
+    window.current_class = "cell"
+    window.activate_tool("polygon")
+    assert window.image_label.current_tool == "polygon"
+
+    monkeypatch.setattr(window.image_label, "check_unsaved_changes", lambda: True)
+    person_item = window.class_list.findItems("person", Qt.MatchFlag.MatchExactly)[0]
+    window.class_controller.on_class_selected(person_item)
+    assert window.image_label.current_tool is None
+
+
+def test_dino_build_configs_skips_pose_class(window, monkeypatch):
+    window.keypoint_schemas["person"] = copy.deepcopy(_SCHEMA)
+    monkeypatch.setattr(
+        window.dino_class_table, "get_class_configs",
+        lambda: [
+            {"name": "person", "box_thr": 0.3, "txt_thr": 0.25, "nms_thr": 0.5},
+            {"name": "cell", "box_thr": 0.3, "txt_thr": 0.25, "nms_thr": 0.5},
+        ],
+    )
+    monkeypatch.setattr(window.dino_phrase_panel, "get_phrases_for", lambda name: ["x"])
+    configs = window.dino_controller._build_dino_class_configs()
+    assert [c["name"] for c in configs] == ["cell"]

--- a/tests/integration/test_project_paths.py
+++ b/tests/integration/test_project_paths.py
@@ -154,3 +154,38 @@ def test_autosave_with_no_project_writes_recovery(window, tmp_path, monkeypatch)
         data = json.load(f)
     assert "cell" in {c["name"] for c in data["classes"]}
     assert any(i["file_name"] == "a.png" for i in data["images"])
+
+
+def _redirect_recovery(tmp_path, monkeypatch):
+    from digitalsreeni_image_annotator.core import recovery
+
+    rec_dir = tmp_path / "rec"
+    rec_dir.mkdir()
+    ini = QSettings(str(tmp_path / "s.ini"), QSettings.Format.IniFormat)
+    monkeypatch.setattr(recovery, "recovery_dir", lambda: str(rec_dir))
+    monkeypatch.setattr(
+        recovery, "_settings",
+        lambda settings=None: settings if settings is not None else ini,
+    )
+    return recovery
+
+
+def test_offer_recovery_keeps_snapshot_on_successful_restore(window, tmp_path, monkeypatch):
+    # The restored project is still unsaved, so the snapshot must survive until
+    # the first real save — a re-crash before then can still re-offer it.
+    recovery = _redirect_recovery(tmp_path, monkeypatch)
+    recovery.write_recovery(
+        {"classes": [{"name": "cell", "color": "#ff0000"}], "images": []}
+    )
+    window.project_controller.offer_recovery()  # question() is patched to Yes
+    assert "cell" in window.class_mapping
+    assert recovery.pending_recovery() is not None
+
+
+def test_offer_recovery_clears_corrupt_snapshot(window, tmp_path, monkeypatch):
+    # A structurally broken snapshot is unusable — drop it so it isn't re-offered
+    # on every launch.
+    recovery = _redirect_recovery(tmp_path, monkeypatch)
+    recovery.write_recovery({"images": "nope"})  # validation will reject this
+    window.project_controller.offer_recovery()
+    assert recovery.pending_recovery() is None

--- a/tests/integration/test_project_paths.py
+++ b/tests/integration/test_project_paths.py
@@ -1,0 +1,156 @@
+"""Project portability (relative paths), load validation, and unsaved-project
+recovery — integration tests (#41 / #42).
+
+One real offscreen ImageAnnotator. Saves a project and confirms both absolute
+and relative image-path dicts land in the `.iap`; moves the whole project dir
+and confirms it still opens with no missing-image prompt; covers the v1
+(no image_paths_rel) fallback and structural-validation rejection; and exercises
+the silent recovery write when there is no project file yet.
+"""
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+from PyQt6.QtCore import QSettings
+from PyQt6.QtGui import QColor, QImage
+
+
+@pytest.fixture
+def window(qt_application):
+    from digitalsreeni_image_annotator.annotator_window import ImageAnnotator
+
+    w = ImageAnnotator()
+    yield w
+    w.deleteLater()
+
+
+@pytest.fixture(autouse=True)
+def _no_native_dialogs(monkeypatch):
+    """No modal may open in an offscreen run — patch every reachable one."""
+    from PyQt6.QtWidgets import QFileDialog, QMessageBox
+
+    monkeypatch.setattr(
+        QMessageBox, "question",
+        staticmethod(lambda *a, **k: QMessageBox.StandardButton.Yes),
+    )
+    monkeypatch.setattr(QMessageBox, "information", staticmethod(lambda *a, **k: None))
+    monkeypatch.setattr(QMessageBox, "warning", staticmethod(lambda *a, **k: None))
+    monkeypatch.setattr(QMessageBox, "critical", staticmethod(lambda *a, **k: None))
+    monkeypatch.setattr(
+        QFileDialog, "getOpenFileNames", staticmethod(lambda *a, **k: ([], ""))
+    )
+
+
+def _make_project(window, project_dir):
+    """A project dir with one real PNG in images/, wired onto the window."""
+    images_dir = project_dir / "images"
+    images_dir.mkdir(parents=True)
+    img = QImage(16, 12, QImage.Format.Format_RGB32)
+    img.fill(QColor("red"))
+    img.save(str(images_dir / "a.png"))
+
+    window.current_project_file = str(project_dir / "proj.iap")
+    window.current_project_dir = str(project_dir)
+    window.add_class("cell", QColor("#ff0000"))
+    window.all_images.append({"file_name": "a.png", "width": 16, "height": 12,
+                              "id": 1, "is_multi_slice": False})
+    window.image_paths["a.png"] = str(images_dir / "a.png")
+    window.all_annotations["a.png"] = {"cell": []}
+    return Path(window.current_project_file)
+
+
+def test_save_writes_both_path_dicts(window, tmp_path):
+    proj = _make_project(window, tmp_path / "proj")
+    window.project_controller.save_project(show_message=False)
+
+    data = json.loads(proj.read_text(encoding="utf-8"))
+    assert "image_paths" in data and "image_paths_rel" in data
+    assert data["image_paths_rel"]["a.png"] == "images/a.png"
+    assert "\\" not in data["image_paths_rel"]["a.png"]  # POSIX separators
+
+
+def test_moved_project_reopens_without_missing_prompt(window, tmp_path, monkeypatch):
+    src = tmp_path / "proj"
+    _make_project(window, src)
+    window.project_controller.save_project(show_message=False)
+
+    # Move the whole project dir to a new path (a different machine, in effect).
+    dst = tmp_path / "moved"
+    shutil.move(str(src), str(dst))
+
+    called = {"missing": False}
+    monkeypatch.setattr(
+        window.project_controller, "handle_missing_images",
+        lambda missing: called.__setitem__("missing", True),
+    )
+    window.project_controller.open_specific_project(str(dst / "proj.iap"))
+
+    assert called["missing"] is False
+    assert Path(window.image_paths["a.png"]).resolve() == (dst / "images" / "a.png").resolve()
+
+
+def test_v1_project_without_rel_resolves_via_images_convention(window, tmp_path):
+    src = tmp_path / "proj"
+    _make_project(window, src)
+    window.project_controller.save_project(show_message=False)
+
+    proj = src / "proj.iap"
+    data = json.loads(proj.read_text(encoding="utf-8"))
+    del data["image_paths_rel"]                       # simulate a pre-#42 file
+    data["image_paths"] = {"a.png": "/nonexistent/a.png"}  # abs fallback dead
+    proj.write_text(json.dumps(data), encoding="utf-8")
+
+    window.project_controller.open_specific_project(str(proj))
+    assert Path(window.image_paths["a.png"]).exists()
+
+
+def test_structurally_broken_project_raises(window, tmp_path):
+    proj = tmp_path / "broken.iap"
+    proj.write_text(json.dumps({"images": "not-a-list"}), encoding="utf-8")
+    with pytest.raises(ValueError):
+        window.project_controller.open_specific_project(str(proj))
+
+
+def test_autosave_with_no_project_writes_recovery(window, tmp_path, monkeypatch):
+    """With no project file, auto_save writes a silent recovery snapshot (no
+    dialog) that a fresh window can load back."""
+    from digitalsreeni_image_annotator.core import recovery
+
+    rec_dir = tmp_path / "rec"
+    rec_dir.mkdir()
+    ini = QSettings(str(tmp_path / "s.ini"), QSettings.Format.IniFormat)
+    monkeypatch.setattr(recovery, "recovery_dir", lambda: str(rec_dir))
+    monkeypatch.setattr(
+        recovery, "_settings",
+        lambda settings=None: settings if settings is not None else ini,
+    )
+
+    # A real image on disk so the snapshot's absolute path resolves on restore.
+    images_dir = tmp_path / "imgs"
+    images_dir.mkdir()
+    img = QImage(4, 4, QImage.Format.Format_RGB32)
+    img.fill(QColor("red"))
+    img.save(str(images_dir / "a.png"))
+
+    if hasattr(window, "current_project_file"):
+        del window.current_project_file
+    window.add_class("cell", QColor("#ff0000"))
+    window.all_images.append({"file_name": "a.png", "width": 4, "height": 4,
+                              "id": 1, "is_multi_slice": False})
+    window.image_paths["a.png"] = str(images_dir / "a.png")
+    window.all_annotations["a.png"] = {
+        "cell": [{"segmentation": [0.0, 0.0, 1.0, 1.0, 1.0, 0.0],
+                  "category_name": "cell"}]
+    }
+
+    window.project_controller.auto_save()
+
+    path = recovery.pending_recovery()
+    assert path and Path(path).exists()
+
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+    assert "cell" in {c["name"] for c in data["classes"]}
+    assert any(i["file_name"] == "a.png" for i in data["images"])

--- a/tests/unit/test_project_schema.py
+++ b/tests/unit/test_project_schema.py
@@ -1,0 +1,55 @@
+"""Unit tests for load-time `.iap` structural validation (#42).
+
+validate_project_data answers only "is this shaped enough to load without a
+mid-load crash?" — leniently, and it must never reject unknown keys (the format
+grows: keypoint schemas, DINO config, relative paths).
+"""
+
+from digitalsreeni_image_annotator.core.project_schema import validate_project_data
+
+
+def test_valid_minimal_returns_empty():
+    assert validate_project_data({"images": []}) == []
+
+
+def test_valid_full_returns_empty():
+    data = {
+        "images": [{"file_name": "a.png"}],
+        "classes": [{"name": "cell", "color": "#ff0000"}],
+        "image_paths": {"a.png": "/abs/a.png"},
+        "image_paths_rel": {"a.png": "images/a.png"},
+        "notes": "hello",
+    }
+    assert validate_project_data(data) == []
+
+
+def test_non_dict_top_level_is_rejected():
+    assert validate_project_data([1, 2, 3])
+
+
+def test_images_not_a_list_is_rejected():
+    assert any("images" in p for p in validate_project_data({"images": "nope"}))
+
+
+def test_image_entry_without_file_name_is_rejected():
+    problems = validate_project_data({"images": [{"width": 10}]})
+    assert any("file_name" in p for p in problems)
+
+
+def test_class_missing_color_is_rejected():
+    data = {"images": [], "classes": [{"name": "cell"}]}
+    assert any("color" in p for p in validate_project_data(data))
+
+
+def test_non_str_path_value_is_rejected():
+    data = {"images": [], "image_paths": {"a.png": 123}}
+    assert any("image_paths" in p for p in validate_project_data(data))
+
+
+def test_notes_wrong_type_is_rejected():
+    assert any("notes" in p for p in validate_project_data({"images": [], "notes": 5}))
+
+
+def test_unknown_keys_are_allowed():
+    data = {"images": [], "keypoint_schema": {"x": 1}, "dino_config": {"phrases": {}}}
+    assert validate_project_data(data) == []

--- a/tests/unit/test_recovery.py
+++ b/tests/unit/test_recovery.py
@@ -1,0 +1,80 @@
+"""Unit tests for the unsaved-project recovery store (#41).
+
+The recovery *directory* is redirected into tmp_path (monkeypatching
+``recovery_dir``) and the QSettings pointer is an INI file, so nothing touches
+the real per-user AppData / registry.
+"""
+
+import json
+import os
+
+import pytest
+from PyQt6.QtCore import QSettings
+
+from digitalsreeni_image_annotator.core import recovery
+
+
+@pytest.fixture
+def rec_dir(tmp_path, monkeypatch):
+    d = tmp_path / "recovery"
+    d.mkdir()
+    monkeypatch.setattr(recovery, "recovery_dir", lambda: str(d))
+    return d
+
+
+@pytest.fixture
+def settings(tmp_path):
+    return QSettings(str(tmp_path / "s.ini"), QSettings.Format.IniFormat)
+
+
+SAMPLE = {
+    "classes": [{"name": "cell", "color": "#ff0000"}],
+    "images": [],
+    "notes": "hi",
+}
+
+
+def test_write_then_pending_returns_path(rec_dir, settings):
+    path = recovery.write_recovery(SAMPLE, settings)
+    assert os.path.exists(path)
+    assert recovery.pending_recovery(settings) == path
+
+
+def test_written_content_roundtrips(rec_dir, settings):
+    path = recovery.write_recovery(SAMPLE, settings)
+    with open(path, encoding="utf-8") as f:
+        assert json.load(f) == SAMPLE
+
+
+def test_pending_with_deleted_file_returns_none_and_clears_key(rec_dir, settings):
+    path = recovery.write_recovery(SAMPLE, settings)
+    os.remove(path)
+    assert recovery.pending_recovery(settings) is None
+    # The stale pointer is cleared, so a second probe is also None.
+    assert settings.value("recovery/pending_path", "", type=str) == ""
+
+
+def test_clear_removes_file_and_key(rec_dir, settings):
+    path = recovery.write_recovery(SAMPLE, settings)
+    recovery.clear_recovery(settings)
+    assert not os.path.exists(path)
+    assert recovery.pending_recovery(settings) is None
+
+
+def test_clear_is_idempotent_when_nothing_pending(rec_dir, settings):
+    recovery.clear_recovery(settings)
+    recovery.clear_recovery(settings)  # must not raise
+
+
+def test_write_leaves_no_tmp_file(rec_dir, settings):
+    recovery.write_recovery(SAMPLE, settings)
+    assert not any(p.name.endswith(".tmp") for p in rec_dir.iterdir())
+
+
+def test_second_write_overwrites_single_file(rec_dir, settings):
+    recovery.write_recovery(SAMPLE, settings)
+    recovery.write_recovery({**SAMPLE, "notes": "second"}, settings)
+    files = list(rec_dir.iterdir())
+    assert len(files) == 1
+    with open(files[0], encoding="utf-8") as f:
+        assert json.load(f)["notes"] == "second"


### PR DESCRIPTION
Phase B robustness bundle — three issues in one PR because #41 and #42 both rewrite the `save_project()` serializer (done apart = a guaranteed conflict on the same lines + the refactor twice); #44 is an independent correctness fix that rides along with zero conflict risk.

Closes #41
Closes #42
Closes #44

## #41 — Autosave protection before first manual save
- Extracted a **pure `ProjectController.build_project_data()`** from `save_project()` (no dialogs / no file I/O), reused by both the save path and the recovery writer.
- New **`core/recovery.py`**: silent snapshots to `QStandardPaths.AppDataLocation/recovery/` (atomic temp + `os.replace`), path stored in QSettings `recovery/pending_path`.
- `auto_save()`'s no-project branch now writes a **silent** recovery snapshot instead of a modal (a modal mid-mutation re-enters the event loop). Trivially-empty sessions write nothing (incl. DINO-only state).
- `main()` calls `ProjectController.offer_recovery()` **after `window.show()`** (never the constructor, so tests don't trigger it). **Lifecycle:** kept on successful restore until the first real save retires it (a re-crash can still re-offer); dropped on a corrupt/partial restore so it can't nag. **ADR-032.**

## #42 — Relative paths in `.iap` for portability
- `build_project_data()` writes portable **`image_paths_rel`** (POSIX separators) alongside the absolutes — only when a project dir exists (recovery snapshots have none). Cross-drive `ValueError` omits that entry.
- **`resolve_image_path()`**: relative → absolute → historical `images/` convention → missing. Moved/shared project folders open with no missing-image prompt; v1 files resolve exactly as before.
- New pure **`core/project_schema.py::validate_project_data`** runs after `json.load`, raising `ValueError` (surfaced by the existing backup-restore + dialog) on a structurally broken `.iap`; lenient about unknown keys. **Supersedes ADR-003. ADR-033.**

## #44 — Guard mixed pose/non-pose classes (ADR-029 gap)
A class is pose **or** regular, not both:
- `define_keypoint_schema` blocked on a class with plain annotations (new conversions only; editing a legacy-mixed schema still allowed).
- Shape tools (`toggle_tool`) and SAM tools (`toggle_sam_box/points`) refused while a pose class is selected (button unchecked).
- Selecting a pose class deactivates an active shape/SAM tool (`on_class_selected`).
- DINO skips pose classes at the one shared config builder (`_build_dino_class_configs`).
- Amends **ADR-029**; `_pose_export_check` stays the import/legacy backstop.

## Tests & quality
- **+30 tests** (recovery, project_schema, project_paths incl. recovery-lifecycle, keypoint-guard). Full suite **683 passed / 3 skipped**.
- Ruff: **0 new** errors (pre-existing baseline untouched). Headless launch OK.
- **Senior-reviewer** run in foreground and iterated to *mergeable* (it caught a real P1 — the recovery keep/clear policy was inverted — now fixed + regression-tested).
- Docs: ADR-032/033, ADR-029 guards, ADR-003 superseded; `docs/06/08/11` updated. CLAUDE.md now mandates `Closes #NN` in PR bodies (the PR #52 omission that left #33–#40 open).

## Manual test checklist (for reviewer)
- [x] Annotate with no project → recovery file appears, **no modal**; kill app, relaunch → restore offer; accept restores state; decline removes it. First Ctrl+S clears it.
- [x] Save a project → JSON has `image_paths` + `image_paths_rel`; move the folder → reopens with no missing-image prompt; open a pre-#42 project → unchanged.
- [x] Pose class: shape/SAM tools refused, keypoint tool works; define-schema refused on a class with polygons; DINO skips pose classes.
- [x] Dark mode: new UI is only `QMessageBox` dialogs — sanity check.

🧙 Built with [WOZCODE](https://wozcode.com)