### PR TITLE
feat: scrollable left sidebar so DINO/Annotations/Export keep usable sizes (#88)

### DIFF
--- a/docs/08_crosscutting_concepts.md
+++ b/docs/08_crosscutting_concepts.md
@@ -294,6 +294,28 @@ which on Windows means barely-visible radio-button indicators and
 white-on-white headers (the dataset splitter radio buttons hit this
 before they were styled).
 
+## Left Sidebar — Scrollable Layout (issue #88)
+
+The left sidebar (`ui/sidebar.py::build_sidebar`) stacks Import, Classes,
+the Annotation tools, the DINO panel, the Annotations table and Export in
+one `QVBoxLayout`. On short screens or at large UI font sizes an expanded
+DINO panel used to squeeze the Annotations table down to just its header
+row. The fix is structural, not per-widget:
+
+- The whole sidebar content widget lives inside a `QScrollArea`
+  (`window.sidebar_scroll`, `setWidgetResizable(True)`) that is what gets
+  added to the main layout — `window.sidebar` itself is the scroll area's
+  inner widget. Horizontal scrolling is `ScrollBarAlwaysOff`; because the
+  area is width-resizable the content tracks the viewport width and wraps.
+- Each vertically-competing section (`class_list`, `dino_class_table`,
+  `dino_phrase_panel`, `annotation_list`) carries a `setMinimumHeight(...)`
+  so it keeps a usable size. The sum of those minimums is what makes the
+  scroll area scroll when the window is too short — otherwise a section
+  could still collapse *inside* the scroll area.
+- The scroll area uses `QFrame.Shape.NoFrame` and sets no
+  `background:`/`color:` — the active stylesheet still paints the sidebar
+  (No Hardcoded Colors Rule above).
+
 ## UI Font Zoom (Low-Vision Mode)
 
 ### Single Source of Truth: `ui_font_pt`

--- a/docs/08_crosscutting_concepts.md
+++ b/docs/08_crosscutting_concepts.md
@@ -306,7 +306,9 @@ row. The fix is structural, not per-widget:
   (`window.sidebar_scroll`, `setWidgetResizable(True)`) that is what gets
   added to the main layout — `window.sidebar` itself is the scroll area's
   inner widget. Horizontal scrolling is `ScrollBarAlwaysOff`; because the
-  area is width-resizable the content tracks the viewport width and wraps.
+  area is width-resizable the content is resized to the viewport width. A
+  `setMinimumWidth` on the scroll area preserves the window-width floor the
+  sidebar's own `minimumSizeHint` used to impose.
 - Each vertically-competing section (`class_list`, `dino_class_table`,
   `dino_phrase_panel`, `annotation_list`) carries a `setMinimumHeight(...)`
   so it keeps a usable size. The sum of those minimums is what makes the

--- a/src/digitalsreeni_image_annotator/ui/sidebar.py
+++ b/src/digitalsreeni_image_annotator/ui/sidebar.py
@@ -12,6 +12,7 @@ from PyQt6.QtWidgets import (
     QAbstractItemView,
     QButtonGroup,
     QComboBox,
+    QFrame,
     QHBoxLayout,
     QHeaderView,
     QLabel,
@@ -43,7 +44,28 @@ def _section_header(text):
 def build_sidebar(window):
     window.sidebar = QWidget()
     window.sidebar_layout = QVBoxLayout(window.sidebar)
-    window.layout.addWidget(window.sidebar, 1)
+
+    # Wrap the sidebar contents in a scroll area (upstream #88). The DINO,
+    # Annotations and Export sections each keep a usable minimum height (set
+    # below) and the sidebar scrolls vertically when the window is too short,
+    # instead of the Annotations table collapsing to just its header row on
+    # small screens or at large UI font sizes. Horizontal scrolling is off:
+    # with setWidgetResizable(True) the content tracks the viewport width, so
+    # it wraps rather than scrolls sideways.
+    window.sidebar_scroll = QScrollArea()
+    window.sidebar_scroll.setWidgetResizable(True)
+    window.sidebar_scroll.setHorizontalScrollBarPolicy(
+        Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+    )
+    window.sidebar_scroll.setVerticalScrollBarPolicy(
+        Qt.ScrollBarPolicy.ScrollBarAsNeeded
+    )
+    # Structural only (no background/border literals) so the active stylesheet
+    # still paints the sidebar; a visible frame would punch a box into the
+    # soft-dark sidebar. See "No Hardcoded Colors Rule" in CLAUDE.md.
+    window.sidebar_scroll.setFrameShape(QFrame.Shape.NoFrame)
+    window.sidebar_scroll.setWidget(window.sidebar)
+    window.layout.addWidget(window.sidebar_scroll, 1)
 
     # Import functionality
     window.import_button = QPushButton("Import Annotations with Images")
@@ -77,6 +99,9 @@ def build_sidebar(window):
     # ImageAnnotator.__init__ post-setup_ui; moved here to live next
     # to the widget construction.
     window.class_list.itemChanged.connect(window.toggle_class_visibility)
+    # Usable minimum so the class list can't be squeezed to nothing when the
+    # sidebar scrolls (#88); the scroll area supplies scrolling instead.
+    window.class_list.setMinimumHeight(100)
     window.sidebar_layout.addWidget(window.class_list)
 
     # Annotation section
@@ -194,10 +219,12 @@ def build_sidebar(window):
     window.dino_class_table.itemSelectionChanged.connect(
         window.on_dino_class_row_changed
     )
+    window.dino_class_table.setMinimumHeight(80)  # keep usable when scrolled (#88)
     dino_layout.addWidget(window.dino_class_table)
 
     # Phrase editor
     window.dino_phrase_panel = PhraseEditorPanel()
+    window.dino_phrase_panel.setMinimumHeight(100)  # keep usable when scrolled (#88)
     dino_layout.addWidget(window.dino_phrase_panel)
 
     # Detect buttons
@@ -264,6 +291,9 @@ def build_sidebar(window):
     # themes. See dino_phrase_editor.ClassThresholdTable.
     table.setStyleSheet("QHeaderView::section { font-weight: bold; padding: 2px; }")
     window.annotation_list = table
+    # Usable minimum so the Annotations table can't collapse to its header row
+    # when the DINO panel expands (#88); the sidebar scrolls instead.
+    window.annotation_list.setMinimumHeight(140)
     window.annotation_list.itemSelectionChanged.connect(
         window.update_highlighted_annotations
     )

--- a/src/digitalsreeni_image_annotator/ui/sidebar.py
+++ b/src/digitalsreeni_image_annotator/ui/sidebar.py
@@ -50,8 +50,8 @@ def build_sidebar(window):
     # below) and the sidebar scrolls vertically when the window is too short,
     # instead of the Annotations table collapsing to just its header row on
     # small screens or at large UI font sizes. Horizontal scrolling is off:
-    # with setWidgetResizable(True) the content tracks the viewport width, so
-    # it wraps rather than scrolls sideways.
+    # with setWidgetResizable(True) the content is resized to the viewport
+    # width rather than scrolling sideways.
     window.sidebar_scroll = QScrollArea()
     window.sidebar_scroll.setWidgetResizable(True)
     window.sidebar_scroll.setHorizontalScrollBarPolicy(
@@ -60,6 +60,10 @@ def build_sidebar(window):
     window.sidebar_scroll.setVerticalScrollBarPolicy(
         Qt.ScrollBarPolicy.ScrollBarAsNeeded
     )
+    # Preserve the window-width floor the sidebar's own minimumSizeHint used to
+    # impose (a width-resizable scroll area with horizontal scroll off would
+    # otherwise let the window shrink until the multi-button rows clip).
+    window.sidebar_scroll.setMinimumWidth(260)
     # Structural only (no background/border literals) so the active stylesheet
     # still paints the sidebar; a visible frame would punch a box into the
     # soft-dark sidebar. See "No Hardcoded Colors Rule" in CLAUDE.md.
@@ -99,8 +103,8 @@ def build_sidebar(window):
     # ImageAnnotator.__init__ post-setup_ui; moved here to live next
     # to the widget construction.
     window.class_list.itemChanged.connect(window.toggle_class_visibility)
-    # Usable minimum so the class list can't be squeezed to nothing when the
-    # sidebar scrolls (#88); the scroll area supplies scrolling instead.
+    # Usable minimum (~4 rows) so the class list can't be squeezed to nothing
+    # when the sidebar scrolls (#88); the scroll area supplies scrolling.
     window.class_list.setMinimumHeight(100)
     window.sidebar_layout.addWidget(window.class_list)
 
@@ -219,12 +223,12 @@ def build_sidebar(window):
     window.dino_class_table.itemSelectionChanged.connect(
         window.on_dino_class_row_changed
     )
-    window.dino_class_table.setMinimumHeight(80)  # keep usable when scrolled (#88)
+    window.dino_class_table.setMinimumHeight(80)  # ~3 rows, usable when scrolled (#88)
     dino_layout.addWidget(window.dino_class_table)
 
     # Phrase editor
     window.dino_phrase_panel = PhraseEditorPanel()
-    window.dino_phrase_panel.setMinimumHeight(100)  # keep usable when scrolled (#88)
+    window.dino_phrase_panel.setMinimumHeight(100)  # ~4 rows, usable when scrolled (#88)
     dino_layout.addWidget(window.dino_phrase_panel)
 
     # Detect buttons
@@ -291,8 +295,8 @@ def build_sidebar(window):
     # themes. See dino_phrase_editor.ClassThresholdTable.
     table.setStyleSheet("QHeaderView::section { font-weight: bold; padding: 2px; }")
     window.annotation_list = table
-    # Usable minimum so the Annotations table can't collapse to its header row
-    # when the DINO panel expands (#88); the sidebar scrolls instead.
+    # Usable minimum (~5 rows) so the Annotations table can't collapse to its
+    # header row when the DINO panel expands (#88); the sidebar scrolls instead.
     window.annotation_list.setMinimumHeight(140)
     window.annotation_list.itemSelectionChanged.connect(
         window.update_highlighted_annotations

--- a/tests/integration/test_sidebar_scroll.py
+++ b/tests/integration/test_sidebar_scroll.py
@@ -1,0 +1,50 @@
+"""Integration test for the scrollable left sidebar (upstream issue #88).
+
+The left sidebar packs Import, Classes, Annotation tools, the DINO panel,
+the Annotations table and Export into one column. On small screens or at
+large UI font sizes an expanded DINO panel used to squeeze the Annotations
+table down to just its header row. The fix wraps the whole sidebar in a
+QScrollArea and gives each competing section a usable minimum height, so
+the sidebar scrolls vertically instead of collapsing a section.
+
+Constructs one full offscreen ImageAnnotator because the wiring under test
+is created in ui.sidebar.build_sidebar during setup_ui.
+"""
+
+import pytest
+
+
+@pytest.fixture
+def window(qt_application):
+    from digitalsreeni_image_annotator.annotator_window import ImageAnnotator
+
+    w = ImageAnnotator()
+    yield w
+    w.deleteLater()
+
+
+def test_sidebar_wrapped_in_scroll_area(window):
+    from PyQt6.QtWidgets import QScrollArea
+
+    assert isinstance(window.sidebar_scroll, QScrollArea)
+    assert window.sidebar_scroll.widgetResizable()
+    # The sidebar content widget is the scroll area's inner widget.
+    assert window.sidebar_scroll.widget() is window.sidebar
+
+
+def test_sidebar_has_no_horizontal_scroll(window):
+    from PyQt6.QtCore import Qt
+
+    assert (
+        window.sidebar_scroll.horizontalScrollBarPolicy()
+        == Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+    )
+
+
+def test_key_sections_keep_a_usable_minimum_height(window):
+    # Each vertically-competing section keeps a minimum so it can't be
+    # squeezed to a header row; the scroll area supplies scrolling instead.
+    assert window.class_list.minimumHeight() > 0
+    assert window.annotation_list.minimumHeight() > 0
+    assert window.dino_class_table.minimumHeight() > 0
+    assert window.dino_phrase_panel.minimumHeight() > 0

--- a/tests/integration/test_sidebar_scroll.py
+++ b/tests/integration/test_sidebar_scroll.py
@@ -32,19 +32,28 @@ def test_sidebar_wrapped_in_scroll_area(window):
     assert window.sidebar_scroll.widget() is window.sidebar
 
 
-def test_sidebar_has_no_horizontal_scroll(window):
+def test_sidebar_scroll_policies_and_parenting(window):
     from PyQt6.QtCore import Qt
 
     assert (
         window.sidebar_scroll.horizontalScrollBarPolicy()
         == Qt.ScrollBarPolicy.ScrollBarAlwaysOff
     )
+    assert (
+        window.sidebar_scroll.verticalScrollBarPolicy()
+        == Qt.ScrollBarPolicy.ScrollBarAsNeeded
+    )
+    # The scroll area (not the bare sidebar) is what sits in the main layout.
+    assert window.layout.indexOf(window.sidebar_scroll) != -1
+    assert window.layout.indexOf(window.sidebar) == -1
 
 
 def test_key_sections_keep_a_usable_minimum_height(window):
-    # Each vertically-competing section keeps a minimum so it can't be
+    # Each vertically-competing section keeps a real minimum so it can't be
     # squeezed to a header row; the scroll area supplies scrolling instead.
-    assert window.class_list.minimumHeight() > 0
-    assert window.annotation_list.minimumHeight() > 0
-    assert window.dino_class_table.minimumHeight() > 0
-    assert window.dino_phrase_panel.minimumHeight() > 0
+    # Assert the intended floors, not just > 0, so a later fat-finger to 1px
+    # that reintroduces the collapse is caught.
+    assert window.class_list.minimumHeight() >= 100
+    assert window.dino_class_table.minimumHeight() >= 80
+    assert window.dino_phrase_panel.minimumHeight() >= 100
+    assert window.annotation_list.minimumHeight() >= 140


### PR DESCRIPTION
## Summary

Implements upstream issue #88 (ported to the fork). The left sidebar packs Import, Classes, Annotation tools, the DINO panel, the Annotations table and Export into a single column. On short screens or at large UI font sizes an expanded DINO panel squeezed the **Annotations** table down to just its header row.

This wraps the sidebar content in a `QScrollArea` and gives the vertically-competing sections a usable minimum height, so the sidebar **scrolls** vertically instead of collapsing a section.

## Changes

- `ui/sidebar.py`: `build_sidebar` now puts `window.sidebar` inside `window.sidebar_scroll` (`QScrollArea`, `setWidgetResizable(True)`, horizontal scroll off, `NoFrame`, `setMinimumWidth(260)` to keep the old window-width floor). Minimum heights on `class_list` (100), `dino_class_table` (80), `dino_phrase_panel` (100), `annotation_list` (140).
- `tests/integration/test_sidebar_scroll.py`: new — asserts the scroll wrapping, parenting into the main layout, scroll-bar policies, and the real min-height floors.
- `docs/08_crosscutting_concepts.md`: new "Left Sidebar — Scrollable Layout" section.

## Compliance

- **No Hardcoded Colors Rule**: no `background:`/`color:` literals; `QFrame.Shape.NoFrame` + the active stylesheet paints the sidebar (verified in dark mode reasoning by the senior review).
- Full suite green (686 passed / 3 skipped locally); ruff clean on changed files.
- Senior-reviewer gate: **mergeable as-is**, P2 nits addressed in the second commit.

## Phase chain

This is **Phase 1** of an overnight stacked chain (#88 → #46 → #43 → #45 → #47 → #48 → #49 → #50 → #51). It branches off `master`; later phases stack on this branch.

Closes #88

🧙 Built with [WOZCODE](https://wozcode.com)