### PR TITLE
perf: lazy multi-dim slice loading with a bounded shared LRU (#45)

### DIFF
--- a/docs/05_building_block_view.md
+++ b/docs/05_building_block_view.md
@@ -34,6 +34,7 @@ src/digitalsreeni_image_annotator/
 	├── core/                          # Constants, annotation utils, image utils
 	│   ├── constants.py
 	│   ├── annotation_utils.py
+	│   ├── slice_cache.py             # Lazy multi-dim slice materialisation + bounded LRU (ADR-036, #45)
 	│   └── torch_utils.py             # Shared torch device resolution + CPU fallback (#57)
 	├── widgets/
 	│   ├── image_label.py             # ImageLabel - canvas widget; dispatcher
@@ -239,7 +240,7 @@ the controller graph.
 | Controller | Responsibility |
 |------------|----------------|
 | `ProjectController` | `.iap` save/load, auto-save, backup/restore, missing-image prompts, window-title sync. Owns the `is_loading_project` autosave guard (load/save round-trip safety, v0.8.12). |
-| `ImageController` | Open / load / switch images and slices. TIFF + CZI loaders (with `imagecodecs` codec-error handling — #56), the multi-dim `DimensionDialog`, the `[-ndim:]` axis-slice bug fix from the v0.9.0 era. Image-list annotation-status filter (`image_has_annotations`, `apply_image_filter` — #27), alphabetical/grouped sort (`sort_image_list` — #60/#43), per-image named groups (`set_image_group`, `_populate_group_combo` — #43) and derived status badges (`refresh_image_status_icons`, painted-pixmap `QIcon` cache rebuilt on theme flip via `on_theme_changed` — #43). |
+| `ImageController` | Open / load / switch images and slices. TIFF + CZI loaders (with `imagecodecs` codec-error handling — #56), the multi-dim `DimensionDialog`, the `[-ndim:]` axis-slice bug fix from the v0.9.0 era. Multi-dim slices are now materialised **lazily** via `core/slice_cache.py` (`create_slices` builds names + a `SliceProvider`, QImages decode on demand through a shared bounded LRU — ADR-036 / #45). Image-list annotation-status filter (`image_has_annotations`, `apply_image_filter` — #27), alphabetical/grouped sort (`sort_image_list` — #60/#43), per-image named groups (`set_image_group`, `_populate_group_combo` — #43) and derived status badges (`refresh_image_status_icons`, painted-pixmap `QIcon` cache rebuilt on theme flip via `on_theme_changed` — #43). |
 | `AnnotationController` | Annotation CRUD, list sorting, highlight, edit-mode entry/exit, `finish_polygon`, `finish_rectangle`, `replace_annotations` (eraser path). Validates writes before mutating `all_annotations`. |
 | `ClassController` | Class add / delete / rename / colour / visibility. `update_slice_list_colors`, `is_class_visible`. |
 | `SAMController` | SAM box/points tool lifecycle, debounce timer, `_sam_inference_in_flight` re-entrancy guard (ADR-013), model picker. |

--- a/docs/06_runtime_view.md
+++ b/docs/06_runtime_view.md
@@ -589,19 +589,19 @@ User adds TIFF stack
     │   │   │
     │   │   └─> dimension_string = "TZCHW"
     │   │
-    │   ├─> Extract slices:
+    │   ├─> Build slice index (LAZY — ADR-036/#45):
+    │   │   │
+    │   │   ├─> SliceProvider retains the source ndarray
     │   │   │
     │   │   ├─> For each T, Z, C combination:
-    │   │   │   │
-    │   │   │   ├─> Extract 2D slice
-    │   │   │   │
-    │   │   │   ├─> Convert to QImage
-    │   │   │   │
-    │   │   │   ├─> Name: "file_T0_Z5_C0"
-    │   │   │   │
-    │   │   │   └─> Store in image_slices[filename]
+    │   │   │   └─> Precompute name "file_T1_Z6_C1" + full-index
+    │   │   │       (NO pixel work, NO QImage yet)
     │   │   │
-    │   │   └─> Display first slice
+    │   │   ├─> Store LazySliceList in image_slices[filename]
+    │   │   │   (mw.slices is the SAME object)
+    │   │   │
+    │   │   └─> Display first slice (its QImage decoded on demand,
+    │   │       cached in the shared bounded LRU; prefetch ±1 on nav)
     │   │
     │   └─> Store dimension metadata
     │       (image_dimensions, image_shapes)

--- a/docs/08_crosscutting_concepts.md
+++ b/docs/08_crosscutting_concepts.md
@@ -810,6 +810,32 @@ emitters follow up with `annotationsBatchSaved`
 New mutation paths must keep one of those two routes — don't add
 bespoke `apply_image_filter()` call sites.
 
+## Lazy Slice Materialisation — Name-Only vs Pixel Consumers (issue #45, ADR-036)
+
+Multi-dim `image_slices[base]` is a `LazySliceList` (`core/slice_cache.py`), not a
+list of `(name, qimage)` tuples — QImages decode on demand through a shared bounded
+LRU (`LRU_CAPACITY = 8`). It stays interface-compatible (`__iter__`, `__getitem__`,
+`__len__`, `__bool__`, `.names`, `.get(name)`, `prefetch_around`), but there is a
+critical distinction for anyone touching slice code:
+
+- **Name-only consumers must never iterate for pixels.** Saving a project, computing
+  annotation status, rebuilding the slice list, and navigation membership checks need
+  only slice *names*. Use `slice_cache.slice_names(slices)` (or `.names`) — iterating
+  `for name, _ in slices` would materialise every QImage. `save_project` is
+  regression-tested to call `SliceProvider.extract` **zero** times.
+- **Pixel consumers materialise one at a time.** `switch_slice`/`activate_slice` use
+  `slices.get(name)` + `prefetch_around(name)`; exporters, the SAM-dataset build and
+  DINO batch iterate via `__iter__` (which feeds/evicts the LRU). A batch export still
+  transiently collects a stack's QImages into its own `slice_map` — that is an accepted
+  per-operation cost; the SESSION memory is what the LRU bounds.
+- **Deletion must release.** `remove_image`/`delete_selected_image`/`redefine_dimensions`
+  call `slice_cache.release_slices(...)` (or the list's `release()`) before dropping the
+  stack, so LRU entries don't linger; `clear_all` clears the whole shared cache.
+- `mw.slices` and `image_slices[base]` are the **same** `LazySliceList` object, and
+  slice naming is byte-identical to the old eager path (it is the annotation key +
+  export filename). Extraction returns a fresh QImage each call — never mutate a cached
+  one (the SAM worker may be reading it, ADR-013).
+
 ## Image List Groups & Status Badges (issue #43)
 
 The image list gained two at-a-glance affordances, both layered on the

--- a/docs/08_crosscutting_concepts.md
+++ b/docs/08_crosscutting_concepts.md
@@ -828,9 +828,12 @@ critical distinction for anyone touching slice code:
   DINO batch iterate via `__iter__` (which feeds/evicts the LRU). A batch export still
   transiently collects a stack's QImages into its own `slice_map` — that is an accepted
   per-operation cost; the SESSION memory is what the LRU bounds.
-- **Deletion must release.** `remove_image`/`delete_selected_image`/`redefine_dimensions`
-  call `slice_cache.release_slices(...)` (or the list's `release()`) before dropping the
-  stack, so LRU entries don't linger; `clear_all` clears the whole shared cache.
+- **Every "drop a stack" path must release.** `remove_image`/`delete_selected_image`/
+  `redefine_dimensions` call `slice_cache.release_slices(...)` before dropping the stack;
+  `open_images` (which replaces the whole dataset) and `clear_all` clear the entire shared
+  LRU **and** `image_slices` — because a `LazySliceList` pins its whole decoded source
+  array under Strategy A, merely rebinding `mw.slices = []` would leak the outgoing stack
+  for the session.
 - `mw.slices` and `image_slices[base]` are the **same** `LazySliceList` object, and
   slice naming is byte-identical to the old eager path (it is the annotation key +
   export filename). Extraction returns a fresh QImage each call — never mutate a cached

--- a/docs/09_architecture_decisions.md
+++ b/docs/09_architecture_decisions.md
@@ -1751,6 +1751,57 @@ non-structural overlays on the existing sort/filter machinery:
 
 ---
 
+## ADR-036: Lazy Slice Extraction with a Bounded Shared LRU (Retained Source Array)
+
+**Status**: Accepted (issue #45)
+
+**Context**: Opening a multi-dimensional TIFF/CZI eagerly converted **every** slice to
+an RGB888 `QImage` in `ImageController.create_slices` and held them all for the session
+(`image_slices[base] = [(name, qimage), ...]`). A 5D 10×20×3 stack of 2048² frames is
+~600 slices ≈ 7.5 GB of live QImages, plus a create-time peak of source-array +
+growing-QImages. Annotation storage is keyed by slice *name* and is unaffected — only
+the pixel data needed to become lazy.
+
+**Decision**: Introduce `core/slice_cache.py` and make QImage materialisation lazy behind
+a process-wide bounded LRU, keeping the exact `(name, qimage)` interface every consumer
+uses (**Strategy A** — retain the already-decoded source ndarray, materialise QImages on
+demand):
+- `SliceProvider` retains the `tif.asarray()`/CZI ndarray and precomputes the ordered
+  `names` + `name → full-index` map with the **byte-identical** naming logic of the old
+  `create_slices` (`{base}_{dim}{index+1}`), then `extract(name)` reconstructs one slice
+  through the exact ADR-010 pipeline (`convert_to_8bit_rgb`/`normalize_array`/
+  `array_to_qimage`) — a **fresh** QImage each call (never mutate a cached one; the SAM
+  worker may be reading it, ADR-013).
+- `LazySliceList` is the drop-in for the old tuple list: `get(name)`, `__getitem__`,
+  `__iter__` (one-at-a-time), `__len__`/`__bool__`/`.names`, `prefetch_around(name)`
+  (pins current ±1 for instant Up/Down nav), `release()`. It is stored as BOTH
+  `image_slices[base]` and `mw.slices` (the same object — several paths compare them).
+- A single module-level `SliceLRU` (keyed `(provider_id, name)`, `LRU_CAPACITY = 8`)
+  bounds live QImages across ALL open stacks; `evict_prefix`/`release_slices` drop a
+  stack's entries on delete. Name-only consumers (save, `image_has_annotations`,
+  `update_slice_list`, navigation membership checks) use `slice_names(...)` so they touch
+  **no** pixels; iterating pixel consumers (exporters, SAM-dataset build, DINO batch,
+  `io_controller`) keep working unchanged via `__iter__`.
+
+**Consequences**:
+- ✅ Opening a stack no longer decodes every slice; live QImages are bounded by the LRU;
+  `save_project` materialises zero pixels (test-asserted via an `extract` spy).
+- ✅ Byte-identical slice names + pixels (lazy == eager, regression-tested), so existing
+  `.iap` annotations and exports are unaffected; Up/Down neighbours are prefetched.
+- ✅ `slice_names()`/`release_slices()` also accept a plain `[(name, qimage)]` list, so
+  legacy/test call sites that inject plain lists keep working with no pixel decode.
+- ⚠️ **Strategy A retains the decoded source ndarray per open stack**, so peak RSS is
+  bounded by the LRU *for QImages* but not for the array. Full array-free reading
+  (memmap/zarr per slice; CZI lazy read) is a deliberate follow-up. The dominant
+  all-QImages-in-RAM cost and the create-time peak are eliminated regardless.
+- ⚠️ The LRU keys on `id(provider)`; providers are `release()`d before being replaced
+  or deleted and `clear_all` wipes the cache, so a recycled `id()` cannot alias a stale
+  QImage.
+- Feeds issue #47: video frames reuse the same lazy-slice contract (`None`-payload
+  frames resolved on demand) rather than introducing a parallel cache.
+
+---
+
 ## Decisions Under Consideration
 
 ### Consider Relative Paths with Image Copying

--- a/docs/09_architecture_decisions.md
+++ b/docs/09_architecture_decisions.md
@@ -1796,7 +1796,9 @@ demand):
   all-QImages-in-RAM cost and the create-time peak are eliminated regardless.
 - ⚠️ The LRU keys on `id(provider)`; providers are `release()`d before being replaced
   or deleted and `clear_all` wipes the cache, so a recycled `id()` cannot alias a stale
-  QImage.
+  QImage. Every dataset-replacing path (`remove_image`/`delete_selected_image`/
+  `redefine_dimensions`/`open_images`/`clear_all`) drops the outgoing `image_slices`
+  entries + their LRU cache so the retained source array cannot leak for the session.
 - Feeds issue #47: video frames reuse the same lazy-slice contract (`None`-payload
   frames resolved on demand) rather than introducing a parallel cache.
 

--- a/docs/11_risks_and_technical_debt.md
+++ b/docs/11_risks_and_technical_debt.md
@@ -84,10 +84,16 @@ without a missing-images prompt. v1 projects still resolve via the `images/` con
 
 **Mitigation**:
 - Slice-by-slice loading for multi-dimensional images
+- **Lazy slice QImage materialisation with a bounded LRU (ADR-036, #45)** —
+  `create_slices` no longer builds every slice's `QImage` up front; slice
+  QImages decode on demand and at most `slice_cache.LRU_CAPACITY` (8) are held
+  live process-wide. Removes the dominant all-QImages-in-RAM cost and the
+  create-time peak.
 - Image downsampling for display (future)
-- Lazy loading (future)
 
-**Current Limitation**: All slices loaded into memory
+**Current Limitation**: The decoded source ndarray is still retained per open
+stack (Strategy A). Full array-free reading (memmap/zarr per-slice, or CZI
+lazy read) is a documented follow-up; the live-QImage count is now bounded.
 
 ---
 

--- a/src/digitalsreeni_image_annotator/annotator_window.py
+++ b/src/digitalsreeni_image_annotator/annotator_window.py
@@ -802,7 +802,12 @@ class ImageAnnotator(QMainWindow):
         self.btn_detect_single.setEnabled(False)
         self.btn_detect_batch.setEnabled(False)
 
-        # Clear slices
+        # Clear slices. Wipe the shared slice LRU too: image_slices is dropped
+        # wholesale here, so any cached QImages keyed by a soon-to-be-recycled
+        # provider id() must go with it or a reloaded stack could alias them
+        # (issue #45).
+        from .core.slice_cache import get_shared_lru
+        get_shared_lru().clear()
         self.image_slices.clear()
         self.slices = []
         self.slice_list.clear()

--- a/src/digitalsreeni_image_annotator/controllers/dino_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/dino_controller.py
@@ -39,6 +39,7 @@ from PyQt6.QtWidgets import (
 
 from ..core.constants import default_class_color
 from ..core.keypoint_schema import schema_k
+from ..core.slice_cache import slice_names
 
 from ..core.logging_config import get_logger
 
@@ -606,7 +607,9 @@ class DINOController(QObject):
                 self.mw.switch_image(item)
                 return True
         for base_name, slices in self.mw.image_slices.items():
-            if not any(s_name == name for s_name, _ in slices):
+            # Name-only membership check — don't materialise every slice's
+            # QImage just to find one by name (issue #45).
+            if name not in slice_names(slices):
                 continue
             for i in range(self.mw.image_list.count()):
                 item = self.mw.image_list.item(i)

--- a/src/digitalsreeni_image_annotator/controllers/image_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/image_controller.py
@@ -393,8 +393,16 @@ class ImageController(QObject):
             self.mw.image_paths.clear()
             self.mw.all_images.clear()
             self.mw.slice_list.clear()
-            # Reassign (not .clear()) — mw.slices may be a LazySliceList,
-            # which has no .clear() (issue #45).
+            # Drop the outgoing stacks' cached QImages AND their retained
+            # source arrays: image_slices is being replaced wholesale, so wipe
+            # the shared slice LRU and clear image_slices. Under Strategy A a
+            # LazySliceList pins its whole decoded ndarray, so merely
+            # rebinding mw.slices = [] (mw.slices is no longer the same object
+            # as image_slices[base]) would leak every previously-open stack for
+            # the session. Mirrors clear_all (issue #45).
+            from ..core.slice_cache import get_shared_lru
+            get_shared_lru().clear()
+            self.mw.image_slices.clear()
             self.mw.slices = []
             self.mw.current_stack = None
             self.mw.current_slice = None

--- a/src/digitalsreeni_image_annotator/controllers/image_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/image_controller.py
@@ -21,7 +21,6 @@ The `DimensionDialog` widget lives here too — it is only used by
 
 import os
 
-import numpy as np
 from czifile import CziFile
 from PyQt6.QtCore import Qt, QObject
 from PyQt6.QtGui import QColor, QIcon, QImage, QPainter, QPen, QPixmap
@@ -43,6 +42,12 @@ from PyQt6.QtWidgets import (
 from tifffile import TiffFile
 
 from ..core import image_utils
+from ..core.slice_cache import (
+    LazySliceList,
+    SliceProvider,
+    release_slices,
+    slice_names,
+)
 
 from ..core.logging_config import get_logger
 
@@ -171,9 +176,11 @@ class ImageController(QObject):
             base_name = os.path.splitext(file_name)[0]
             slices = self.mw.image_slices.get(base_name)
             if slices:
+                # Name-only scan (slice_names) — never materialise QImages
+                # just to check annotation status (issue #45).
                 return any(
                     _non_empty(self.mw.all_annotations.get(slice_name, {}))
-                    for slice_name, _ in slices
+                    for slice_name in slice_names(slices)
                 )
             # Slices not extracted yet (e.g. load cancelled) — slice keys
             # are f"{base_name}_T1_Z5_..." so a "{base_name}_" prefix match
@@ -386,7 +393,9 @@ class ImageController(QObject):
             self.mw.image_paths.clear()
             self.mw.all_images.clear()
             self.mw.slice_list.clear()
-            self.mw.slices.clear()
+            # Reassign (not .clear()) — mw.slices may be a LazySliceList,
+            # which has no .clear() (issue #45).
+            self.mw.slices = []
             self.mw.current_stack = None
             self.mw.current_slice = None
             self.add_images_to_list(file_names)
@@ -498,18 +507,21 @@ class ImageController(QObject):
         self.mw.annotation_controller.reset_coalesce()
 
         slice_name = item.text()
-        for name, qimage in self.mw.slices:
-            if name == slice_name:
-                self.mw.current_image = qimage
-                self.mw.current_slice = name
-                self.display_image()
-                self.mw.load_image_annotations()
-                self.mw.update_annotation_list()
-                self.mw.clear_highlighted_annotation()
-                self.mw.image_label.reset_annotation_state()
-                self.mw.image_label.clear_current_annotation()
-                self.mw.update_image_info()
-                break
+        # Lazy materialise this slice (LRU-cached) instead of scanning +
+        # holding every slice's QImage; prefetch neighbours so Up/Down nav
+        # stays instant (issue #45).
+        qimage = self.mw.slices.get(slice_name)
+        if qimage is not None:
+            self.mw.slices.prefetch_around(slice_name)
+            self.mw.current_image = qimage
+            self.mw.current_slice = slice_name
+            self.display_image()
+            self.mw.load_image_annotations()
+            self.mw.update_annotation_list()
+            self.mw.clear_highlighted_annotation()
+            self.mw.image_label.reset_annotation_state()
+            self.mw.image_label.clear_current_annotation()
+            self.mw.update_image_info()
 
         self.mw.image_label.update()
         self.mw.update_slice_list_colors()
@@ -845,67 +857,43 @@ class ImageController(QObject):
 
     def create_slices(self, image_array, dimensions, image_path):
         base_name = os.path.splitext(os.path.basename(image_path))[0]
-        slices = []
         self.mw.slice_list.clear()
 
         logger.debug(f"Creating slices for {base_name}")
         logger.debug(f"Dimensions: {dimensions}")
         logger.debug(f"Image array shape: {image_array.shape}")
 
-        progress = QProgressDialog("Loading slices...", "Cancel", 0, 100, self.mw)
-        progress.setWindowModality(Qt.WindowModality.WindowModal)
-        progress.setMinimumDuration(0)
+        # Reloading a stack under the same base_name (redefine dims, project
+        # reload) drops the previous LazySliceList — evict its cached QImages
+        # first so a recycled provider id() can't alias stale entries. The old
+        # object stays referenced until the reassignment below, so the new
+        # provider is guaranteed a distinct id() (issue #45).
+        release_slices(self.mw.image_slices.get(base_name))
 
-        if image_array.ndim == 2:
-            progress.setValue(50)
-            QApplication.processEvents()
-            normalized_array = image_utils.normalize_array(image_array)
-            qimage = image_utils.array_to_qimage(normalized_array)
-            slice_name = f"{base_name}"
-            slices.append((slice_name, qimage))
+        # Lazy slicing (issue #45): retain the already-decoded source array in
+        # a provider and materialise each slice's QImage ON DEMAND through a
+        # shared bounded LRU. No per-slice pixel work happens here now, so the
+        # progress dialog (pixel work only) is gone; building names is cheap.
+        provider = SliceProvider(image_array, dimensions, base_name)
+        lazy = LazySliceList(provider)
+
+        for slice_name in lazy.names:
             self.add_slice_to_list(slice_name)
-        else:
-            slice_indices = [
-                i for i, dim in enumerate(dimensions) if dim not in ["H", "W"]
-            ]
 
-            total_slices = np.prod([image_array.shape[i] for i in slice_indices])
-            for idx, _ in enumerate(
-                np.ndindex(tuple(image_array.shape[i] for i in slice_indices))
-            ):
-                if progress.wasCanceled():
-                    break
+        # mw.image_slices[base] and mw.slices MUST be the same object — several
+        # paths compare/assign them (issue #45 guardrail).
+        self.mw.image_slices[base_name] = lazy
+        self.mw.slices = lazy
 
-                full_idx = [slice(None)] * len(dimensions)
-                for i, val in zip(slice_indices, _):
-                    full_idx[i] = val
-
-                slice_array = image_array[tuple(full_idx)]
-                rgb_slice = image_utils.convert_to_8bit_rgb(slice_array)
-                qimage = image_utils.array_to_qimage(rgb_slice)
-
-                slice_name = f"{base_name}_{'_'.join([f'{dimensions[i]}{val+1}' for i, val in zip(slice_indices, _)])}"
-                slices.append((slice_name, qimage))
-
-                self.add_slice_to_list(slice_name)
-
-                progress_value = int((idx + 1) / total_slices * 100)
-                progress.setValue(progress_value)
-                QApplication.processEvents()
-
-        progress.setValue(100)
-
-        self.mw.image_slices[base_name] = slices
-        self.mw.slices = slices
-
-        if slices:
-            self.mw.current_image = slices[0][1]
-            self.mw.current_slice = slices[0][0]
+        if lazy:
+            first_name, first_image = lazy[0]
+            self.mw.current_image = first_image
+            self.mw.current_slice = first_name
             self.mw.slice_list.setCurrentRow(0)
 
             self.activate_slice(self.mw.current_slice)
 
-            slice_info = f"Total slices: {len(slices)}"
+            slice_info = f"Total slices: {len(lazy)}"
             for dim, size in zip(dimensions, image_array.shape):
                 if dim not in ["H", "W"]:
                     slice_info += f", {dim}: {size}"
@@ -913,8 +901,8 @@ class ImageController(QObject):
         else:
             logger.warning("No slices were created")
 
-        logger.info(f"Created {len(slices)} slices for {base_name}")
-        return slices
+        logger.info(f"Created {len(lazy)} slices for {base_name}")
+        return lazy
 
     def add_slice_to_list(self, slice_name):
         item = QListWidgetItem(slice_name)
@@ -942,11 +930,12 @@ class ImageController(QObject):
         self.mw.load_image_annotations()
         self.mw.update_annotation_list()
 
-        for name, qimage in self.mw.slices:
-            if name == slice_name:
-                self.mw.current_image = qimage
-                self.display_image()
-                break
+        # Lazy materialise (LRU-cached) + prefetch neighbours (issue #45).
+        qimage = self.mw.slices.get(slice_name)
+        if qimage is not None:
+            self.mw.slices.prefetch_around(slice_name)
+            self.mw.current_image = qimage
+            self.display_image()
 
         self.mw.image_label.update()
 
@@ -956,7 +945,9 @@ class ImageController(QObject):
 
     def update_slice_list(self):
         self.mw.slice_list.clear()
-        for slice_name, _ in self.mw.slices:
+        # Name-only (slice_names) — rebuilding the list must not decode pixels
+        # (issue #45).
+        for slice_name in slice_names(self.mw.slices):
             item = QListWidgetItem(slice_name)
             if slice_name in self.mw.all_annotations:
                 item.setForeground(QColor(Qt.GlobalColor.green))
@@ -1018,6 +1009,9 @@ class ImageController(QObject):
                 del self.mw.all_annotations[key]
 
             if base_name in self.mw.image_slices:
+                # Drop this stack's cached QImages before dropping the list so
+                # shared-LRU entries don't leak (issue #45).
+                release_slices(self.mw.image_slices[base_name])
                 del self.mw.image_slices[base_name]
 
             if self.mw.image_file_name == file_name:
@@ -1055,8 +1049,10 @@ class ImageController(QObject):
 
             base_name = os.path.splitext(file_name)[0]
             if base_name in self.mw.image_slices:
-                for slice_name, _ in self.mw.image_slices[base_name]:
+                stack_slices = self.mw.image_slices[base_name]
+                for slice_name in slice_names(stack_slices):
                     self.mw.all_annotations.pop(slice_name, None)
+                release_slices(stack_slices)  # evict cached QImages (issue #45)
                 del self.mw.image_slices[base_name]
 
                 self.mw.slice_list.clear()
@@ -1107,8 +1103,10 @@ class ImageController(QObject):
 
                 base_name = os.path.splitext(file_name)[0]
                 if base_name in self.mw.image_slices:
-                    for slice_name, _ in self.mw.image_slices[base_name]:
+                    stack_slices = self.mw.image_slices[base_name]
+                    for slice_name in slice_names(stack_slices):
                         self.mw.all_annotations.pop(slice_name, None)
+                    release_slices(stack_slices)  # evict cached QImages (issue #45)
                     del self.mw.image_slices[base_name]
 
                     self.mw.slice_list.clear()

--- a/src/digitalsreeni_image_annotator/controllers/image_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/image_controller.py
@@ -45,6 +45,7 @@ from ..core import image_utils
 from ..core.slice_cache import (
     LazySliceList,
     SliceProvider,
+    get_shared_lru,
     release_slices,
     slice_names,
 )
@@ -400,7 +401,6 @@ class ImageController(QObject):
             # rebinding mw.slices = [] (mw.slices is no longer the same object
             # as image_slices[base]) would leak every previously-open stack for
             # the session. Mirrors clear_all (issue #45).
-            from ..core.slice_cache import get_shared_lru
             get_shared_lru().clear()
             self.mw.image_slices.clear()
             self.mw.slices = []

--- a/src/digitalsreeni_image_annotator/controllers/io_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/io_controller.py
@@ -406,11 +406,25 @@ def export_annotations(mw):
 
 
 def save_slices(mw, directory):
+    # Decode ONLY the annotated slices (issue #45): iterate names first (no
+    # pixel work) and materialise a slice's QImage only when it has
+    # annotations, instead of decoding every slice of every stack.
+    from ..core.slice_cache import slice_names
+
     slices_saved = False
     for image_file, image_slices in mw.image_slices.items():
-        for slice_name, qimage in image_slices:
-            if slice_name in mw.all_annotations and mw.all_annotations[slice_name]:
-                file_path = os.path.join(directory, f"{slice_name}.png")
-                qimage.save(file_path, "PNG")
+        getter = getattr(image_slices, "get", None)
+        name_to_qimage = None  # lazily built only for plain-list collections
+        for slice_name in slice_names(image_slices):
+            if not mw.all_annotations.get(slice_name):
+                continue
+            if getter is not None:
+                qimage = getter(slice_name)
+            else:
+                if name_to_qimage is None:
+                    name_to_qimage = {n: q for n, q in image_slices}
+                qimage = name_to_qimage.get(slice_name)
+            if qimage is not None:
+                qimage.save(os.path.join(directory, f"{slice_name}.png"), "PNG")
                 slices_saved = True
     return slices_saved

--- a/src/digitalsreeni_image_annotator/controllers/project_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/project_controller.py
@@ -24,6 +24,7 @@ from PyQt6.QtWidgets import QFileDialog, QInputDialog, QMessageBox
 from ..core import image_utils, recovery
 from ..core.keypoint_schema import sanitize_schema as _sanitize_keypoint_schema
 from ..core.project_schema import validate_project_data
+from ..core.slice_cache import release_slices, slice_names
 
 from ..core.logging_config import get_logger
 
@@ -323,8 +324,10 @@ class ProjectController(QObject):
 
             base_name = os.path.splitext(image_name)[0]
             if base_name in self.mw.image_slices:
-                for slice_name, _ in self.mw.image_slices[base_name]:
+                stack_slices = self.mw.image_slices[base_name]
+                for slice_name in slice_names(stack_slices):
                     self.mw.all_annotations.pop(slice_name, None)
+                release_slices(stack_slices)  # evict cached QImages (issue #45)
                 del self.mw.image_slices[base_name]
 
         self.mw.update_ui()
@@ -459,7 +462,12 @@ class ProjectController(QObject):
             if image_data["is_multi_slice"]:
                 base_name_without_ext = os.path.splitext(file_name)[0]
                 image_data["slices"] = []
-                for slice_name, _ in self.mw.image_slices.get(base_name_without_ext, []):
+                # Name-only (slice_names) — saving a project must not decode a
+                # single slice's pixels (issue #45); it also accepts a plain
+                # list or an absent/None entry.
+                for slice_name in slice_names(
+                    self.mw.image_slices.get(base_name_without_ext)
+                ):
                     slice_data = {
                         "name": slice_name,
                         "annotations": image_utils.convert_to_serializable(

--- a/src/digitalsreeni_image_annotator/core/slice_cache.py
+++ b/src/digitalsreeni_image_annotator/core/slice_cache.py
@@ -1,0 +1,252 @@
+"""Lazy, bounded materialisation of multi-dimensional image slices (issue #45).
+
+Multi-dim TIFF/CZI stacks used to be exploded eagerly: every slice was
+converted to an RGB888 ``QImage`` up front and all of them were held for the
+whole session (``image_slices[base] = [(name, qimage), ...]``). A large 5D
+stack could be several GB of live QImages.
+
+This module keeps the identical ``(name, qimage)`` interface the rest of the
+app relies on, but materialises each slice's QImage **on demand** and holds at
+most :data:`LRU_CAPACITY` of them process-wide.
+
+Strategy A (see ADR): the already-decoded source ndarray from
+``tif.asarray()`` / CZI is *retained* by a :class:`SliceProvider`, and each
+slice's QImage is reconstructed lazily through the exact ADR-010 8-bit-RGB
+pipeline (``image_utils.convert_to_8bit_rgb`` / ``normalize_array`` /
+``array_to_qimage``) so lazy pixels are byte-identical to the old eager ones.
+Full array-free (memmap/zarr) reading is a deliberate follow-up.
+
+Public API (consumed by controllers and issue #47 video work):
+
+- :data:`LRU_CAPACITY` — default per-process live-QImage budget.
+- :class:`SliceLRU` + :func:`get_shared_lru` — the one shared cache.
+- :func:`evict_prefix` / :func:`release_slices` — drop a stack's cached QImages.
+- :func:`slice_names` — names of a slice collection with **no** pixel work.
+- :class:`SliceProvider` — retains the source array, materialises one slice.
+- :class:`LazySliceList` — the drop-in replacement for the old list of tuples.
+"""
+
+import collections
+
+import numpy as np
+
+from . import image_utils
+
+# Default number of materialised slice QImages held live across ALL stacks.
+# Shared, so total QImage memory stays bounded no matter how many stacks are
+# open. Per-list this bounds each stack to ~this many live QImages too.
+LRU_CAPACITY = 8
+
+
+class SliceLRU:
+    """Process-wide bounded LRU of materialised slice QImages.
+
+    Keyed by ``(provider_id, slice_name)`` so every :class:`LazySliceList`
+    shares one capacity budget. Least-recently-``get``/``put`` entry is
+    evicted first once ``len`` exceeds ``capacity``.
+    """
+
+    def __init__(self, capacity=LRU_CAPACITY):
+        self.capacity = capacity
+        self._cache = collections.OrderedDict()
+
+    def get(self, key):
+        cache = self._cache
+        if key in cache:
+            cache.move_to_end(key)
+            return cache[key]
+        return None
+
+    def put(self, key, qimage):
+        cache = self._cache
+        cache[key] = qimage
+        cache.move_to_end(key)
+        # Capacity may have been lowered at runtime (tests) — evict to fit.
+        while len(cache) > self.capacity:
+            cache.popitem(last=False)
+
+    def evict_prefix(self, provider_id):
+        """Drop every entry belonging to ``provider_id`` (stack deletion)."""
+        cache = self._cache
+        for key in [k for k in cache if k[0] == provider_id]:
+            del cache[key]
+
+    def count_prefix(self, provider_id):
+        """Number of cached entries for ``provider_id`` (test introspection)."""
+        return sum(1 for k in self._cache if k[0] == provider_id)
+
+    def clear(self):
+        self._cache.clear()
+
+    def __contains__(self, key):
+        return key in self._cache
+
+    def __len__(self):
+        return len(self._cache)
+
+
+# The single process-wide cache shared by all LazySliceLists.
+_SHARED_LRU = SliceLRU()
+
+
+def get_shared_lru():
+    """Return the process-wide :class:`SliceLRU` singleton."""
+    return _SHARED_LRU
+
+
+def evict_prefix(provider_id):
+    """Evict every shared-LRU entry for ``provider_id``."""
+    _SHARED_LRU.evict_prefix(provider_id)
+
+
+def slice_names(slices):
+    """Ordered slice names of ``slices`` **without materialising any QImage**.
+
+    Accepts either a :class:`LazySliceList` (returns its precomputed
+    ``names``) or a plain ``[(name, qimage), ...]`` list — several tests and
+    legacy call sites still hand in the latter, and name-only scans (save,
+    annotation-status, navigation) must never trigger pixel decoding.
+    ``None`` / empty yields ``[]``.
+    """
+    names = getattr(slices, "names", None)
+    if names is not None:
+        return list(names)
+    return [name for name, _ in (slices or [])]
+
+
+def release_slices(slices):
+    """Release a slice collection's cached QImages, if it is a LazySliceList.
+
+    A no-op for plain-list slice collections (nothing to evict). Call this
+    before dropping a stack from ``image_slices`` so its LRU entries don't
+    linger.
+    """
+    release = getattr(slices, "release", None)
+    if callable(release):
+        release()
+
+
+class SliceProvider:
+    """Retains a loaded multi-dim source array; materialises one slice's
+    QImage on demand.
+
+    The ordered ``names`` list and the ``name -> full-index`` map are
+    precomputed once (cheap, no pixel work) using the EXACT same logic the
+    old eager ``ImageController.create_slices`` used, so slice naming stays
+    byte-identical (it is the annotation key + export filename — any drift
+    orphans annotations).
+    """
+
+    def __init__(self, image_array, dimensions, base_name):
+        self._array = image_array
+        self.dimensions = list(dimensions)
+        self.base_name = base_name
+        self.provider_id = id(self)
+        self.names = []
+        # name -> tuple(full_idx) for ND; name -> None for the 2D single slice.
+        self._index_map = {}
+        self._build_index()
+
+    def _build_index(self):
+        arr = self._array
+        dims = self.dimensions
+        base = self.base_name
+
+        if arr.ndim == 2:
+            self.names = [base]
+            self._index_map = {base: None}
+            return
+
+        slice_indices = [i for i, dim in enumerate(dims) if dim not in ("H", "W")]
+        for idx_tuple in np.ndindex(tuple(arr.shape[i] for i in slice_indices)):
+            full_idx = [slice(None)] * len(dims)
+            for i, val in zip(slice_indices, idx_tuple):
+                full_idx[i] = val
+            slice_name = f"{base}_" + "_".join(
+                f"{dims[i]}{val + 1}" for i, val in zip(slice_indices, idx_tuple)
+            )
+            self.names.append(slice_name)
+            self._index_map[slice_name] = tuple(full_idx)
+
+    def extract(self, name):
+        """Reconstruct ONE slice's QImage. Returns a FRESH QImage every call
+        (never mutate a cached one — the SAM worker may be reading it,
+        ADR-013). Unknown name -> ``None``."""
+        if name not in self._index_map:
+            return None
+        full_idx = self._index_map[name]
+        if full_idx is None:  # the 2D single-slice case
+            normalized = image_utils.normalize_array(self._array)
+            return image_utils.array_to_qimage(normalized)
+        slice_array = self._array[full_idx]
+        rgb_slice = image_utils.convert_to_8bit_rgb(slice_array)
+        return image_utils.array_to_qimage(rgb_slice)
+
+
+class LazySliceList:
+    """Drop-in replacement for the old ``[(name, qimage), ...]`` slice list.
+
+    Backed by a :class:`SliceProvider` and the shared :class:`SliceLRU`.
+    Supports the access patterns every consumer uses:
+
+    - ``lazy.get(name)`` — LRU-cached materialise (miss extracts + inserts).
+    - ``lazy[i]`` -> ``(name, qimage)`` (probes like ``slices[0][1]``).
+    - ``for name, qimage in lazy`` — one-at-a-time materialise, feeding/
+      evicting the shared LRU so a full export/DINO-batch pass never holds
+      more than ``capacity`` live in the cache.
+    - ``len`` / ``bool`` / ``.names`` — name-only, no pixel work.
+    - ``prefetch_around(name)`` — pin current +/-1 for instant Up/Down nav.
+    - ``release()`` — drop this stack's cached QImages.
+    """
+
+    def __init__(self, provider):
+        self.provider = provider
+        self.names = provider.names
+        self._lru = get_shared_lru()
+
+    @property
+    def provider_id(self):
+        return self.provider.provider_id
+
+    def get(self, name):
+        """Return the slice QImage for ``name`` (LRU hit or fresh extract),
+        or ``None`` for an unknown name."""
+        key = (self.provider.provider_id, name)
+        qimage = self._lru.get(key)
+        if qimage is not None:
+            return qimage
+        qimage = self.provider.extract(name)
+        if qimage is None:
+            return None
+        self._lru.put(key, qimage)
+        return qimage
+
+    def __getitem__(self, index):
+        name = self.names[index]
+        return (name, self.get(name))
+
+    def __iter__(self):
+        for name in self.names:
+            yield (name, self.get(name))
+
+    def __len__(self):
+        return len(self.names)
+
+    def __bool__(self):
+        return bool(self.names)
+
+    def prefetch_around(self, name):
+        """Materialise ``name`` and its +/-1 neighbours (by index in
+        ``names``) so navigation is instant. Synchronous, main-thread only."""
+        try:
+            idx = self.names.index(name)
+        except ValueError:
+            self.get(name)
+            return
+        for j in (idx - 1, idx, idx + 1):
+            if 0 <= j < len(self.names):
+                self.get(self.names[j])
+
+    def release(self):
+        """Evict this stack's entries from the shared LRU (on delete)."""
+        self._lru.evict_prefix(self.provider.provider_id)

--- a/tests/integration/test_image_controller_slicing.py
+++ b/tests/integration/test_image_controller_slicing.py
@@ -361,6 +361,38 @@ def test_collect_dino_batch_flattens_lazy_stack(tmp_path, window, fake_dimension
     assert all(isinstance(img, QImage) for _, img in items)
 
 
+def test_open_images_releases_previous_stack(
+    tmp_path, window, fake_dimension_dialog, monkeypatch
+):
+    """open_images replaces the dataset: the previously-open stack's cached
+    QImages AND its retained source array (the whole LazySliceList) must be
+    dropped, not merely unaliased. Under Strategy A that array can be GBs, so a
+    bare ``mw.slices = []`` would leak the outgoing stack for the session (#45).
+    """
+    from PyQt6.QtWidgets import QFileDialog
+
+    path, _ = make_tiff(tmp_path, "stack3d.tif", (4, 8, 6), axes="ZYX")
+    window.image_controller.load_tiff(path)
+    lazy = window.image_slices["stack3d"]
+    old_pid = lazy.provider_id
+    lazy.get(lazy.names[0])  # prime the LRU with one entry
+    assert get_shared_lru().count_prefix(old_pid) > 0
+
+    # Open a fresh, unrelated regular image via the (monkeypatched) dialog.
+    png = tmp_path / "plain.png"
+    img = QImage(4, 4, QImage.Format.Format_RGB888)
+    img.fill(Qt.GlobalColor.gray)
+    img.save(str(png))
+    monkeypatch.setattr(
+        QFileDialog, "getOpenFileNames",
+        staticmethod(lambda *a, **k: ([str(png)], "")),
+    )
+    window.image_controller.open_images()
+
+    assert "stack3d" not in window.image_slices  # outgoing stack dropped
+    assert get_shared_lru().count_prefix(old_pid) == 0  # its LRU entries gone
+
+
 def test_deleting_stack_evicts_lru(tmp_path, window, fake_dimension_dialog, no_native_dialogs):
     """Deleting a stack drops every one of its cached QImages from the shared
     LRU (no stale entries keyed by a soon-to-be-recycled provider id)."""

--- a/tests/integration/test_image_controller_slicing.py
+++ b/tests/integration/test_image_controller_slicing.py
@@ -19,8 +19,10 @@ import tifffile
 
 import digitalsreeni_image_annotator.controllers.image_controller as ic
 from digitalsreeni_image_annotator.core import image_utils
+from digitalsreeni_image_annotator.core.slice_cache import get_shared_lru
 
-from PyQt6.QtGui import QImage
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QColor, QImage
 
 
 @pytest.fixture
@@ -220,3 +222,165 @@ def test_uint16_normalized_to_uint8():
 
     qimg = image_utils.array_to_qimage(rgb)
     assert qimg.format() == QImage.Format.Format_RGB888
+
+
+# ── lazy slice loading (issue #45) ───────────────────────────────────────────
+
+POLY = {"segmentation": [1.0, 1.0, 10.0, 1.0, 10.0, 8.0], "area": 31.5,
+        "category_id": 1, "category_name": "cell", "number": 1}
+
+
+@pytest.fixture
+def no_native_dialogs(monkeypatch):
+    """Hard safety net: no modal may open in an offscreen run (it hangs)."""
+    from PyQt6.QtWidgets import QFileDialog, QMessageBox
+
+    monkeypatch.setattr(
+        QMessageBox, "question",
+        staticmethod(lambda *a, **k: QMessageBox.StandardButton.Yes),
+    )
+    for m in ("information", "warning", "critical"):
+        monkeypatch.setattr(QMessageBox, m, staticmethod(lambda *a, **k: None))
+    monkeypatch.setattr(QFileDialog, "getOpenFileNames", staticmethod(lambda *a, **k: ([], "")))
+    monkeypatch.setattr(QFileDialog, "getSaveFileName", staticmethod(lambda *a, **k: ("", "")))
+
+
+def _spy_extract(provider):
+    """Count how many times a provider actually decodes a slice."""
+    calls = {"n": 0}
+    original = provider.extract
+
+    def counting(name):
+        calls["n"] += 1
+        return original(name)
+
+    provider.extract = counting
+    return calls
+
+
+def test_create_slices_stores_lazy_list_shared_object(tmp_path, window, fake_dimension_dialog):
+    """mw.slices and mw.image_slices[base] are the SAME LazySliceList object
+    (issue #45 guardrail), and names are byte-identical to the eager output."""
+    path, _ = make_tiff(tmp_path, "stack5d.tif", (2, 3, 2, 16, 12), axes="TZCYX")
+
+    window.image_controller.load_tiff(path)
+
+    lazy = window.image_slices["stack5d"]
+    assert window.slices is lazy  # exact same object, not a copy
+    expected = [
+        f"stack5d_T{t+1}_Z{z+1}_C{c+1}"
+        for t in range(2) for z in range(3) for c in range(2)
+    ]
+    assert lazy.names == expected
+    # First slice is materialised + active after load.
+    assert window.current_slice == "stack5d_T1_Z1_C1"
+    assert isinstance(window.current_image, QImage)
+
+
+def test_switch_to_far_slice_materialises_lazily(tmp_path, window, fake_dimension_dialog):
+    """Switching to a far slice returns its QImage on demand (LRU miss →
+    extract), and only a bounded number of slices are ever held live."""
+    path, _ = make_tiff(tmp_path, "stack5d.tif", (2, 3, 2, 16, 12), axes="TZCYX")
+    window.image_controller.load_tiff(path)
+
+    lazy = window.image_slices["stack5d"]
+    far = lazy.names[-1]
+    items = window.slice_list.findItems(far, Qt.MatchFlag.MatchExactly)
+    assert items
+    window.image_controller.switch_slice(items[0])
+
+    assert window.current_slice == far
+    assert isinstance(window.current_image, QImage)
+    assert window.current_image.width() == 12 and window.current_image.height() == 16
+    # Never more than the shared capacity live across the whole session.
+    assert len(get_shared_lru()) <= get_shared_lru().capacity
+
+
+def test_save_reads_no_slice_pixels(tmp_path, window, fake_dimension_dialog):
+    """build_project_data must persist per-slice annotations WITHOUT decoding
+    a single slice — proven by a zero call-count on provider.extract."""
+    path, _ = make_tiff(tmp_path, "stack5d.tif", (2, 3, 2, 8, 6), axes="TZCYX")
+    window.image_controller.load_tiff(path)
+    window.all_images.append({"file_name": "stack5d.tif", "width": 6, "height": 8,
+                              "id": 1, "is_multi_slice": True})
+
+    lazy = window.image_slices["stack5d"]
+    calls = _spy_extract(lazy.provider)  # spy AFTER load (ignore load-time extracts)
+
+    data = window.project_controller.build_project_data()
+
+    assert calls["n"] == 0
+    stack = next(i for i in data["images"] if i["file_name"] == "stack5d.tif")
+    assert [s["name"] for s in stack["slices"]] == lazy.names
+
+
+def test_far_slice_annotation_survives_save_reload(
+    tmp_path, window, fake_dimension_dialog, no_native_dialogs
+):
+    """Full roundtrip: open a stack, switch to a far slice, annotate it, save,
+    reload — the annotation is preserved under the slice key."""
+    images_dir = tmp_path / "images"
+    images_dir.mkdir()
+    path, _ = make_tiff(images_dir, "stack5d.tif", (2, 3, 2, 8, 6), axes="TZCYX")
+
+    window.current_project_file = str(tmp_path / "proj.iap")
+    window.current_project_dir = str(tmp_path)
+    window.add_class("cell", QColor("#ff0000"))
+
+    window.image_controller.add_images_to_list([path])
+    lazy = window.image_slices["stack5d"]
+    far = lazy.names[-1]
+
+    items = window.slice_list.findItems(far, Qt.MatchFlag.MatchExactly)
+    assert items
+    window.image_controller.switch_slice(items[0])
+    assert window.current_slice == far
+
+    # Annotate the (far) current slice through the normal save path.
+    window.image_label.annotations = {"cell": [dict(POLY)]}
+    window.save_current_annotations()
+
+    window.project_controller.save_project(show_message=False)
+    window.project_controller.open_specific_project(str(window.current_project_file))
+
+    assert far in window.all_annotations
+    assert window.all_annotations[far]["cell"][0]["segmentation"] == POLY["segmentation"]
+
+
+def test_collect_dino_batch_flattens_lazy_stack(tmp_path, window, fake_dimension_dialog):
+    """DINO batch flattening yields one work item per slice of a lazily-loaded
+    stack, each a real QImage (materialised on demand)."""
+    path, _ = make_tiff(tmp_path, "stack3d.tif", (4, 8, 6), axes="ZYX")
+    window.image_controller.load_tiff(path)
+    window.all_images.append({"file_name": "stack3d.tif", "is_multi_slice": True})
+
+    items = window.dino_controller._collect_dino_batch_work_items()
+
+    names = [n for n, _ in items]
+    assert names == window.image_slices["stack3d"].names
+    assert all(isinstance(img, QImage) for _, img in items)
+
+
+def test_deleting_stack_evicts_lru(tmp_path, window, fake_dimension_dialog, no_native_dialogs):
+    """Deleting a stack drops every one of its cached QImages from the shared
+    LRU (no stale entries keyed by a soon-to-be-recycled provider id)."""
+    path, _ = make_tiff(tmp_path, "stack3d.tif", (4, 8, 6), axes="ZYX")
+    window.image_controller.load_tiff(path)
+
+    lazy = window.image_slices["stack3d"]
+    provider_id = lazy.provider_id
+    for name in lazy.names:  # force several entries into the LRU
+        lazy.get(name)
+    assert get_shared_lru().count_prefix(provider_id) > 0
+
+    # Minimal image-list state so delete_selected_image can find the entry.
+    window.all_images.append({"file_name": "stack3d.tif", "width": 6, "height": 8,
+                              "id": 1, "is_multi_slice": True})
+    window.image_paths["stack3d.tif"] = path
+    window.image_list.addItem("stack3d.tif")
+    window.image_list.setCurrentRow(window.image_list.count() - 1)
+
+    window.image_controller.delete_selected_image()
+
+    assert "stack3d" not in window.image_slices
+    assert get_shared_lru().count_prefix(provider_id) == 0

--- a/tests/manual/profile_lazy_slices.py
+++ b/tests/manual/profile_lazy_slices.py
@@ -1,0 +1,70 @@
+"""Manual RSS profiling for lazy multi-dim slice loading (issue #45).
+
+NOT collected by pytest (no ``test_`` prefix). Run it by hand to eyeball the
+resident-set-size (RSS) win of retaining the source array + a bounded LRU of
+materialised QImages instead of exploding every slice up front.
+
+Usage (from the repo root, offscreen so no display is needed)::
+
+    QT_QPA_PLATFORM=offscreen python tests/manual/profile_lazy_slices.py
+
+It builds a synthetic 5D uint16 stack, measures RSS after (a) just building the
+LazySliceList (names only, no pixels) and (b) touching every slice one at a
+time through the LRU, and prints both. The gap between "eager-equivalent"
+(N * H*W*3 bytes of live QImages) and the bounded LRU is the memory saved.
+
+Requires ``psutil`` for RSS; falls back to a note if it is not installed.
+"""
+
+import numpy as np
+from PyQt6.QtWidgets import QApplication
+
+from digitalsreeni_image_annotator.core.slice_cache import (
+    LRU_CAPACITY,
+    LazySliceList,
+    SliceProvider,
+    get_shared_lru,
+)
+
+
+def _rss_mb():
+    try:
+        import psutil
+    except ImportError:
+        return None
+    return psutil.Process().memory_info().rss / (1024 * 1024)
+
+
+def main():
+    app = QApplication.instance() or QApplication([])  # noqa: F841
+
+    T, Z, C, H, W = 4, 8, 3, 1024, 1024  # 96 slices of ~3 MB RGB each
+    arr = (np.random.rand(T, Z, C, H, W) * 65535).astype(np.uint16)
+
+    base_rss = _rss_mb()
+    provider = SliceProvider(arr, ["T", "Z", "C", "H", "W"], "profile")
+    lazy = LazySliceList(provider)
+    after_build = _rss_mb()
+
+    # Touch every slice once (feeds/evicts the shared LRU).
+    for name in lazy.names:
+        _img = lazy.get(name)
+    after_touch = _rss_mb()
+
+    n = len(lazy.names)
+    eager_qimage_mb = n * H * W * 3 / (1024 * 1024)
+
+    print(f"slices: {n}  (LRU capacity {LRU_CAPACITY})")
+    print(f"source array: {arr.nbytes / (1024 * 1024):.0f} MB (retained, Strategy A)")
+    print(f"eager would hold ~{eager_qimage_mb:.0f} MB of live QImages")
+    print(f"LRU holds at most {get_shared_lru().capacity} QImages "
+          f"(~{get_shared_lru().capacity * H * W * 3 / (1024 * 1024):.0f} MB)")
+    if base_rss is None:
+        print("(install psutil for RSS numbers)")
+    else:
+        print(f"RSS: baseline {base_rss:.0f} MB -> after build {after_build:.0f} MB "
+              f"-> after touching all slices {after_touch:.0f} MB")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_slice_cache.py
+++ b/tests/unit/test_slice_cache.py
@@ -1,0 +1,281 @@
+"""Unit tests for the lazy slice cache (issue #45).
+
+`core/slice_cache.py` replaces the old "materialise every slice's QImage up
+front and hold them for the session" behaviour with on-demand materialisation
+behind a process-wide bounded LRU. These tests pin the invariants the rest of
+the app depends on:
+
+  1. slice NAMES are byte-identical to the old create_slices (`{base}_T1_Z5_C1`,
+     1-based) — they are the annotation key + export filename;
+  2. the shared LRU evicts beyond ``LRU_CAPACITY``;
+  3. ``prefetch_around`` pins current +/-1 (instant Up/Down nav);
+  4. iterating N names with a tiny capacity re-extracts but never holds more
+     than ``capacity`` live in the LRU;
+  5. lazily extracted pixels are byte-identical to the eager
+     convert_to_8bit_rgb / array_to_qimage pipeline (ADR-010).
+"""
+
+import numpy as np
+import pytest
+from PyQt6.QtGui import QImage
+
+from digitalsreeni_image_annotator.core import image_utils
+from digitalsreeni_image_annotator.core.slice_cache import (
+    LRU_CAPACITY,
+    LazySliceList,
+    SliceProvider,
+    get_shared_lru,
+    release_slices,
+    slice_names,
+)
+
+
+@pytest.fixture
+def clean_lru():
+    """Isolate each test from the process-wide shared LRU: clear it and
+    restore its capacity afterwards (other tests share the singleton)."""
+    cache = get_shared_lru()
+    saved_capacity = cache.capacity
+    cache.clear()
+    yield cache
+    cache.clear()
+    cache.capacity = saved_capacity
+
+
+def _spy_extract(provider):
+    """Wrap ``provider.extract`` with a call counter; returns the counter dict."""
+    calls = {"n": 0}
+    original = provider.extract
+
+    def counting(name):
+        calls["n"] += 1
+        return original(name)
+
+    provider.extract = counting
+    return calls
+
+
+def _ramp(n, h=4, w=4):
+    """A non-constant uint16 stack — each plane has varying values so the
+    normalize step never divides by a zero (max == min) range."""
+    return (np.arange(n * h * w, dtype=np.float64).reshape(n, h, w) % 60000).astype(
+        np.uint16
+    )
+
+
+# ── (1) naming is byte-identical to create_slices ────────────────────────────
+
+class TestNaming:
+    def test_2d_single_slice_named_base(self, clean_lru):
+        provider = SliceProvider(np.zeros((8, 6), np.uint16), ["H", "W"], "flat")
+        assert provider.names == ["flat"]
+
+    def test_3d_zhw_one_based(self, clean_lru):
+        provider = SliceProvider(np.zeros((4, 8, 6), np.uint16), ["Z", "H", "W"], "stack3d")
+        assert provider.names == [f"stack3d_Z{i}" for i in range(1, 5)]
+
+    def test_5d_tzcyx_matches_ndindex_order_and_is_one_based(self, clean_lru):
+        provider = SliceProvider(
+            np.zeros((2, 5, 2, 8, 6), np.uint16),
+            ["T", "Z", "C", "H", "W"],
+            "stack5d",
+        )
+        expected = [
+            f"stack5d_T{t + 1}_Z{z + 1}_C{c + 1}"
+            for t in range(2)
+            for z in range(5)
+            for c in range(2)
+        ]
+        assert provider.names == expected
+        assert provider.names[0] == "stack5d_T1_Z1_C1"
+        assert "stack5d_T1_Z5_C1" in provider.names
+        assert provider.names[-1] == "stack5d_T2_Z5_C2"
+        assert len(provider.names) == 2 * 5 * 2
+
+    def test_empty_leading_dim_yields_no_names(self, clean_lru):
+        provider = SliceProvider(np.zeros((0, 4, 4), np.uint16), ["Z", "H", "W"], "e")
+        assert provider.names == []
+
+
+# ── (2) LRU eviction ─────────────────────────────────────────────────────────
+
+class TestLRUEviction:
+    def test_evicts_beyond_capacity_keeping_most_recent(self, clean_lru):
+        clean_lru.capacity = LRU_CAPACITY
+        n = LRU_CAPACITY + 4
+        provider = SliceProvider(_ramp(n), ["Z", "H", "W"], "s")
+        lazy = LazySliceList(provider)
+
+        for name in lazy.names:
+            lazy.get(name)
+
+        assert len(clean_lru) == LRU_CAPACITY
+        retained = set(lazy.names[-LRU_CAPACITY:])
+        for name in lazy.names:
+            present = (provider.provider_id, name) in clean_lru
+            assert present == (name in retained)
+
+    def test_lru_hit_returns_same_object(self, clean_lru):
+        provider = SliceProvider(_ramp(3), ["Z", "H", "W"], "s")
+        lazy = LazySliceList(provider)
+        first = lazy.get(lazy.names[0])
+        again = lazy.get(lazy.names[0])
+        assert first is again  # cache hit, not a re-extract
+
+
+# ── (3) prefetch pins current +/-1 ───────────────────────────────────────────
+
+class TestPrefetch:
+    def test_prefetch_around_pins_current_and_neighbors(self, clean_lru):
+        clean_lru.capacity = 8
+        provider = SliceProvider(_ramp(5), ["Z", "H", "W"], "s")
+        lazy = LazySliceList(provider)
+        pid = provider.provider_id
+
+        lazy.prefetch_around(lazy.names[2])
+
+        assert (pid, lazy.names[1]) in clean_lru
+        assert (pid, lazy.names[2]) in clean_lru
+        assert (pid, lazy.names[3]) in clean_lru
+        assert (pid, lazy.names[0]) not in clean_lru
+        assert (pid, lazy.names[4]) not in clean_lru
+
+    def test_prefetch_at_edges_stays_in_bounds(self, clean_lru):
+        clean_lru.capacity = 8
+        provider = SliceProvider(_ramp(3), ["Z", "H", "W"], "s")
+        lazy = LazySliceList(provider)
+        pid = provider.provider_id
+
+        lazy.prefetch_around(lazy.names[0])  # no left neighbour
+        assert (pid, lazy.names[0]) in clean_lru
+        assert (pid, lazy.names[1]) in clean_lru
+        assert (pid, lazy.names[2]) not in clean_lru
+
+
+# ── (4) iteration re-extracts but bounds the LRU ─────────────────────────────
+
+class TestIterationBounded:
+    def test_full_pass_reextracts_but_never_exceeds_capacity(self, clean_lru):
+        clean_lru.capacity = 2
+        provider = SliceProvider(_ramp(5), ["Z", "H", "W"], "s")
+        calls = _spy_extract(provider)
+        lazy = LazySliceList(provider)
+
+        sizes = []
+        for _name, _img in lazy:
+            sizes.append(len(clean_lru))
+        assert calls["n"] == 5           # one extract per name (all missed)
+        assert max(sizes) <= 2           # never held more than capacity
+        assert len(clean_lru) <= 2
+
+        # A second pass re-extracts the evicted entries (nothing is permanently
+        # pinned) and still never exceeds capacity.
+        for _name, _img in lazy:
+            assert len(clean_lru) <= 2
+        assert calls["n"] == 10
+
+
+# ── (5) lazy pixels == eager pipeline ────────────────────────────────────────
+
+class TestPixelEquivalence:
+    def test_extracted_slice_matches_eager_pipeline(self, clean_lru, qt_application):
+        rng = np.random.RandomState(0)
+        arr = (rng.rand(3, 8, 6) * 65535).astype(np.uint16)
+        provider = SliceProvider(arr, ["Z", "H", "W"], "s")
+        lazy = LazySliceList(provider)
+
+        got = lazy.get("s_Z2")  # 1-based Z2 -> plane index 1
+
+        eager_rgb = image_utils.convert_to_8bit_rgb(arr[1])
+        eager = image_utils.array_to_qimage(eager_rgb)
+
+        assert got.format() == eager.format() == QImage.Format.Format_RGB888
+        assert (got.width(), got.height()) == (eager.width(), eager.height())
+        for y in range(eager.height()):
+            for x in range(eager.width()):
+                assert got.pixel(x, y) == eager.pixel(x, y)
+
+    def test_2d_slice_matches_grayscale_pipeline(self, clean_lru, qt_application):
+        rng = np.random.RandomState(1)
+        arr = (rng.rand(8, 6) * 65535).astype(np.uint16)
+        provider = SliceProvider(arr, ["H", "W"], "flat")
+        lazy = LazySliceList(provider)
+
+        got = lazy.get("flat")
+        eager = image_utils.array_to_qimage(image_utils.normalize_array(arr))
+
+        assert got.format() == eager.format() == QImage.Format.Format_Grayscale8
+        for y in range(eager.height()):
+            for x in range(eager.width()):
+                assert got.pixel(x, y) == eager.pixel(x, y)
+
+
+# ── list protocol + helpers ──────────────────────────────────────────────────
+
+class TestListProtocol:
+    def test_getitem_iter_len_bool(self, clean_lru):
+        provider = SliceProvider(_ramp(3), ["Z", "H", "W"], "s")
+        lazy = LazySliceList(provider)
+
+        assert len(lazy) == 3
+        assert bool(lazy) is True
+
+        name0, img0 = lazy[0]
+        assert name0 == "s_Z1"
+        assert isinstance(img0, QImage)
+
+        pairs = list(lazy)
+        assert [n for n, _ in pairs] == lazy.names
+        assert all(isinstance(im, QImage) for _, im in pairs)
+
+        assert lazy.get("does-not-exist") is None
+
+    def test_empty_list_is_falsy(self, clean_lru):
+        provider = SliceProvider(np.zeros((0, 4, 4), np.uint16), ["Z", "H", "W"], "e")
+        lazy = LazySliceList(provider)
+        assert len(lazy) == 0
+        assert bool(lazy) is False
+        assert list(lazy) == []
+
+
+class TestSliceNamesHelper:
+    def test_accepts_lazy_plain_list_and_none(self, clean_lru):
+        provider = SliceProvider(_ramp(3), ["Z", "H", "W"], "s")
+        lazy = LazySliceList(provider)
+
+        assert slice_names(lazy) == lazy.names
+        assert slice_names([("a", None), ("b", None)]) == ["a", "b"]
+        assert slice_names(None) == []
+        assert slice_names([]) == []
+
+    def test_does_not_materialise_pixels(self, clean_lru):
+        provider = SliceProvider(_ramp(3), ["Z", "H", "W"], "s")
+        calls = _spy_extract(provider)
+        lazy = LazySliceList(provider)
+
+        slice_names(lazy)
+        assert calls["n"] == 0
+
+
+class TestReleaseEviction:
+    def test_release_evicts_only_its_own_entries(self, clean_lru):
+        arr = _ramp(3)
+        p1 = SliceProvider(arr, ["Z", "H", "W"], "a")
+        p2 = SliceProvider(arr, ["Z", "H", "W"], "b")
+        l1, l2 = LazySliceList(p1), LazySliceList(p2)
+        l1.get(l1.names[0])
+        l2.get(l2.names[0])
+
+        assert clean_lru.count_prefix(p1.provider_id) == 1
+        assert clean_lru.count_prefix(p2.provider_id) == 1
+
+        l1.release()
+        assert clean_lru.count_prefix(p1.provider_id) == 0
+        assert clean_lru.count_prefix(p2.provider_id) == 1  # untouched
+
+        release_slices(l2)  # module-level helper
+        assert clean_lru.count_prefix(p2.provider_id) == 0
+
+    def test_release_slices_no_op_on_plain_list(self, clean_lru):
+        release_slices([("a", None)])  # must not raise
+        release_slices(None)

--- a/tests/unit/test_slice_cache.py
+++ b/tests/unit/test_slice_cache.py
@@ -195,6 +195,28 @@ class TestPixelEquivalence:
             for x in range(eager.width()):
                 assert got.pixel(x, y) == eager.pixel(x, y)
 
+    def test_5d_tzcyx_slice_matches_eager_pipeline(self, clean_lru, qt_application):
+        # Pixel-equality on the 5D dimension order that shipped the historical
+        # [-ndim:] axis-slice bug, so byte-identity is proven, not just argued.
+        rng = np.random.RandomState(2)
+        arr = (rng.rand(2, 3, 2, 8, 6) * 65535).astype(np.uint16)
+        dims = ["T", "Z", "C", "H", "W"]
+        provider = SliceProvider(arr, dims, "vol")
+        lazy = LazySliceList(provider)
+
+        # A mid-stack slice: T2_Z2_C1 -> array indices [1, 1, 0].
+        name = "vol_T2_Z2_C1"
+        assert name in lazy.names
+        got = lazy.get(name)
+        eager_rgb = image_utils.convert_to_8bit_rgb(arr[1, 1, 0])
+        eager = image_utils.array_to_qimage(eager_rgb)
+
+        assert got.format() == eager.format() == QImage.Format.Format_RGB888
+        assert (got.width(), got.height()) == (eager.width(), eager.height())
+        for y in range(eager.height()):
+            for x in range(eager.width()):
+                assert got.pixel(x, y) == eager.pixel(x, y)
+
     def test_2d_slice_matches_grayscale_pipeline(self, clean_lru, qt_application):
         rng = np.random.RandomState(1)
         arr = (rng.rand(8, 6) * 65535).astype(np.uint16)


### PR DESCRIPTION
## Summary

Multi-dim TIFF/CZI slices no longer decode every `QImage` up front. New `core/slice_cache.py` makes slice-QImage materialisation lazy behind a process-wide bounded LRU, keeping the exact `(name, qimage)` interface every consumer uses.

- **`SliceProvider`** retains the already-loaded source ndarray and precomputes `names` + `name→full-index` with **byte-identical** naming; `extract(name)` reconstructs one slice through the exact ADR-010 pipeline (fresh QImage each call, ADR-013-safe).
- **`LazySliceList`** is a drop-in for the old `[(name, qimage)]` list (`get`/`__iter__`/`__getitem__`/`__len__`/`__bool__`/`.names`/`prefetch_around`/`release`), stored as **both** `image_slices[base]` and `mw.slices` (same object).
- A single module-level **`SliceLRU`** (`LRU_CAPACITY=8`, keyed `(provider_id, name)`) bounds live QImages across all stacks; release/evict on every dataset-drop path (delete, `redefine_dimensions`, `open_images`, `clear_all`).

Name-only consumers (save, `image_has_annotations`, `update_slice_list`, nav, deletion) use `slice_names()`/`.names` → **zero pixel decode**; exporters / SAM-dataset / DINO-batch keep working via `__iter__`.

**Strategy A (documented tradeoff):** the decoded source ndarray is still retained per open stack; the dominant all-QImages-in-RAM cost and the create-time peak are eliminated. Full array-free reading (memmap/zarr) is a documented follow-up (ADR-036).

## Verification

- Full suite **727 passed / 3 skipped** (+25 new tests). Ruff clean. `save_project` asserted to decode **zero** slices; lazy-vs-eager pixel-equality proven on 2D/3D/**5D TZCYX** (the dimension order of the historical `[-ndim:]` bug); byte-identical names; LRU eviction/prefetch/delete-evict all tested.
- **Senior review**: "genuinely competent, well-tested, behavior-preserving." The one P1 (a real `open_images` memory-retention regression from the `.clear()`→`=[]` swap) is fixed + regression-tested; P2s (only-decode-annotated export, 5D pixel test) done.

## Docs

ADR-036, `docs/05/06/08/11` (resolves the "all slices in memory" risk).

## Phase chain

**Phase 4**, base = `feature/image-list-groups-badges` (Phase 3 / #43). Feeds the video track (#47 reuses this lazy contract).

Closes #45

🧙 Built with [WOZCODE](https://wozcode.com)