### PR TITLE
feat: image-list named groups + derived annotation-status badges (#43)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,10 +1,23 @@
 name: Tests
 
 on:
+  # Feature-branch prefixes are included so the stacked review PR chain gets
+  # full-matrix CI on every push (a pull_request event only fires when the PR
+  # base is master/main/develop, which stacked PRs are not). For push events
+  # GitHub uses the workflow file at the pushed commit, so this triggers
+  # reliably on the branch that introduces it.
   push:
-    branches: [ master, main, develop ]
+    branches:
+      - master
+      - main
+      - develop
+      - 'feature/**'
+      - 'refactor/**'
+      - 'perf/**'
+      - 'spike/**'
   pull_request:
     branches: [ master, main, develop ]
+  workflow_dispatch:
 
 jobs:
   test:

--- a/docs/05_building_block_view.md
+++ b/docs/05_building_block_view.md
@@ -239,7 +239,7 @@ the controller graph.
 | Controller | Responsibility |
 |------------|----------------|
 | `ProjectController` | `.iap` save/load, auto-save, backup/restore, missing-image prompts, window-title sync. Owns the `is_loading_project` autosave guard (load/save round-trip safety, v0.8.12). |
-| `ImageController` | Open / load / switch images and slices. TIFF + CZI loaders (with `imagecodecs` codec-error handling — #56), the multi-dim `DimensionDialog`, the `[-ndim:]` axis-slice bug fix from the v0.9.0 era. Image-list annotation-status filter (`image_has_annotations`, `apply_image_filter` — #27) and alphabetical sort (`sort_image_list` — #60). |
+| `ImageController` | Open / load / switch images and slices. TIFF + CZI loaders (with `imagecodecs` codec-error handling — #56), the multi-dim `DimensionDialog`, the `[-ndim:]` axis-slice bug fix from the v0.9.0 era. Image-list annotation-status filter (`image_has_annotations`, `apply_image_filter` — #27), alphabetical/grouped sort (`sort_image_list` — #60/#43), per-image named groups (`set_image_group`, `_populate_group_combo` — #43) and derived status badges (`refresh_image_status_icons`, painted-pixmap `QIcon` cache rebuilt on theme flip via `on_theme_changed` — #43). |
 | `AnnotationController` | Annotation CRUD, list sorting, highlight, edit-mode entry/exit, `finish_polygon`, `finish_rectangle`, `replace_annotations` (eraser path). Validates writes before mutating `all_annotations`. |
 | `ClassController` | Class add / delete / rename / colour / visibility. `update_slice_list_colors`, `is_class_visible`. |
 | `SAMController` | SAM box/points tool lifecycle, debounce timer, `_sam_inference_in_flight` re-entrancy guard (ADR-013), model picker. |

--- a/docs/06_runtime_view.md
+++ b/docs/06_runtime_view.md
@@ -547,6 +547,28 @@ main() → window.show() → offer_recovery()
 A real save (or New Project) calls `clear_recovery()`, so a stale snapshot is never
 offered once the project is disk-backed.
 
+## Organising the Image List — Groups & Status Badges (issue #43)
+
+1. **Badge refresh** (automatic, no user action): any annotation mutation
+   flows through `ClassController.update_slice_list_colors →
+   ImageController.apply_image_filter`, whose tail calls
+   `refresh_image_status_icons()`. Each row's `QIcon` is set from a
+   `(annotated, dark_mode)`-keyed painted-pixmap cache — filled green dot if
+   the image (or any of its slices) has annotations, hollow gray otherwise.
+   Toggling dark mode calls `ImageController.on_theme_changed()`, which clears
+   the cache and repaints.
+2. **Assigning a group**: right-click a row → "Move to group…" opens
+   `QInputDialog.getItem` (existing groups + free text) →
+   `set_image_group(name, group)` sets the `"group"` key on the `all_images`
+   entry, `sort_image_list()` re-clusters grouped rows (ungrouped first; item
+   text stays the file name, group in the tooltip), then `auto_save()` (skipped
+   during load). "Remove from group" passes `None`.
+3. **Filtering by group**: `image_group_combo` ("All groups" + derived names)
+   drives `apply_image_filter`, which hides a row when the status filter **or**
+   the group filter excludes it. Both combos' index 0 means "hide nothing".
+4. **Persistence**: `save_project` writes `"group"` per image; on load a
+   restoration loop re-applies saved groups onto the rebuilt `all_images`.
+
 ## Multi-dimensional Image Loading
 
 ```

--- a/docs/08_crosscutting_concepts.md
+++ b/docs/08_crosscutting_concepts.md
@@ -810,6 +810,39 @@ emitters follow up with `annotationsBatchSaved`
 New mutation paths must keep one of those two routes — don't add
 bespoke `apply_image_filter()` call sites.
 
+## Image List Groups & Status Badges (issue #43)
+
+The image list gained two at-a-glance affordances, both layered on the
+existing filter/sort wiring — **no tree widget, no thumbnails, no header
+rows**:
+
+- **Status badges**: `ImageController.refresh_image_status_icons()` sets a
+  small painted-pixmap `QIcon` per row — a filled green dot when
+  `image_has_annotations(info)` (any slice of a stack counts), a hollow gray
+  outline otherwise. Nothing is stored; both states are derived. Icons are
+  painted once per `(annotated, dark_mode)` into a cache; because they are
+  **painted pixmaps, not stylesheet colours**, the No Hardcoded Colors Rule
+  isn't violated — but the cache is cleared and rebuilt when the theme flips
+  (`on_theme_changed`, called from `ui/theme.py::toggle_dark_mode`). The
+  refresh runs at the end of `apply_image_filter()` (so every annotation
+  mutation repaints badges via the `update_slice_list_colors →
+  apply_image_filter` contract) and at the end of `sort_image_list()`.
+- **Named groups**: an optional `"group"` string key on each `all_images`
+  entry (no registry; the group set is derived). `set_image_group` sets/clears
+  it, re-sorts, and auto-saves (guarded by `is_loading_project`). The
+  context menu ("Move to group…" / "Remove from group") drives it. Grouped
+  images cluster via the `sort_image_list` key
+  `(group.casefold(), name.casefold(), name)`; the group shows only in the
+  row **tooltip** — the item TEXT stays the bare file name, because
+  `item(i).text()` is read as a filename by DINO batch navigation and COCO
+  import reconciliation. A second combo (`image_group_combo`) filters by
+  group; `apply_image_filter` hides a row when **either** the status filter
+  or the group filter excludes it (OR of the two hide flags), keeping index 0
+  of both combos as the cheap "hide nothing" default. Groups persist in the
+  `.iap`; because this fork's `load_project_data` rebuilds `all_images` from
+  scratch (dropping extra keys), a small restoration loop copies saved
+  `"group"` values back after the image-load loop.
+
 ## Image List Sorting — Rebuild, Don't `setSortingEnabled`
 
 The image list is kept alphabetical (upstream issue #60,

--- a/docs/08_crosscutting_concepts.md
+++ b/docs/08_crosscutting_concepts.md
@@ -826,7 +826,10 @@ rows**:
   (`on_theme_changed`, called from `ui/theme.py::toggle_dark_mode`). The
   refresh runs at the end of `apply_image_filter()` (so every annotation
   mutation repaints badges via the `update_slice_list_colors →
-  apply_image_filter` contract) and at the end of `sort_image_list()`.
+  apply_image_filter` contract) and at the end of `sort_image_list()`. The
+  dot colours are theme-tuned (a brighter green / lighter gray on the dark
+  sidebar), which is what makes the `(annotated, dark_mode)` cache dimension
+  and the `on_theme_changed` rebuild do real work.
 - **Named groups**: an optional `"group"` string key on each `all_images`
   entry (no registry; the group set is derived). `set_image_group` sets/clears
   it, re-sorts, and auto-saves (guarded by `is_loading_project`). The
@@ -839,9 +842,10 @@ rows**:
   group; `apply_image_filter` hides a row when **either** the status filter
   or the group filter excludes it (OR of the two hide flags), keeping index 0
   of both combos as the cheap "hide nothing" default. Groups persist in the
-  `.iap`; because this fork's `load_project_data` rebuilds `all_images` from
-  scratch (dropping extra keys), a small restoration loop copies saved
-  `"group"` values back after the image-load loop.
+  `.iap`; on load no restoration step is needed — `load_project_data` aliases
+  `all_images` to the parsed `project_data["images"]` and the load loop does
+  not rebuild it (`add_images_to_list` no-ops because `image_paths` is set
+  first), so the `"group"` keys survive as-is.
 
 ## Image List Sorting — Rebuild, Don't `setSortingEnabled`
 

--- a/docs/09_architecture_decisions.md
+++ b/docs/09_architecture_decisions.md
@@ -1711,6 +1711,42 @@ dispatcher that owns state and thin delegates — a strictly behavior-preserving
 
 ---
 
+## ADR-035: Flat Grouped Image List with Derived Status Badges (No Tree, No Thumbnails)
+
+**Status**: Accepted (issue #43)
+
+**Context**: The image list had alphabetical sort and an annotation-status filter
+(#27/#60) but gave no at-a-glance "is this done?" signal and no way to organise a
+large dataset. A tree/`QTreeWidget` with group headers or per-image thumbnails were
+both considered and rejected: many consumers (DINO batch navigation, COCO import
+reconciliation, `apply_image_filter`) read `image_list.item(i).text()` as a **file
+name** and rely on the positional invariant `all_images[i] ↔ item(i)`, so any header
+/ separator row would be interpreted as a phantom image; thumbnails were explicitly
+out of scope (memory + async decode complexity).
+
+**Decision**: Stay on the flat `QListWidget` and express both features as derived,
+non-structural overlays on the existing sort/filter machinery:
+- **Status badge** = a painted-pixmap `QIcon` per row (filled green dot if
+  `image_has_annotations`, hollow gray otherwise), cached per `(state, dark_mode)`
+  and rebuilt on theme flip. Nothing stored; both states derived.
+- **Group** = an optional `"group"` key on the `all_images` entry (no registry; set
+  derived by `sorted({...})`). Grouped images cluster via the sort key
+  `(group.casefold(), name.casefold(), name)`; the group is shown only in the row
+  tooltip so item text stays the bare file name. A second combo filters by group,
+  OR-combined with the status filter. Persisted in the `.iap` (dual with a load-time
+  restoration loop because this fork rebuilds `all_images` on load).
+
+**Consequences**:
+- ✅ Both features ride the `update_slice_list_colors → apply_image_filter` contract,
+  so badges/marks stay correct after every annotation mutation with no new call sites.
+- ✅ The `.text() == file_name` contract and positional invariant are preserved, so
+  DINO batch nav and COCO import are unaffected (regression-guarded).
+- ✅ No hardcoded colours (painted pixmaps + palette-safe dot colours), dark-mode safe.
+- ⚠️ Groups are a flat single-level tag, not nested folders — sufficient for the PRD
+  US-1 remainder; a real hierarchy would need the tree widget this ADR rejects.
+
+---
+
 ## Decisions Under Consideration
 
 ### Consider Relative Paths with Image Copying

--- a/docs/09_architecture_decisions.md
+++ b/docs/09_architecture_decisions.md
@@ -1733,8 +1733,9 @@ non-structural overlays on the existing sort/filter machinery:
   derived by `sorted({...})`). Grouped images cluster via the sort key
   `(group.casefold(), name.casefold(), name)`; the group is shown only in the row
   tooltip so item text stays the bare file name. A second combo filters by group,
-  OR-combined with the status filter. Persisted in the `.iap` (dual with a load-time
-  restoration loop because this fork rebuilds `all_images` on load).
+  OR-combined with the status filter. Persisted in the `.iap`; no load-time
+  restoration is needed because `load_project_data` aliases `all_images` to the
+  parsed `images` list and the load loop doesn't rebuild it.
 
 **Consequences**:
 - ✅ Both features ride the `update_slice_list_colors → apply_image_filter` contract,
@@ -1744,6 +1745,9 @@ non-structural overlays on the existing sort/filter machinery:
 - ✅ No hardcoded colours (painted pixmaps + palette-safe dot colours), dark-mode safe.
 - ⚠️ Groups are a flat single-level tag, not nested folders — sufficient for the PRD
   US-1 remainder; a real hierarchy would need the tree widget this ADR rejects.
+- Status-badge colours are theme-tuned (a brighter green / lighter gray on the dark
+  sidebar), so the `(annotated, dark_mode)` cache dimension and the `on_theme_changed`
+  rebuild produce genuinely different pixmaps — not dead machinery.
 
 ---
 

--- a/src/digitalsreeni_image_annotator/annotator_window.py
+++ b/src/digitalsreeni_image_annotator/annotator_window.py
@@ -8,6 +8,7 @@ from PyQt6.QtWidgets import (
     QDialog,
     QFileDialog,
     QHBoxLayout,
+    QInputDialog,
     QLineEdit,
     QMainWindow,
     QMenu,
@@ -876,6 +877,10 @@ class ImageAnnotator(QMainWindow):
             if self.is_multi_dimensional(file_name):
                 redefine_dimensions_action = menu.addAction("Redefine Dimensions")
 
+            menu.addSeparator()
+            move_to_group_action = menu.addAction("Move to group…")
+            remove_from_group_action = menu.addAction("Remove from group")
+
             action = menu.exec(self.image_list.mapToGlobal(position))
 
             if action == delete_action:
@@ -887,6 +892,36 @@ class ImageAnnotator(QMainWindow):
                 and action == redefine_dimensions_action
             ):
                 self.redefine_dimensions(file_name)
+            elif action == move_to_group_action:
+                self._prompt_move_image_to_group(file_name)
+            elif action == remove_from_group_action:
+                self.image_controller.set_image_group(file_name, None)
+
+    def _prompt_move_image_to_group(self, file_name):
+        """Ask for a group name and assign it (issue #43).
+
+        The combo is seeded with the existing derived groups and is
+        editable so a new name can be typed. Thin delegation: the
+        controller owns the state change (set_image_group).
+        """
+        existing = sorted(
+            {info.get("group") for info in self.all_images if info.get("group")}
+        )
+        info = next(
+            (img for img in self.all_images if img["file_name"] == file_name), None
+        )
+        current = (info.get("group") if info else "") or ""
+        current_index = existing.index(current) if current in existing else 0
+        name, ok = QInputDialog.getItem(
+            self,
+            "Move to group",
+            "Group name (leave blank to ungroup):",
+            existing,
+            current_index,
+            True,
+        )
+        if ok:
+            self.image_controller.set_image_group(file_name, name)
 
     def is_multi_dimensional(self, file_name):
         return self.image_controller.is_multi_dimensional(file_name)

--- a/src/digitalsreeni_image_annotator/controllers/image_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/image_controller.py
@@ -219,8 +219,10 @@ class ImageController(QObject):
             active_group = group_combo.currentText()
 
         if mode == 0 and active_group is None:
-            # Default case runs on every update_slice_list_colors —
-            # keep it a plain unhide pass with no annotation scans.
+            # Default case runs on every update_slice_list_colors — skip the
+            # per-row hide computation (nothing is filtered) but still refresh
+            # the status badges, which necessarily scan annotation state per
+            # row (unavoidable: badges must stay current after every mutation).
             for i in range(self.mw.image_list.count()):
                 self.mw.image_list.setRowHidden(i, False)
             self.refresh_image_status_icons()
@@ -248,8 +250,9 @@ class ImageController(QObject):
         Filled green dot = the image (or, for a multi-dim stack, any of
         its slices) has annotations; hollow gray dot = none. Both states
         are derived — nothing is stored. Icons are cached per (annotated,
-        dark_mode) and only painted once; on_theme_changed clears the
-        cache when the theme flips so they recolour.
+        dark_mode) and painted once; the colours are theme-tuned (brighter
+        on the dark sidebar), so on_theme_changed clears the cache on a
+        dark-mode flip to force a repaint at the new theme's colours.
 
         Called at the end of apply_image_filter (so it refreshes on every
         annotation mutation via update_slice_list_colors) and after
@@ -267,28 +270,35 @@ class ImageController(QObject):
         key = (annotated, dark)
         icon = self._status_icon_cache.get(key)
         if icon is None:
-            icon = self._build_status_icon(annotated)
+            icon = self._build_status_icon(annotated, dark)
             self._status_icon_cache[key] = icon
         return icon
 
     @staticmethod
-    def _build_status_icon(annotated):
-        """Paint a 12x12 status dot into a QIcon.
+    def _build_status_icon(annotated, dark):
+        """Paint a 12x12 status dot into a QIcon, tuned for the theme.
 
         These are painted PIXMAPS, not stylesheet colours, so the "No
-        Hardcoded Colors Rule" does not apply. The two colours are chosen
-        to read on both the light and soft-dark sidebar backgrounds.
+        Hardcoded Colors Rule" (which targets setStyleSheet literals) does
+        not apply. The colours are picked per theme: a brighter green /
+        lighter gray on the soft-dark sidebar for adequate contrast, a
+        deeper pair on the light one. That difference is what makes the
+        (annotated, dark) cache dimension and on_theme_changed do real work.
         """
+        if annotated:
+            fill = QColor(63, 185, 80) if dark else QColor(46, 160, 67)
+        else:
+            outline = QColor(155, 155, 155) if dark else QColor(120, 120, 120)
         pixmap = QPixmap(12, 12)
         pixmap.fill(Qt.GlobalColor.transparent)
         painter = QPainter(pixmap)
         painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
         if annotated:
             painter.setPen(Qt.PenStyle.NoPen)
-            painter.setBrush(QColor(46, 160, 67))  # green fill
+            painter.setBrush(fill)  # filled dot
             painter.drawEllipse(2, 2, 8, 8)
         else:
-            pen = QPen(QColor(140, 140, 140))  # mid-gray outline
+            pen = QPen(outline)  # hollow outline dot
             pen.setWidthF(1.5)
             painter.setPen(pen)
             painter.setBrush(Qt.BrushStyle.NoBrush)
@@ -321,6 +331,11 @@ class ImageController(QObject):
         if info is None:
             return
         normalized = group.strip() if isinstance(group, str) else None
+        normalized = normalized or None
+        # No-op if nothing actually changes (e.g. "Remove from group" on an
+        # already-ungrouped image) so we don't re-sort + auto_save for nothing.
+        if normalized == info.get("group"):
+            return
         if normalized:
             info["group"] = normalized
         else:

--- a/src/digitalsreeni_image_annotator/controllers/image_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/image_controller.py
@@ -24,7 +24,7 @@ import os
 import numpy as np
 from czifile import CziFile
 from PyQt6.QtCore import Qt, QObject
-from PyQt6.QtGui import QColor, QImage, QPixmap
+from PyQt6.QtGui import QColor, QIcon, QImage, QPainter, QPen, QPixmap
 from PyQt6.QtWidgets import (
     QApplication,
     QComboBox,
@@ -88,6 +88,10 @@ class ImageController(QObject):
     def __init__(self, main_window):
         super().__init__(main_window)
         self.mw = main_window
+        # Annotation-status badge icons, keyed by (annotated: bool,
+        # dark: bool). Each is painted once and reused; cleared on a
+        # dark-mode flip via on_theme_changed (issue #43).
+        self._status_icon_cache = {}
 
     def update_image_list(self):
         # Rebuild (and sort) the list, preserving the current selection
@@ -113,8 +117,11 @@ class ImageController(QObject):
         if self.mw.image_list.currentItem() is not None:
             current = self.mw.image_list.currentItem().text()
 
+        # Grouped images cluster together (ungrouped first, blank group
+        # sorts before any name); within a group, by file name (issue #43).
         self.mw.all_images.sort(
             key=lambda info: (
+                info.get("group", "").casefold(),
                 info.get("file_name", "").casefold(),
                 info.get("file_name", ""),
             )
@@ -123,8 +130,17 @@ class ImageController(QObject):
         self.mw.image_list.blockSignals(True)
         self.mw.image_list.clear()
         for info in self.mw.all_images:
-            self.mw.image_list.addItem(info["file_name"])
+            item = QListWidgetItem(info["file_name"])
+            group = info.get("group")
+            if group:
+                # Item TEXT stays the bare file name (many consumers read
+                # item(i).text() as a filename — DINO batch nav, COCO
+                # import). The group shows only in the tooltip. See #43.
+                item.setToolTip(f"{info['file_name']}  [{group}]")
+            self.mw.image_list.addItem(item)
         self.mw.image_list.blockSignals(False)
+
+        self._populate_group_combo()
 
         self.apply_image_filter()
 
@@ -193,18 +209,149 @@ class ImageController(QObject):
         if combo is None:
             return
         mode = combo.currentIndex()  # 0 = all, 1 = without, 2 = with
-        if mode == 0:
+
+        # Group filter (issue #43): a specific group selected (index > 0)
+        # hides rows whose image isn't in it. Index 0 ("All groups") means
+        # "hide nothing", so the default path below stays a cheap unhide.
+        group_combo = getattr(self.mw, "image_group_combo", None)
+        active_group = None
+        if group_combo is not None and group_combo.currentIndex() > 0:
+            active_group = group_combo.currentText()
+
+        if mode == 0 and active_group is None:
             # Default case runs on every update_slice_list_colors —
             # keep it a plain unhide pass with no annotation scans.
             for i in range(self.mw.image_list.count()):
                 self.mw.image_list.setRowHidden(i, False)
+            self.refresh_image_status_icons()
             return
         infos = {info["file_name"]: info for info in self.mw.all_images}
         for i in range(self.mw.image_list.count()):
             info = infos.get(self.mw.image_list.item(i).text())
+            if mode == 0:
+                status_hide = False
+            else:
+                annotated = bool(info) and self.image_has_annotations(info)
+                status_hide = annotated if mode == 1 else not annotated
+            if active_group is None:
+                group_hide = False
+            else:
+                group_hide = not (info and info.get("group") == active_group)
+            # Hide the row if EITHER filter excludes it.
+            self.mw.image_list.setRowHidden(i, status_hide or group_hide)
+
+        self.refresh_image_status_icons()
+
+    def refresh_image_status_icons(self):
+        """Set a per-row annotation-status badge on the image list (#43).
+
+        Filled green dot = the image (or, for a multi-dim stack, any of
+        its slices) has annotations; hollow gray dot = none. Both states
+        are derived — nothing is stored. Icons are cached per (annotated,
+        dark_mode) and only painted once; on_theme_changed clears the
+        cache when the theme flips so they recolour.
+
+        Called at the end of apply_image_filter (so it refreshes on every
+        annotation mutation via update_slice_list_colors) and after
+        sort_image_list's rebuild.
+        """
+        dark = bool(getattr(self.mw, "dark_mode", False))
+        infos = {info["file_name"]: info for info in self.mw.all_images}
+        for i in range(self.mw.image_list.count()):
+            item = self.mw.image_list.item(i)
+            info = infos.get(item.text())
             annotated = bool(info) and self.image_has_annotations(info)
-            hide = annotated if mode == 1 else not annotated
-            self.mw.image_list.setRowHidden(i, hide)
+            item.setIcon(self._status_icon(annotated, dark))
+
+    def _status_icon(self, annotated, dark):
+        key = (annotated, dark)
+        icon = self._status_icon_cache.get(key)
+        if icon is None:
+            icon = self._build_status_icon(annotated)
+            self._status_icon_cache[key] = icon
+        return icon
+
+    @staticmethod
+    def _build_status_icon(annotated):
+        """Paint a 12x12 status dot into a QIcon.
+
+        These are painted PIXMAPS, not stylesheet colours, so the "No
+        Hardcoded Colors Rule" does not apply. The two colours are chosen
+        to read on both the light and soft-dark sidebar backgrounds.
+        """
+        pixmap = QPixmap(12, 12)
+        pixmap.fill(Qt.GlobalColor.transparent)
+        painter = QPainter(pixmap)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+        if annotated:
+            painter.setPen(Qt.PenStyle.NoPen)
+            painter.setBrush(QColor(46, 160, 67))  # green fill
+            painter.drawEllipse(2, 2, 8, 8)
+        else:
+            pen = QPen(QColor(140, 140, 140))  # mid-gray outline
+            pen.setWidthF(1.5)
+            painter.setPen(pen)
+            painter.setBrush(Qt.BrushStyle.NoBrush)
+            painter.drawEllipse(3, 3, 6, 6)
+        painter.end()
+        return QIcon(pixmap)
+
+    def on_theme_changed(self):
+        """Rebuild the status-icon cache after a dark-mode flip (#43).
+
+        Called from the theme choke point (ui/theme.toggle_dark_mode).
+        The cached icons are keyed by dark-mode, so clearing forces a
+        redraw at the new theme on the next refresh.
+        """
+        self._status_icon_cache.clear()
+        self.refresh_image_status_icons()
+
+    def set_image_group(self, file_name, group):
+        """Assign or clear an image's group tag (issue #43).
+
+        group: a name (whitespace stripped) or None/empty to remove the
+        image from any group. Re-sorts the list so grouped images cluster,
+        then auto-saves — but never during project load (CLAUDE.md guard,
+        matching add_images_to_list).
+        """
+        info = next(
+            (img for img in self.mw.all_images if img["file_name"] == file_name),
+            None,
+        )
+        if info is None:
+            return
+        normalized = group.strip() if isinstance(group, str) else None
+        if normalized:
+            info["group"] = normalized
+        else:
+            info.pop("group", None)
+        self.sort_image_list()
+        if not self.mw.is_loading_project:
+            self.mw.auto_save()
+
+    def _populate_group_combo(self):
+        """Repopulate image_group_combo from the derived group set (#43).
+
+        Signals are blocked (repopulating fires currentIndexChanged →
+        apply_image_filter otherwise) and the current selection is
+        preserved by text, falling back to "All groups" if its group is
+        gone.
+        """
+        combo = getattr(self.mw, "image_group_combo", None)
+        if combo is None:
+            return
+        groups = sorted(
+            {info.get("group") for info in self.mw.all_images if info.get("group")}
+        )
+        current = combo.currentText()
+        combo.blockSignals(True)
+        combo.clear()
+        combo.addItem("All groups")
+        for g in groups:
+            combo.addItem(g)
+        idx = combo.findText(current)
+        combo.setCurrentIndex(idx if idx >= 0 else 0)
+        combo.blockSignals(False)
 
     def setup_slice_list(self):
         self.mw.slice_list = QListWidget()

--- a/src/digitalsreeni_image_annotator/controllers/project_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/project_controller.py
@@ -220,6 +220,20 @@ class ProjectController(QObject):
             else:
                 self.mw.add_images_to_list([image_path])
 
+        # Restore per-image group tags (issue #43). add_images_to_list /
+        # load_multi_slice_image rebuild all_images from scratch and drop
+        # extra keys, so copy the saved "group" back onto the matching entry.
+        saved_groups = {
+            img["file_name"]: img["group"]
+            for img in project_data["images"]
+            if img.get("group")
+        }
+        if saved_groups:
+            for info in self.mw.all_images:
+                group = saved_groups.get(info["file_name"])
+                if group:
+                    info["group"] = group
+
         dino_cfg = project_data.get("dino_config", {})
         valid_classes = set(self.mw.class_mapping.keys())
 
@@ -445,6 +459,10 @@ class ProjectController(QObject):
                 "height": image_info["height"],
                 "is_multi_slice": image_info["is_multi_slice"],
             }
+            # Persist the optional group tag (issue #43); absent for
+            # ungrouped images so old projects are unchanged.
+            if image_info.get("group"):
+                image_data["group"] = image_info["group"]
 
             if image_data["is_multi_slice"]:
                 base_name_without_ext = os.path.splitext(file_name)[0]

--- a/src/digitalsreeni_image_annotator/controllers/project_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/project_controller.py
@@ -220,19 +220,11 @@ class ProjectController(QObject):
             else:
                 self.mw.add_images_to_list([image_path])
 
-        # Restore per-image group tags (issue #43). add_images_to_list /
-        # load_multi_slice_image rebuild all_images from scratch and drop
-        # extra keys, so copy the saved "group" back onto the matching entry.
-        saved_groups = {
-            img["file_name"]: img["group"]
-            for img in project_data["images"]
-            if img.get("group")
-        }
-        if saved_groups:
-            for info in self.mw.all_images:
-                group = saved_groups.get(info["file_name"])
-                if group:
-                    info["group"] = group
+        # Per-image group tags (issue #43) need no restoration step: line ~193
+        # aliases self.mw.all_images to project_data["images"], and the load
+        # loop above does not rebuild it (add_images_to_list no-ops because
+        # image_paths[file_name] is set first, and load_multi_slice_image only
+        # loads slices), so the "group" keys parsed from JSON survive as-is.
 
         dino_cfg = project_data.get("dino_config", {})
         valid_classes = set(self.mw.class_mapping.keys())

--- a/src/digitalsreeni_image_annotator/ui/sidebar.py
+++ b/src/digitalsreeni_image_annotator/ui/sidebar.py
@@ -404,6 +404,17 @@ def build_image_list(window):
     )
     window.image_list_layout.addWidget(window.image_filter_combo)
 
+    # Group filter (issue #43). Index 0 ("All groups") means "hide
+    # nothing"; the other entries are the derived group names, repopulated
+    # by ImageController.sort_image_list with signals blocked.
+    window.image_group_combo = QComboBox()
+    window.image_group_combo.addItem("All groups")
+    window.image_group_combo.setToolTip("Filter the image list by group")
+    window.image_group_combo.currentIndexChanged.connect(
+        lambda _index: window.apply_image_filter()
+    )
+    window.image_list_layout.addWidget(window.image_group_combo)
+
     window.image_list = QListWidget()
     window.image_list.itemClicked.connect(window.switch_image)
     window.image_list.currentRowChanged.connect(

--- a/src/digitalsreeni_image_annotator/ui/theme.py
+++ b/src/digitalsreeni_image_annotator/ui/theme.py
@@ -105,6 +105,11 @@ def sync_font_menu(mw):
 def toggle_dark_mode(mw):
     mw.dark_mode = not mw.dark_mode
     apply_theme_and_font(mw)
+    # Rebuild the image-list status badges for the new theme (#43). Routed
+    # through the controller, not painted here.
+    image_controller = getattr(mw, "image_controller", None)
+    if image_controller is not None:
+        image_controller.on_theme_changed()
     save_ui_prefs(mw.ui_font_pt, mw.dark_mode)
     mw.update_slice_list_colors()
     mw.update_class_list()

--- a/tests/integration/test_image_filter_wiring.py
+++ b/tests/integration/test_image_filter_wiring.py
@@ -14,6 +14,7 @@ and three controllers.
 """
 
 import pytest
+from PyQt6.QtCore import Qt
 
 
 FILTER_WITHOUT = 1  # combo index: "Without annotations"
@@ -85,3 +86,61 @@ def test_hiding_current_row_keeps_canvas_and_fires_no_switch(window):
     assert not window.image_list.isRowHidden(1)
     assert window.current_image is sentinel  # canvas unchanged
     assert calls == []  # hiding the current row fired no switch_image
+
+
+def test_annotation_commit_sets_status_badge(window):
+    # The same real mutation path (issue #43): finishing an annotation must
+    # refresh the per-row status badge via update_slice_list_colors ->
+    # apply_image_filter -> refresh_image_status_icons.
+    for name in ("a.png", "b.png"):
+        window.all_images.append({"file_name": name, "is_multi_slice": False})
+        window.image_list.addItem(name)
+    window.image_controller.refresh_image_status_icons()
+
+    def _icon_for(name):
+        items = window.image_list.findItems(name, Qt.MatchFlag.MatchExactly)
+        return items[0].icon()
+
+    window.image_file_name = "a.png"
+    window.image_label.annotations = {
+        "cell": [{"segmentation": [0, 0, 10, 0, 10, 10], "category_name": "cell"}]
+    }
+    window.image_label.annotationsBatchSaved.emit()
+
+    icon_a = _icon_for("a.png")
+    icon_b = _icon_for("b.png")
+    assert not icon_a.isNull()  # badge was set on the annotated row
+    # Annotated (green) vs un-annotated (hollow) badges differ.
+    assert icon_a.pixmap(12, 12).toImage() != icon_b.pixmap(12, 12).toImage()
+
+
+def test_group_survives_save_reload_roundtrip(window, tmp_path):
+    from PyQt6.QtGui import QImage
+
+    # A real (tiny) image on disk so the load path can resolve it.
+    img_path = tmp_path / "photo.png"
+    QImage(4, 4, QImage.Format.Format_RGB32).save(str(img_path))
+
+    # Stub auto_save so add/assign don't pop a blocking Save dialog.
+    window.auto_save = lambda *a, **k: None
+
+    window.image_controller.add_images_to_list([str(img_path)])
+    window.image_controller.set_image_group("photo.png", "Batch A")
+    info = next(i for i in window.all_images if i["file_name"] == "photo.png")
+    assert info["group"] == "Batch A"
+
+    project_data = window.project_controller.build_project_data()
+    assert any(
+        img.get("file_name") == "photo.png" and img.get("group") == "Batch A"
+        for img in project_data["images"]
+    )
+
+    # Reload the saved data into the same window (open-project data contract).
+    window.is_loading_project = True
+    try:
+        window.project_controller.load_project_data(project_data)
+    finally:
+        window.is_loading_project = False
+
+    reloaded = next(i for i in window.all_images if i["file_name"] == "photo.png")
+    assert reloaded.get("group") == "Batch A"

--- a/tests/unit/test_image_filter.py
+++ b/tests/unit/test_image_filter.py
@@ -30,6 +30,8 @@ def mw(qtbot):
     window.image_filter_combo.addItems(
         ["All images", "Without annotations", "With annotations"]
     )
+    window.image_group_combo = QComboBox(window)
+    window.image_group_combo.addItem("All groups")
     window.all_images = []
     window.all_annotations = {}
     window.image_slices = {}
@@ -147,3 +149,67 @@ class TestApplyImageFilter:
         populated.image_filter_combo.setCurrentIndex(FILTER_ALL)
         populated.image_controller.apply_image_filter()
         assert self._hidden(populated) == [False, False]
+
+
+class TestGroupFilter:
+    """Group filter (issue #43): a specific group hides non-members;
+    combines with the status filter via OR; index 0 of both hides nothing.
+    """
+
+    def _visible(self, mw):
+        return [
+            mw.image_list.item(i).text()
+            for i in range(mw.image_list.count())
+            if not mw.image_list.isRowHidden(i)
+        ]
+
+    def _add(self, mw, name, group=None, annotated=False):
+        info = {"file_name": name, "is_multi_slice": False}
+        if group:
+            info["group"] = group
+        mw.all_images.append(info)
+        if annotated:
+            mw.all_annotations[name] = {"cell": [{"segmentation": [0, 0, 1, 0, 1, 1]}]}
+
+    def test_group_filter_hides_non_members(self, mw):
+        self._add(mw, "a.png", group="G1")
+        self._add(mw, "b.png", group="G2")
+        self._add(mw, "c.png")  # ungrouped
+        mw.image_controller.sort_image_list()  # rebuilds list + group combo
+        mw.image_list.setCurrentRow(-1)
+
+        idx = mw.image_group_combo.findText("G1")
+        assert idx > 0  # combo was populated with the derived groups
+        mw.image_group_combo.setCurrentIndex(idx)
+        mw.image_controller.apply_image_filter()
+
+        assert self._visible(mw) == ["a.png"]
+
+    def test_combined_status_and_group(self, mw):
+        self._add(mw, "g1_annot.png", group="G1", annotated=True)
+        self._add(mw, "g1_plain.png", group="G1")
+        self._add(mw, "g2_annot.png", group="G2", annotated=True)
+        mw.image_controller.sort_image_list()
+        mw.image_list.setCurrentRow(-1)
+
+        mw.image_filter_combo.setCurrentIndex(FILTER_WITH)
+        mw.image_group_combo.setCurrentIndex(mw.image_group_combo.findText("G1"))
+        mw.image_controller.apply_image_filter()
+
+        # "With annotations" drops g1_plain; group G1 drops g2_annot.
+        assert self._visible(mw) == ["g1_annot.png"]
+
+    def test_both_combos_index_zero_hides_nothing(self, mw):
+        self._add(mw, "a.png", group="G1")
+        self._add(mw, "b.png")
+        mw.image_controller.sort_image_list()
+        mw.image_list.setCurrentRow(-1)
+
+        mw.image_filter_combo.setCurrentIndex(FILTER_ALL)
+        mw.image_group_combo.setCurrentIndex(0)
+        mw.image_controller.apply_image_filter()
+
+        assert self._visible(mw) == ["b.png", "a.png"]  # ungrouped clusters first
+        assert not any(
+            mw.image_list.isRowHidden(i) for i in range(mw.image_list.count())
+        )

--- a/tests/unit/test_image_list_sort.py
+++ b/tests/unit/test_image_list_sort.py
@@ -27,6 +27,8 @@ def mw(qtbot):
     window.image_filter_combo.addItems(
         ["All images", "Without annotations", "With annotations"]
     )
+    window.image_group_combo = QComboBox(window)
+    window.image_group_combo.addItem("All groups")
     window.all_images = []
     window.all_annotations = {}
     window.image_slices = {}
@@ -93,6 +95,98 @@ def test_select_name_and_switch(mw):
     mw.image_controller.sort_image_list(select_name="a.png", do_switch=True)
     assert mw.image_list.currentItem().text() == "a.png"
     assert calls == ["a.png"]
+
+
+def _populate_grouped(mw, entries):
+    # entries: list of (file_name, group_or_None).
+    for name, group in entries:
+        info = {"file_name": name, "is_multi_slice": False}
+        if group:
+            info["group"] = group
+        mw.all_images.append(info)
+        mw.image_list.addItem(name)
+
+
+def test_grouped_images_cluster_then_sort_by_name(mw):
+    _populate_grouped(
+        mw,
+        [
+            ("z.png", None),
+            ("b.png", "Beta"),
+            ("a.png", "Alpha"),
+            ("y.png", None),
+            ("c.png", "Alpha"),
+        ],
+    )
+    mw.image_controller.sort_image_list()
+    # Ungrouped first (by name), then Alpha, then Beta.
+    assert _list_texts(mw) == ["y.png", "z.png", "a.png", "c.png", "b.png"]
+
+
+def test_grouped_sort_keeps_positional_invariant(mw):
+    _populate_grouped(
+        mw, [("z.png", None), ("a.png", "Alpha"), ("b.png", "Beta")]
+    )
+    mw.image_controller.sort_image_list()
+    # all_images[i] <-> image_list.item(i) still aligned, and item text
+    # stays the bare file name (no group decoration).
+    assert _list_texts(mw) == [info["file_name"] for info in mw.all_images]
+    assert _list_texts(mw) == ["z.png", "a.png", "b.png"]
+
+
+def test_group_combo_repopulated_from_derived_groups(mw):
+    _populate_grouped(
+        mw, [("a.png", "Alpha"), ("b.png", "Beta"), ("c.png", None)]
+    )
+    mw.image_controller.sort_image_list()
+    combo = mw.image_group_combo
+    texts = [combo.itemText(i) for i in range(combo.count())]
+    assert texts == ["All groups", "Alpha", "Beta"]
+
+
+def test_set_image_group_fires_no_switch_image(mw):
+    _populate_grouped(mw, [("a.png", None), ("b.png", None)])
+    switch_calls = []
+    mw.switch_image = lambda item: switch_calls.append(item)
+    mw.image_controller.switch_image = lambda item: switch_calls.append(item)
+    save_calls = []
+    mw.auto_save = lambda: save_calls.append(1)
+    mw.image_list.setCurrentRow(0)
+    switch_calls.clear()
+
+    mw.image_controller.set_image_group("a.png", "G1")
+
+    assert switch_calls == []  # re-sort must not fire switch_image
+    info = next(i for i in mw.all_images if i["file_name"] == "a.png")
+    assert info["group"] == "G1"
+    assert save_calls  # auto_save fired (not loading a project)
+
+
+def test_set_image_group_strips_and_clears(mw):
+    _populate_grouped(mw, [("a.png", None)])
+    info = mw.all_images[0]
+
+    mw.image_controller.set_image_group("a.png", "  Team A  ")
+    assert info["group"] == "Team A"  # whitespace stripped
+
+    mw.image_controller.set_image_group("a.png", "   ")
+    assert "group" not in info  # blank removes the key
+
+    mw.image_controller.set_image_group("a.png", "Team A")
+    mw.image_controller.set_image_group("a.png", None)
+    assert "group" not in info  # None removes the key
+
+
+def test_set_image_group_skips_autosave_during_load(mw):
+    _populate_grouped(mw, [("a.png", None)])
+    mw.is_loading_project = True
+    save_calls = []
+    mw.auto_save = lambda: save_calls.append(1)
+
+    mw.image_controller.set_image_group("a.png", "G1")
+
+    assert save_calls == []  # guarded during project load
+    assert mw.all_images[0]["group"] == "G1"  # assignment still happens
 
 
 def test_project_load_path_ends_sorted(mw):

--- a/tests/unit/test_image_status_icons.py
+++ b/tests/unit/test_image_status_icons.py
@@ -72,11 +72,15 @@ def test_icons_are_cached_per_state(qt_application):
     window.deleteLater()
 
 
-def test_theme_flip_rebuilds_cache(qt_application):
+def test_theme_flip_repaints_icons_with_theme_tuned_colors(qt_application):
+    # The badge colours are theme-tuned, so a dark-mode flip must produce a
+    # visibly DIFFERENT pixmap (not just a rebuilt cache key). This defends
+    # against the dark-mode machinery silently becoming inert.
     window = _make_window()
     _add_image(window, "a.png")  # un-annotated
 
     window.image_controller.refresh_image_status_icons()
+    light_img = window.image_list.item(0).icon().pixmap(12, 12).toImage()
     assert (False, False) in window.image_controller._status_icon_cache
 
     window.dark_mode = True
@@ -85,5 +89,8 @@ def test_theme_flip_rebuilds_cache(qt_application):
     cache = window.image_controller._status_icon_cache
     assert (False, True) in cache  # rebuilt for the dark theme
     assert (False, False) not in cache  # stale light-theme entry cleared
+
+    dark_img = window.image_list.item(0).icon().pixmap(12, 12).toImage()
+    assert dark_img != light_img  # the dot actually recolours per theme
 
     window.deleteLater()

--- a/tests/unit/test_image_status_icons.py
+++ b/tests/unit/test_image_status_icons.py
@@ -1,0 +1,89 @@
+"""
+Unit tests for image-list annotation-status badges (issue #43).
+
+ImageController.refresh_image_status_icons paints a filled dot on
+annotated rows and a hollow dot on un-annotated ones, cached per
+(annotated, dark_mode) and rebuilt on a theme flip.
+"""
+
+from PyQt6.QtWidgets import QListWidget, QWidget
+
+from src.digitalsreeni_image_annotator.controllers.image_controller import (
+    ImageController,
+)
+
+
+class FakeMainWindow(QWidget):
+    pass
+
+
+def _make_window():
+    window = FakeMainWindow()
+    window.image_list = QListWidget(window)
+    window.all_images = []
+    window.all_annotations = {}
+    window.image_slices = {}
+    window.dark_mode = False
+    window.image_controller = ImageController(window)
+    return window
+
+
+def _add_image(window, name, annotated=False):
+    window.all_images.append({"file_name": name, "is_multi_slice": False})
+    window.image_list.addItem(name)
+    if annotated:
+        window.all_annotations[name] = {
+            "cell": [{"segmentation": [0, 0, 1, 0, 1, 1]}]
+        }
+
+
+def test_annotated_and_unannotated_rows_get_distinct_icons(qt_application):
+    window = _make_window()
+    _add_image(window, "annotated.png", annotated=True)
+    _add_image(window, "empty.png")
+
+    window.image_controller.refresh_image_status_icons()
+
+    annotated_icon = window.image_list.item(0).icon()
+    empty_icon = window.image_list.item(1).icon()
+    assert not annotated_icon.isNull()
+    assert not empty_icon.isNull()
+
+    annotated_img = annotated_icon.pixmap(12, 12).toImage()
+    empty_img = empty_icon.pixmap(12, 12).toImage()
+    assert annotated_img != empty_img
+
+    window.deleteLater()
+
+
+def test_icons_are_cached_per_state(qt_application):
+    window = _make_window()
+    _add_image(window, "a.png", annotated=True)
+
+    window.image_controller.refresh_image_status_icons()
+    cache = window.image_controller._status_icon_cache
+    assert (True, False) in cache  # annotated, light theme
+
+    cached_icon = cache[(True, False)]
+    window.image_controller.refresh_image_status_icons()
+    # Second refresh reuses the same cached QIcon object.
+    assert cache[(True, False)] is cached_icon
+
+    window.deleteLater()
+
+
+def test_theme_flip_rebuilds_cache(qt_application):
+    window = _make_window()
+    _add_image(window, "a.png")  # un-annotated
+
+    window.image_controller.refresh_image_status_icons()
+    assert (False, False) in window.image_controller._status_icon_cache
+
+    window.dark_mode = True
+    window.image_controller.on_theme_changed()
+
+    cache = window.image_controller._status_icon_cache
+    assert (False, True) in cache  # rebuilt for the dark theme
+    assert (False, False) not in cache  # stale light-theme entry cleared
+
+    window.deleteLater()


### PR DESCRIPTION
## Summary

Implements issue #43 (PRD US-1 remainder): two at-a-glance affordances on the right-hand image list, layered on the existing filter/sort wiring — **flat QListWidget, no tree, no thumbnails, no header rows**.

- **Status badges** — per-row painted-pixmap `QIcon`: filled green dot if the image (or any slice of a stack) has annotations, hollow gray outline otherwise. Derived, nothing stored. Colours are **theme-tuned** and cached per `(annotated, dark_mode)`; `on_theme_changed` (from `ui/theme.py`) rebuilds on a dark-mode flip. Refreshed from `apply_image_filter` + `sort_image_list`.
- **Named groups** — optional `"group"` key on `all_images` (derived set, no registry). Context menu "Move to group…" / "Remove from group" → `set_image_group` (re-sort + `auto_save`, `is_loading_project`-guarded, no-op when unchanged). `image_group_combo` filters by group, OR-combined with the status filter. **Item text stays the bare file name** (group in tooltip) to preserve the `.text()==filename` + positional invariants relied on by DINO batch nav and COCO import. Groups persist in the `.iap` (survive load via the `all_images`-is-`project_data["images"]` alias — no restoration step needed).

## CI enablement

Also broadens `.github/workflows/tests.yml`'s `push` trigger to the chain's branch prefixes (`feature/**`, `refactor/**`, `perf/**`, `spike/**`) + `workflow_dispatch`, so the **stacked review-PR chain gets full-matrix CI** (a `pull_request` event only fires for PRs whose base is master/main/develop).

## Verification

- Full suite **702 passed / 3 skipped** (+14 new tests); ruff clean on touched files.
- **Senior review**: no P0; the P1 (inert dark-mode badge machinery) and P2s (redundant load-loop with a false premise, spurious re-sort on no-op, stale comment) are all fixed — badges are now genuinely theme-aware with a cross-theme pixmap-difference test; the redundant loop was removed after empirically confirming the alias carries groups.

## Docs

ADR-035 (flat grouped list, no tree/thumbnails), `docs/05/06/08`.

## Phase chain

**Phase 3**, base = `refactor/split-image-label` (Phase 2 / #46).

Closes #43

🧙 Built with [WOZCODE](https://wozcode.com)