### PR TITLE
feat: video loading with frames as lazy slices (#47)

### DIFF
--- a/docs/05_building_block_view.md
+++ b/docs/05_building_block_view.md
@@ -35,6 +35,7 @@ src/digitalsreeni_image_annotator/
 	│   ├── constants.py
 	│   ├── annotation_utils.py
 	│   ├── slice_cache.py             # Lazy multi-dim slice materialisation + bounded LRU (ADR-036, #45)
+	│   ├── video_handler.py           # cv2 video decode; frames as lazy slices (ADR-037, #47)
 	│   └── torch_utils.py             # Shared torch device resolution + CPU fallback (#57)
 	├── widgets/
 	│   ├── image_label.py             # ImageLabel - canvas widget; dispatcher
@@ -240,7 +241,7 @@ the controller graph.
 | Controller | Responsibility |
 |------------|----------------|
 | `ProjectController` | `.iap` save/load, auto-save, backup/restore, missing-image prompts, window-title sync. Owns the `is_loading_project` autosave guard (load/save round-trip safety, v0.8.12). |
-| `ImageController` | Open / load / switch images and slices. TIFF + CZI loaders (with `imagecodecs` codec-error handling — #56), the multi-dim `DimensionDialog`, the `[-ndim:]` axis-slice bug fix from the v0.9.0 era. Multi-dim slices are now materialised **lazily** via `core/slice_cache.py` (`create_slices` builds names + a `SliceProvider`, QImages decode on demand through a shared bounded LRU — ADR-036 / #45). Image-list annotation-status filter (`image_has_annotations`, `apply_image_filter` — #27), alphabetical/grouped sort (`sort_image_list` — #60/#43), per-image named groups (`set_image_group`, `_populate_group_combo` — #43) and derived status badges (`refresh_image_status_icons`, painted-pixmap `QIcon` cache rebuilt on theme flip via `on_theme_changed` — #43). |
+| `ImageController` | Open / load / switch images and slices. TIFF + CZI loaders (with `imagecodecs` codec-error handling — #56), the multi-dim `DimensionDialog`, the `[-ndim:]` axis-slice bug fix from the v0.9.0 era. Multi-dim slices are now materialised **lazily** via `core/slice_cache.py` (`create_slices` builds names + a `SliceProvider`, QImages decode on demand through a shared bounded LRU — ADR-036 / #45). Videos (`load_video`, `mw.video_handlers`) reuse the same lazy contract: frames are `LazySliceList` slices backed by a `VideoSliceProvider` over `core/video_handler.py::VideoHandler` (ADR-037 / #47). Image-list annotation-status filter (`image_has_annotations`, `apply_image_filter` — #27), alphabetical/grouped sort (`sort_image_list` — #60/#43), per-image named groups (`set_image_group`, `_populate_group_combo` — #43) and derived status badges (`refresh_image_status_icons`, painted-pixmap `QIcon` cache rebuilt on theme flip via `on_theme_changed` — #43). |
 | `AnnotationController` | Annotation CRUD, list sorting, highlight, edit-mode entry/exit, `finish_polygon`, `finish_rectangle`, `replace_annotations` (eraser path). Validates writes before mutating `all_annotations`. |
 | `ClassController` | Class add / delete / rename / colour / visibility. `update_slice_list_colors`, `is_class_visible`. |
 | `SAMController` | SAM box/points tool lifecycle, debounce timer, `_sam_inference_in_flight` re-entrancy guard (ADR-013), model picker. |

--- a/docs/06_runtime_view.md
+++ b/docs/06_runtime_view.md
@@ -569,6 +569,29 @@ offered once the project is disk-backed.
 4. **Persistence**: `save_project` writes `"group"` per image; on load a
    restoration loop re-applies saved groups onto the rebuilt `all_images`.
 
+## Video Loading (issue #47, ADR-037)
+
+1. User adds `clip.mp4` (or `.avi`/`.mov`) via Add New Images / Open Images.
+2. `add_images_to_list` detects the video extension (`is_video`) and calls
+   `ImageController.load_video(path)`:
+   - `VideoHandler(path)` opens the capture and reads metadata once
+     (`total_frames`, `fps`, `width`, `height`, `duration_s`).
+   - A `VideoSliceProvider` (names `clip_F00000 … clip_F<N-1>`) is wrapped in a
+     `LazySliceList` and stored as both `image_slices["clip"]` and `mw.slices`;
+     the handler is stored in `mw.video_handlers["clip"]`.
+   - The slice list is populated with frame names; frame 0 is activated.
+   - `image_info` gets `is_multi_slice=True`, `is_video=True`,
+     `video_metadata=handler.metadata()`.
+3. Navigation (Up/Down, slice-list click) routes through `switch_slice`, which
+   `.get(frame_key)`s the frame QImage on demand (decoded via `VideoHandler`,
+   cached in the shared `SliceLRU`) and `prefetch_around`s the neighbours — no
+   frame is decoded until visited.
+4. Annotating a frame keys under its frame name in `all_annotations`, exactly
+   like a stack slice — per-frame independence, save/load and export come for free.
+5. Save writes `is_video`/`video_metadata` + per-frame annotations (no pixels);
+   load branches to `load_video`. A missing video flows through the existing
+   missing-images prompt.
+
 ## Multi-dimensional Image Loading
 
 ```

--- a/docs/08_crosscutting_concepts.md
+++ b/docs/08_crosscutting_concepts.md
@@ -839,6 +839,29 @@ critical distinction for anyone touching slice code:
   export filename). Extraction returns a fresh QImage each call — never mutate a cached
   one (the SAM worker may be reading it, ADR-013).
 
+## Video Frames as Lazy Slices (issue #47, ADR-037)
+
+A video is a stack whose slices are frames, and it **reuses** the #45 lazy machinery
+rather than a parallel cache: `image_slices[base]` is a `LazySliceList` backed by a
+`core/video_handler.py::VideoSliceProvider` (duck-compatible with `SliceProvider`), so
+every slice consumer above works for video unchanged. Practical rules:
+
+- **Never read a frame's pixels directly.** Go through the `LazySliceList`
+  (`slices.get(frame_key)` / `__iter__`), which decodes via `VideoHandler.get_frame`
+  and caches in the shared `SliceLRU`. Frame keys are `f"{base}_F{idx:05d}"`
+  (`video_handler.frame_key` / `parse_frame_index`, regex anchored at end so a
+  `stack_T1_Z5` key never parses as a frame).
+- **Handlers are a separate resource that must be released.** `mw.video_handlers[base]`
+  holds the open `cv2.VideoCapture`; release it on every drop path
+  (`remove_image`/`delete_selected_image`/`redefine_dimensions`/`open_images`/
+  `clear_all`) alongside `release_slices`.
+- **GUI-thread only.** `cv2.VideoCapture` is not thread-safe; `get_frame` seeks +
+  decodes synchronously on the main thread (same discipline as `SliceProvider.extract`),
+  and always returns a fresh `.copy()` QImage (the numpy buffer dies at return; the SAM
+  worker may read a cached one, ADR-013).
+- **Base-name collision** (`video.mp4` vs `video.tif` → same `image_slices` key) is
+  refused in `add_images_to_list`.
+
 ## Image List Groups & Status Badges (issue #43)
 
 The image list gained two at-a-glance affordances, both layered on the

--- a/docs/09_architecture_decisions.md
+++ b/docs/09_architecture_decisions.md
@@ -1840,8 +1840,13 @@ lazy-slice machinery** rather than a parallel frame cache (the #45/#47 reconcili
   (`switch_slice`/`activate_slice` `.get()`+prefetch, `switch_image` `slices[0]`, `.names`,
   `__iter__`, exporters, DINO batch, save-touches-no-pixels, delete→`release_slices`)
   works for video **unchanged** — no parallel resolver, no `None`-placeholder path.
-- ✅ Frames decode lazily and are bounded by the shared LRU; opening a video decodes
-  nothing beyond frame 0; `save_project` decodes zero frames (test-asserted).
+- ✅ Frames decode lazily and are bounded by the shared LRU for interactive use
+  (navigation, display); opening a video decodes nothing beyond frame 0;
+  `save_project` decodes zero frames (test-asserted).
+- ⚠️ One batch path is NOT LRU-bounded: `DINOController._collect_dino_batch_work_items`
+  builds a flat `[(name, QImage), …]` list, so running DINO batch over a long video
+  materialises all its frames at once (pre-existing for stacks; more costly for video).
+  Streaming that collector frame-by-frame is a documented follow-up.
 - ✅ Annotation storage, per-frame independence, navigation, save/load and export path
   matching all come for free from the slice machinery.
 - ⚠️ `cv2.VideoCapture` seeking is per-codec-variable; heavy random scrubbing re-seeks.

--- a/docs/09_architecture_decisions.md
+++ b/docs/09_architecture_decisions.md
@@ -1804,6 +1804,56 @@ demand):
 
 ---
 
+## ADR-037: Video Frames as Multi-dimensional Slices (Lazy, Keyed `_F#####`, Reusing LazySliceList)
+
+**Status**: Accepted (issue #47)
+
+**Context**: Video annotation is the next platform feature. The app already handles
+"one file, many annotatable 2D planes" for multi-dim TIFF/CZI stacks — per-slice
+annotation storage, a slice list, Up/Down navigation, per-slice colour, save/load and
+export all key on a slice *name*. The cheapest correct design is to treat a video frame
+exactly like a stack slice. The one thing frames must NOT inherit is eager loading: a
+300-frame 1080p clip is ~1.8 GB of QImages.
+
+**Decision**: Model a video as a stack whose slices are frames, and **reuse the #45
+lazy-slice machinery** rather than a parallel frame cache (the #45/#47 reconciliation):
+- `core/video_handler.py::VideoHandler` wraps `cv2.VideoCapture` — metadata read once,
+  `get_frame(idx)` seeks + decodes ONE frame (BGR→RGB via `cvtColor`, mandatory `.copy()`
+  because the numpy buffer dies at return), `release()` idempotent. Decoding only, no
+  internal LRU. GUI-thread only (`cv2.VideoCapture` is not thread-safe).
+- `VideoSliceProvider` is **duck-type compatible** with `slice_cache.SliceProvider`
+  (`provider_id` / `names` / `extract(name)`), so a video's `image_slices[base]` is an
+  ordinary `LazySliceList` and the shared bounded `SliceLRU` (ADR-036) caps live frame
+  QImages. Frame slice keys are `frame_key(base, idx) = f"{base}_F{idx:05d}"` (0-based),
+  parsed by `parse_frame_index` (`_F(\d+)$` anchored at end so it never matches a
+  `stack_T1_Z5` key).
+- `ImageController.load_video` builds the handler + provider + `LazySliceList` (stored as
+  both `image_slices[base]` and `mw.slices`); `add_images_to_list` gains an
+  `is_video(...)` branch setting `is_multi_slice=True`, `is_video=True`,
+  `video_metadata=handler.metadata()`; `open_images` accepts `*.mp4 *.avi *.mov`.
+  Handlers live in `mw.video_handlers[base]` and are `release()`d on every drop path
+  (delete/remove/redefine/`open_images`/`clear_all`). `.iap` round-trips `is_video`
+  +`video_metadata`; load branches to `load_video`.
+
+**Consequences**:
+- ✅ Because a video is a `LazySliceList`, EVERY existing slice consumer
+  (`switch_slice`/`activate_slice` `.get()`+prefetch, `switch_image` `slices[0]`, `.names`,
+  `__iter__`, exporters, DINO batch, save-touches-no-pixels, delete→`release_slices`)
+  works for video **unchanged** — no parallel resolver, no `None`-placeholder path.
+- ✅ Frames decode lazily and are bounded by the shared LRU; opening a video decodes
+  nothing beyond frame 0; `save_project` decodes zero frames (test-asserted).
+- ✅ Annotation storage, per-frame independence, navigation, save/load and export path
+  matching all come for free from the slice machinery.
+- ⚠️ `cv2.VideoCapture` seeking is per-codec-variable; heavy random scrubbing re-seeks.
+  The LRU + `prefetch_around(±1)` keep sequential nav responsive; whole-video
+  pre-decode is deliberately never done.
+- ⚠️ Base-name collision (`video.mp4` vs `video.tif` → same `image_slices` key) is
+  refused with a warning in `add_images_to_list`.
+- Feeds #48 (timeline over `video_handlers`/frame keys) and #51 (SAM 3 tracking seeds a
+  mask on a frame and writes per-frame annotations).
+
+---
+
 ## Decisions Under Consideration
 
 ### Consider Relative Paths with Image Copying

--- a/docs/12_glossary.md
+++ b/docs/12_glossary.md
@@ -34,6 +34,13 @@ The mask-supervision loss used during SAM fine-tuning: a focal term (down-weight
 ### Mask Decoder
 The lightweight SAM head that turns image embeddings + prompt embeddings into mask logits. The default fine-tuning target (`sam_mask_decoder`, ~4.2M params for the tiny model) since it is small and adapts quickly.
 
+### Frame Key
+The slice name of a single video frame (issue #47): `f"{base_name}_F{idx:05d}"` with a
+0-based, zero-padded frame index (e.g. `clip_F00042`). Produced by
+`core/video_handler.py::frame_key` and parsed by `parse_frame_index` (`_F(\d+)$`
+anchored at the end so an ordinary multi-dim slice key like `stack_T1_Z5` is not
+mistaken for a frame). It is the annotation key + export filename for that frame.
+
 ### Keypoint / Pose Instance
 A single labelled instance of a **pose class** (issue #35, [ADR-029](09_architecture_decisions.md#adr-029-keypoint--pose-annotation--per-class-schema-coco-instance-model-3-state-visibility)):
 an ordered set of K keypoints stored flat as `[x1, y1, v1, x2, y2, v2, ...]` (COCO
@@ -159,6 +166,13 @@ A 2D image extracted from a multi-dimensional image stack. Named with format `{f
 
 ### Stack
 A multi-dimensional image, typically a TIFF or CZI file with multiple 2D slices in Z-dimension (depth).
+
+### Video (Frames as Slices)
+A video file (`.mp4`/`.avi`/`.mov`) opened as a stack whose slices are its frames
+(issue #47, [ADR-037](09_architecture_decisions.md)). Frames decode lazily on demand via
+`core/video_handler.py::VideoHandler` (OpenCV) and are held in the same shared bounded
+`SliceLRU` as multi-dim slices, so a long clip never materialises all its frames. Each
+frame is keyed by its [Frame Key](#frame-key).
 
 ### Subprocess Worker (historical)
 A standalone Python script (`sam_worker.py`, `dino_worker.py`) that ran ML model inference in its own process to dodge a PyQt5 + Torch DLL load-order conflict on Windows + Python 3.14. Removed once the codebase migrated to PyQt6 (the conflict no longer manifests). See [ADR-011](09_architecture_decisions.md#adr-011-run-torch-based-workers-in-isolated-subprocesses) (Superseded) and [ADR-013](09_architecture_decisions.md#adr-013-in-process-inference-with-qthread-wrapping).

--- a/src/digitalsreeni_image_annotator/annotator_window.py
+++ b/src/digitalsreeni_image_annotator/annotator_window.py
@@ -878,13 +878,21 @@ class ImageAnnotator(QMainWindow):
         )
 
     def show_image_context_menu(self, position):
+        from .core.video_handler import is_video
+
         menu = QMenu()
         current_item = self.image_list.itemAt(position)
         if current_item:
             file_name = current_item.text()
             delete_action = menu.addAction("Remove Image")
 
-            if not self.is_multi_dimensional(file_name):
+            # YOLO single-image predict is for plain 2D images only — not
+            # multi-dim stacks and NOT videos (predicting a video would run
+            # Ultralytics over the whole clip on the GUI thread, #47).
+            can_predict = not self.is_multi_dimensional(file_name) and not is_video(
+                file_name
+            )
+            if can_predict:
                 predict_action = menu.addAction("Predict using YOLO")
 
             if self.is_multi_dimensional(file_name):
@@ -898,7 +906,7 @@ class ImageAnnotator(QMainWindow):
 
             if action == delete_action:
                 self.remove_image()
-            elif not self.is_multi_dimensional(file_name) and action == predict_action:
+            elif can_predict and action == predict_action:
                 self.predict_single_image(file_name)
             elif (
                 self.is_multi_dimensional(file_name)

--- a/src/digitalsreeni_image_annotator/annotator_window.py
+++ b/src/digitalsreeni_image_annotator/annotator_window.py
@@ -97,6 +97,10 @@ class ImageAnnotator(QMainWindow):
         self.current_stack = None
         self.image_dimensions = {}
         self.image_slices = {}
+        # Open cv2.VideoCapture handlers keyed by ext-stripped base name
+        # (issue #47). A video's image_slices[base] is a LazySliceList backed
+        # by a VideoSliceProvider that decodes frames through the handler.
+        self.video_handlers = {}
         self.image_shapes = {}
 
         
@@ -809,6 +813,10 @@ class ImageAnnotator(QMainWindow):
         from .core.slice_cache import get_shared_lru
         get_shared_lru().clear()
         self.image_slices.clear()
+        # Release each video's cv2 capture before dropping the dict (issue #47).
+        for handler in self.video_handlers.values():
+            handler.release()
+        self.video_handlers.clear()
         self.slices = []
         self.slice_list.clear()
         self.current_slice = None

--- a/src/digitalsreeni_image_annotator/controllers/image_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/image_controller.py
@@ -687,6 +687,12 @@ class ImageController(QObject):
                             self.mw.current_slice = self.mw.slices[0][0]
                             self.update_slice_list()
                             self.activate_slice(self.mw.current_slice)
+                    elif image_info.get("is_video"):
+                        # Video whose frames aren't in image_slices yet (e.g. a
+                        # future path that dropped them): rebuild via load_video,
+                        # never load_multi_slice_image (which handles neither
+                        # branch for a video and would leave a stale display).
+                        self.load_video(image_path)
                     else:
                         self.load_multi_slice_image(
                             image_path,

--- a/src/digitalsreeni_image_annotator/controllers/image_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/image_controller.py
@@ -49,6 +49,11 @@ from ..core.slice_cache import (
     release_slices,
     slice_names,
 )
+from ..core.video_handler import (
+    VideoHandler,
+    VideoSliceProvider,
+    is_video,
+)
 
 from ..core.logging_config import get_logger
 
@@ -387,7 +392,7 @@ class ImageController(QObject):
             self.mw,
             "Open Images",
             "",
-            "Image Files (*.png *.jpg *.bmp *.tif *.tiff *.czi)",
+            "Image Files (*.png *.jpg *.bmp *.tif *.tiff *.czi *.mp4 *.avi *.mov)",
         )
         if file_names:
             self.mw.image_list.clear()
@@ -403,6 +408,11 @@ class ImageController(QObject):
             # the session. Mirrors clear_all (issue #45).
             get_shared_lru().clear()
             self.mw.image_slices.clear()
+            # Video handlers own an open cv2.VideoCapture each — release them
+            # before the dict is wiped so no file handle leaks (issue #47).
+            for handler in self.mw.video_handlers.values():
+                handler.release()
+            self.mw.video_handlers.clear()
             self.mw.slices = []
             self.mw.current_stack = None
             self.mw.current_slice = None
@@ -413,6 +423,22 @@ class ImageController(QObject):
         for file_name in file_names:
             base_name = os.path.basename(file_name)
             if base_name not in self.mw.image_paths:
+                # Slices, video frames and their annotations are all keyed by
+                # the EXT-STRIPPED base name, so `video.mp4` and `video.tif`
+                # would silently clobber each other's slices. Refuse the
+                # colliding file instead (issue #47).
+                if self._base_name_collision(base_name):
+                    QMessageBox.warning(
+                        self.mw,
+                        "Duplicate Name",
+                        f"An image named "
+                        f"'{os.path.splitext(base_name)[0]}' is already loaded "
+                        "from a different file. Rename one of the files and "
+                        "reopen it — slices and annotations are keyed by this "
+                        "base name.",
+                    )
+                    continue
+
                 image_info = {
                     "file_name": base_name,
                     "height": 0,
@@ -458,6 +484,19 @@ class ImageController(QObject):
                         image_info["shape"] = self.mw.image_shapes.get(
                             base_name_without_ext, []
                         )
+                elif is_video(file_name):
+                    # Video frames become lazy slices (issue #47). Read the
+                    # probe from the handler's metadata — do NOT force a frame
+                    # decode just to fill height/width. `dimensions`/`shape`
+                    # are omitted (a video has none).
+                    self.load_video(file_name)
+                    base_name_without_ext = os.path.splitext(base_name)[0]
+                    handler = self.mw.video_handlers[base_name_without_ext]
+                    image_info["height"] = handler.height
+                    image_info["width"] = handler.width
+                    image_info["is_multi_slice"] = True
+                    image_info["is_video"] = True
+                    image_info["video_metadata"] = handler.metadata()
                 else:
                     image = QImage(file_name)
                     image_info["height"] = image.height()
@@ -491,6 +530,73 @@ class ImageController(QObject):
         silently swallow unrelated ValueErrors behind a misleading dialog.
         """
         return "imagecodecs" in str(exc).lower()
+
+    def _base_name_collision(self, base_name):
+        """True if a DIFFERENT already-loaded image shares this file's
+        ext-stripped base name (issue #47).
+
+        Slice keys, video frame keys and ``image_slices`` are all keyed by
+        the ext-stripped base, so two files that differ only by extension
+        (``video.mp4`` vs ``video.tif``) would clobber each other's slices.
+        """
+        base_no_ext = os.path.splitext(base_name)[0]
+        for info in self.mw.all_images:
+            other = info["file_name"]
+            if other != base_name and os.path.splitext(other)[0] == base_no_ext:
+                return True
+        return False
+
+    def load_video(self, image_path):
+        """Load a video as a stack whose slices are its frames (issue #47).
+
+        Reuses the #45 lazy-slice machinery: a :class:`VideoSliceProvider`
+        decodes each frame on demand and the shared ``SliceLRU`` bounds the
+        live QImages. ``mw.slices`` and ``mw.image_slices[base]`` are the SAME
+        :class:`LazySliceList` object (the #45 guardrail), so every existing
+        slice consumer works for video unchanged.
+        """
+        base_name = os.path.splitext(os.path.basename(image_path))[0]
+
+        # Release + replace any prior handler / slice list under this base
+        # BEFORE overwriting, mirroring create_slices' release-before-replace:
+        # the old objects stay referenced until the reassignment below, so the
+        # new provider is guaranteed a distinct id() and a recycled id can't
+        # alias stale LRU entries.
+        old_handler = self.mw.video_handlers.get(base_name)
+        if old_handler is not None:
+            old_handler.release()
+        release_slices(self.mw.image_slices.get(base_name))
+
+        handler = VideoHandler(image_path)
+        self.mw.video_handlers[base_name] = handler
+
+        provider = VideoSliceProvider(handler, base_name)
+        lazy = LazySliceList(provider)
+        self.mw.image_slices[base_name] = lazy
+        self.mw.slices = lazy
+
+        self.mw.slice_list.clear()
+        for slice_name in lazy.names:
+            self.add_slice_to_list(slice_name)
+
+        if lazy:
+            first_name, first_image = lazy[0]
+            self.mw.current_image = first_image
+            self.mw.current_slice = first_name
+            self.mw.slice_list.setCurrentRow(0)
+            self.activate_slice(self.mw.current_slice)
+
+            meta = handler.metadata()
+            slice_info = (
+                f"Total frames: {meta['total_frames']}, "
+                f"{meta['width']}x{meta['height']}, {meta['fps']:.2f} fps"
+            )
+            self.mw.update_image_info(additional_info=slice_info)
+        else:
+            logger.warning(f"No frames decoded for video: {base_name}")
+
+        logger.info(f"Loaded video {base_name}: {handler.total_frames} frames")
+        return lazy
 
     def update_all_images(self, new_image_info):
         for info in new_image_info:
@@ -1022,6 +1128,12 @@ class ImageController(QObject):
                 release_slices(self.mw.image_slices[base_name])
                 del self.mw.image_slices[base_name]
 
+            # A video never reaches here (redefine only runs for tif/czi), but
+            # release its capture defensively so no path can leak one (#47).
+            if base_name in self.mw.video_handlers:
+                self.mw.video_handlers[base_name].release()
+                del self.mw.video_handlers[base_name]
+
             if self.mw.image_file_name == file_name:
                 self.mw.current_image = None
                 self.mw.image_label.clear()
@@ -1064,6 +1176,11 @@ class ImageController(QObject):
                 del self.mw.image_slices[base_name]
 
                 self.mw.slice_list.clear()
+
+            # Release the video's cv2 capture, if any (issue #47).
+            if base_name in self.mw.video_handlers:
+                self.mw.video_handlers[base_name].release()
+                del self.mw.video_handlers[base_name]
 
             if self.mw.image_file_name == file_name:
                 self.mw.current_image = None
@@ -1118,6 +1235,11 @@ class ImageController(QObject):
                     del self.mw.image_slices[base_name]
 
                     self.mw.slice_list.clear()
+
+                # Release the video's cv2 capture, if any (issue #47).
+                if base_name in self.mw.video_handlers:
+                    self.mw.video_handlers[base_name].release()
+                    del self.mw.video_handlers[base_name]
 
                 if self.mw.image_file_name == file_name:
                     self.mw.current_image = None

--- a/src/digitalsreeni_image_annotator/controllers/project_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/project_controller.py
@@ -365,7 +365,7 @@ class ProjectController(QObject):
             self.mw,
             "Select Missing Images",
             "",
-            "Image Files (*.png *.jpg *.bmp *.tif *.tiff *.czi)",
+            "Image Files (*.png *.jpg *.bmp *.tif *.tiff *.czi *.mp4 *.avi *.mov)",
         )
         if files:
             images_loaded = 0
@@ -493,7 +493,7 @@ class ProjectController(QObject):
                 # LazySliceList persists names only, no pixels (issue #45).
                 if image_info.get("is_video"):
                     image_data["is_video"] = True
-                    image_data["video_metadata"] = image_info["video_metadata"]
+                    image_data["video_metadata"] = image_info.get("video_metadata")
             else:
                 image_data["annotations"] = {}
                 for class_name, annotations in self.mw.all_annotations.get(

--- a/src/digitalsreeni_image_annotator/controllers/project_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/project_controller.py
@@ -215,9 +215,14 @@ class ProjectController(QObject):
             self.mw.image_paths[image_info["file_name"]] = image_path
 
             if image_info.get("is_multi_slice", False):
-                dimensions = image_info.get("dimensions", [])
-                shape = image_info.get("shape", [])
-                self.mw.load_multi_slice_image(image_path, dimensions, shape)
+                if image_info.get("is_video"):
+                    # A missing video already flowed through resolve_image_path
+                    # → missing_images above, so image_path exists here (#47).
+                    self.mw.image_controller.load_video(image_path)
+                else:
+                    dimensions = image_info.get("dimensions", [])
+                    shape = image_info.get("shape", [])
+                    self.mw.load_multi_slice_image(image_path, dimensions, shape)
             else:
                 self.mw.add_images_to_list([image_path])
 
@@ -482,6 +487,13 @@ class ProjectController(QObject):
                 image_data["shape"] = image_utils.convert_to_serializable(
                     self.mw.image_shapes.get(base_name_without_ext, [])
                 )
+                # Videos carry no dimensions/shape but need their metadata so
+                # a reload knows to re-open them via load_video (issue #47).
+                # Slice entries (name + annotations) serialize unchanged — the
+                # LazySliceList persists names only, no pixels (issue #45).
+                if image_info.get("is_video"):
+                    image_data["is_video"] = True
+                    image_data["video_metadata"] = image_info["video_metadata"]
             else:
                 image_data["annotations"] = {}
                 for class_name, annotations in self.mw.all_annotations.get(

--- a/src/digitalsreeni_image_annotator/controllers/yolo_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/yolo_controller.py
@@ -599,7 +599,12 @@ class YOLOController(QObject):
             self.process_yolo_results(results, image_name)
 
     def predict_single_image(self, file_name):
-        if self.mw.is_multi_dimensional(file_name):
+        from ..core.video_handler import is_video
+
+        # Plain 2D images only: stacks have no single frame, and a video would
+        # run Ultralytics over the whole clip on the GUI thread then fail in
+        # cv2.imread (#47). The context menu already hides this for both.
+        if self.mw.is_multi_dimensional(file_name) or is_video(file_name):
             return
 
         if not self.mw.yolo_trainer or not self.mw.yolo_trainer.model:

--- a/src/digitalsreeni_image_annotator/core/video_handler.py
+++ b/src/digitalsreeni_image_annotator/core/video_handler.py
@@ -1,0 +1,141 @@
+"""Video loading with frames exposed as lazy "slices" (issue #47).
+
+A video is treated as a multi-dimensional stack whose slices are its frames.
+Rather than inventing a parallel frame cache, this module plugs into the
+issue-#45 lazy-slice machinery (:mod:`core.slice_cache`): a
+:class:`VideoSliceProvider` is duck-type compatible with
+``slice_cache.SliceProvider`` (it exposes ``provider_id``, ``names`` and
+``extract(name)``), so a video's ``image_slices[base]`` is an ordinary
+:class:`~core.slice_cache.LazySliceList`. Every existing slice consumer
+(``switch_slice``, ``activate_slice``, exporters, DINO batch, save, delete)
+therefore works for video unchanged, and the shared bounded ``SliceLRU``
+caps how many decoded frame QImages are held live at once.
+
+Frame decoding uses OpenCV (``cv2.VideoCapture``). ``cv2.VideoCapture`` is
+**not thread-safe**, so ``VideoHandler`` must be driven from the GUI thread
+only. It performs *decoding only* — no internal LRU; the shared SliceLRU
+does the caching (a fresh QImage per decode keeps the SAM worker
+ADR-013-safe).
+
+This module deliberately imports no main-window code, so it is unit-testable
+headless (only ``cv2`` and ``QImage`` are needed).
+"""
+
+import re
+
+import cv2
+from PyQt6.QtGui import QImage
+
+# Recognised video container extensions (case-insensitive).
+VIDEO_EXTS = (".mp4", ".avi", ".mov")
+
+# Frame slice keys look like "<base>_F00042" — 0-based frame index, zero
+# padded to 5 digits, anchored at the END of the name so it never matches a
+# multi-dim slice key like "stack_T1_Z5".
+FRAME_KEY_RE = re.compile(r"_F(\d+)$")
+
+
+def is_video(file_name):
+    """True if ``file_name`` has a recognised video extension (#47)."""
+    return file_name.lower().endswith(VIDEO_EXTS)
+
+
+def frame_key(base_name, idx):
+    """Slice name for frame ``idx`` (0-based) of the video ``base_name``."""
+    return f"{base_name}_F{idx:05d}"
+
+
+def parse_frame_index(slice_name):
+    """Frame index encoded in ``slice_name``, or ``None``.
+
+    Matches ``_F<digits>`` anchored at the end of the name so ordinary
+    multi-dim slice keys (``stack_T1_Z5``) return ``None``.
+    """
+    match = FRAME_KEY_RE.search(slice_name)
+    return int(match.group(1)) if match else None
+
+
+class VideoHandler:
+    """Decode individual frames of a video on demand (GUI-thread only).
+
+    Metadata is read once at construction; ``get_frame`` seeks and decodes a
+    single frame per call and always returns a fresh, self-owned QImage.
+    """
+
+    def __init__(self, path):
+        self.path = path
+        self._cap = cv2.VideoCapture(path)
+        if not self._cap.isOpened():
+            raise ValueError(f"Could not open video: {path}")
+        self._released = False
+
+        self.total_frames = int(self._cap.get(cv2.CAP_PROP_FRAME_COUNT))
+        fps = self._cap.get(cv2.CAP_PROP_FPS)
+        # Some containers report 0 (or NaN) fps; fall back to a sane default
+        # so duration_s and the info line stay finite.
+        self.fps = fps if fps and fps > 0 else 30.0
+        self.width = int(self._cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+        self.height = int(self._cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+        self.duration_s = self.total_frames / self.fps if self.fps else 0.0
+
+    def get_frame(self, idx):
+        """Return frame ``idx`` as a QImage, or ``None``.
+
+        Out-of-range indices, a failed decode, or a released handler all
+        yield ``None``. OpenCV decodes BGR; we convert to RGB before building
+        the QImage. The ``.copy()`` is MANDATORY — the numpy buffer backing
+        the QImage is freed when this method returns, so the QImage must own
+        its pixels.
+        """
+        if self._released or idx is None or not (0 <= idx < self.total_frames):
+            return None
+        self._cap.set(cv2.CAP_PROP_POS_FRAMES, idx)
+        ret, frame = self._cap.read()
+        if not ret:
+            return None
+        rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        height, width = rgb.shape[:2]
+        qimage = QImage(
+            rgb.data, width, height, 3 * width, QImage.Format.Format_RGB888
+        )
+        return qimage.copy()
+
+    def metadata(self):
+        """Return the video's metadata as a plain, JSON-serializable dict."""
+        return {
+            "fps": self.fps,
+            "total_frames": self.total_frames,
+            "width": self.width,
+            "height": self.height,
+            "duration_s": self.duration_s,
+        }
+
+    def release(self):
+        """Release the capture. Idempotent."""
+        if not self._released:
+            self._cap.release()
+            self._released = True
+
+
+class VideoSliceProvider:
+    """Duck-type compatible with :class:`core.slice_cache.SliceProvider`.
+
+    Exposes ``provider_id`` / ``names`` / ``extract(name)`` so a
+    :class:`~core.slice_cache.LazySliceList` can wrap it and the shared
+    SliceLRU caches the decoded frames (a fresh QImage per decode).
+    """
+
+    def __init__(self, video_handler, base_name):
+        self._handler = video_handler
+        self.base_name = base_name
+        self.provider_id = id(self)
+        self.names = [
+            frame_key(base_name, i) for i in range(video_handler.total_frames)
+        ]
+
+    def extract(self, name):
+        """Decode the frame named ``name`` to a QImage (``None`` if unknown)."""
+        idx = parse_frame_index(name)
+        if idx is None:
+            return None
+        return self._handler.get_frame(idx)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,35 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 os.environ['QT_QPA_PLATFORM'] = 'offscreen'
 
 
+@pytest.fixture
+def make_test_video():
+    """Factory: write a tiny MJPG/.avi video and return its path (issue #47).
+
+    Shared by the video-handler unit tests and the video-loading integration
+    tests. Frame ``i`` is filled BGR ``(0, 0, 10*i)`` — a pure red-channel
+    ramp — so a forgotten ``cvtColor`` (BGR→RGB) regression is detectable:
+    the decoded pixel would come back blue instead of red. MJPG on a uniform
+    fill round-trips exactly, so frame ``i``'s red component reads back as
+    ``10*i``.
+    """
+    import cv2
+    import numpy as np
+
+    def _make(dir_path, name="clip.avi", frames=8, width=32, height=24, fps=10.0):
+        path = os.path.join(str(dir_path), name)
+        fourcc = cv2.VideoWriter_fourcc(*"MJPG")
+        writer = cv2.VideoWriter(path, fourcc, fps, (width, height))
+        assert writer.isOpened(), "cv2.VideoWriter failed to open (MJPG/.avi)"
+        for i in range(frames):
+            frame = np.zeros((height, width, 3), dtype=np.uint8)
+            frame[:, :, 2] = 10 * i  # BGR: ramp the red channel
+            writer.write(frame)
+        writer.release()
+        return path
+
+    return _make
+
+
 @pytest.fixture(scope="session")
 def qt_application():
     """Create a QApplication instance for the test session."""

--- a/tests/integration/test_video_loading.py
+++ b/tests/integration/test_video_loading.py
@@ -102,6 +102,42 @@ def test_base_name_collision_refused(
     assert not any(i["file_name"] == "clip.png" for i in window.all_images)
 
 
+def test_switch_between_video_and_image_reuses_lazy_slices(
+    window, make_test_video, tmp_path, no_native_dialogs
+):
+    """switch_image between a video and a plain image and back exercises the
+    `base in image_slices` reuse branch the #45/#47 reconciliation rests on:
+    the video's LazySliceList is restored intact (no rebuild, no stale
+    display)."""
+    video = make_test_video(tmp_path, name="clip.avi", frames=8)
+    png = tmp_path / "plain.png"
+    plain = QImage(6, 5, QImage.Format.Format_RGB888)
+    plain.fill(Qt.GlobalColor.darkGreen)
+    plain.save(str(png))
+
+    window.image_controller.add_images_to_list([video, str(png)])
+    lazy = window.image_slices["clip"]
+
+    def item(name):
+        its = window.image_list.findItems(name, Qt.MatchFlag.MatchExactly)
+        assert its, name
+        return its[0]
+
+    # Switch to the plain image: slice list cleared, a single 2D image shown.
+    window.image_controller.switch_image(item("plain.png"))
+    assert window.current_slice is None
+    assert window.slice_list.count() == 0
+    assert isinstance(window.current_image, QImage)
+
+    # Switch back to the video: the SAME LazySliceList is restored via the
+    # reuse branch (not rebuilt), frame 0 current, slice list repopulated.
+    window.image_controller.switch_image(item("clip.avi"))
+    assert window.image_slices["clip"] is lazy
+    assert window.slices is lazy
+    assert window.current_slice == frame_key("clip", 0)
+    assert window.slice_list.count() == len(lazy)
+
+
 def test_video_roundtrip_save_reload(
     window, make_test_video, tmp_path, no_native_dialogs
 ):

--- a/tests/integration/test_video_loading.py
+++ b/tests/integration/test_video_loading.py
@@ -1,0 +1,165 @@
+"""Integration tests for video-frames-as-slices (issue #47).
+
+Drives a full offscreen ``ImageAnnotator`` through the real load / navigate /
+save / reload paths, proving a video reuses the #45 lazy-slice machinery: its
+``image_slices[base]`` is a ``LazySliceList`` and saving decodes no frames.
+
+The video is built with the shared ``make_test_video`` fixture
+(tests/conftest.py). Modal dialogs are neutralised by ``no_native_dialogs``
+(an offscreen modal hangs the run).
+"""
+
+import pytest
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QColor, QImage
+from PyQt6.QtWidgets import QFileDialog, QMessageBox
+
+from digitalsreeni_image_annotator.core.slice_cache import LazySliceList
+from digitalsreeni_image_annotator.core.video_handler import frame_key
+
+
+POLY = {"segmentation": [1.0, 1.0, 10.0, 1.0, 10.0, 8.0], "area": 31.5,
+        "category_id": 1, "category_name": "cell", "number": 1}
+
+
+@pytest.fixture
+def window(qt_application):
+    from digitalsreeni_image_annotator.annotator_window import ImageAnnotator
+
+    w = ImageAnnotator()
+    yield w
+    w.deleteLater()
+
+
+@pytest.fixture
+def no_native_dialogs(monkeypatch):
+    """Hard safety net: no modal may open in an offscreen run (it hangs)."""
+    monkeypatch.setattr(
+        QMessageBox, "question",
+        staticmethod(lambda *a, **k: QMessageBox.StandardButton.Yes),
+    )
+    for m in ("information", "warning", "critical"):
+        monkeypatch.setattr(QMessageBox, m, staticmethod(lambda *a, **k: None))
+    monkeypatch.setattr(
+        QFileDialog, "getOpenFileNames", staticmethod(lambda *a, **k: ([], ""))
+    )
+    monkeypatch.setattr(
+        QFileDialog, "getSaveFileName", staticmethod(lambda *a, **k: ("", ""))
+    )
+
+
+def _slice_list_texts(window):
+    return [
+        window.slice_list.item(i).text()
+        for i in range(window.slice_list.count())
+    ]
+
+
+def test_load_video_creates_lazy_frame_slices(window, make_test_video, tmp_path):
+    """load_video builds a LazySliceList of frame slices (the #45 object), the
+    slice list is populated, and navigating to a far frame materialises it."""
+    path = make_test_video(tmp_path, name="clip.avi", frames=8)
+
+    window.image_controller.load_video(path)
+
+    lazy = window.image_slices["clip"]
+    n = window.video_handlers["clip"].total_frames
+    assert isinstance(lazy, LazySliceList)
+    assert window.slices is lazy          # same object (issue #45 guardrail)
+    assert len(lazy) == n
+    assert lazy.names == [frame_key("clip", i) for i in range(n)]
+    assert _slice_list_texts(window) == lazy.names
+
+    # First frame is current + materialised after load.
+    assert window.current_slice == frame_key("clip", 0)
+    assert isinstance(window.current_image, QImage)
+
+    # Navigate to frame 3 — decoded lazily on demand.
+    target = frame_key("clip", 3)
+    items = window.slice_list.findItems(target, Qt.MatchFlag.MatchExactly)
+    assert items
+    window.image_controller.switch_slice(items[0])
+    assert window.current_slice == target
+    assert isinstance(window.current_image, QImage)
+    assert not window.current_image.isNull()
+
+
+def test_base_name_collision_refused(
+    window, make_test_video, tmp_path, no_native_dialogs
+):
+    """A second file whose ext-stripped base collides with a loaded video is
+    refused (slices/annotations are keyed by the ext-stripped base)."""
+    video = make_test_video(tmp_path, name="clip.avi", frames=8)
+    window.image_controller.add_images_to_list([video])
+    assert "clip" in window.image_slices
+
+    # A PNG named "clip.png" shares the base name "clip" → refused.
+    png = tmp_path / "clip.png"
+    QImage(4, 4, QImage.Format.Format_RGB32).save(str(png))
+    window.image_controller.add_images_to_list([str(png)])
+
+    assert "clip.png" not in window.image_paths
+    assert not any(i["file_name"] == "clip.png" for i in window.all_images)
+
+
+def test_video_roundtrip_save_reload(
+    window, make_test_video, tmp_path, no_native_dialogs
+):
+    """Open a video, annotate a far frame, save, reload: the annotation is
+    restored under the frame key, the reloaded entry carries is_video /
+    video_metadata, and saving decoded NO frames (lazy holds)."""
+    images_dir = tmp_path / "images"
+    images_dir.mkdir()
+    path = make_test_video(images_dir, name="clip.avi", frames=8)
+
+    window.current_project_file = str(tmp_path / "proj.iap")
+    window.current_project_dir = str(tmp_path)
+    window.add_class("cell", QColor("#ff0000"))
+
+    window.image_controller.add_images_to_list([path])
+    handler = window.video_handlers["clip"]
+    target = frame_key("clip", 3)
+
+    items = window.slice_list.findItems(target, Qt.MatchFlag.MatchExactly)
+    assert items
+    window.image_controller.switch_slice(items[0])
+    assert window.current_slice == target
+
+    # Annotate the (far) current frame through the normal save path.
+    window.image_label.annotations = {"cell": [dict(POLY)]}
+    window.save_current_annotations()
+
+    # Spy on decode AFTER annotating — the save must touch no pixels.
+    calls = {"n": 0}
+    original = handler.get_frame
+
+    def counting(idx):
+        calls["n"] += 1
+        return original(idx)
+
+    handler.get_frame = counting
+
+    window.project_controller.save_project(show_message=False)
+    assert calls["n"] == 0  # placeholders / lazy holds — save decoded nothing
+
+    # Reload from disk.
+    window.project_controller.open_specific_project(
+        str(window.current_project_file)
+    )
+
+    # Annotation restored under the frame key.
+    assert target in window.all_annotations
+    assert (
+        window.all_annotations[target]["cell"][0]["segmentation"]
+        == POLY["segmentation"]
+    )
+
+    # Reloaded image entry is still a video with its metadata.
+    reloaded = next(
+        i for i in window.all_images if i["file_name"] == "clip.avi"
+    )
+    assert reloaded.get("is_video") is True
+    assert reloaded.get("video_metadata")
+    assert reloaded["video_metadata"]["total_frames"] == handler.total_frames
+    # Reload rebuilt the lazy frame slices.
+    assert isinstance(window.image_slices["clip"], LazySliceList)

--- a/tests/unit/test_video_handler.py
+++ b/tests/unit/test_video_handler.py
@@ -1,0 +1,179 @@
+"""Unit tests for the video-handler layer (issue #47).
+
+These exercise ``core/video_handler.py`` headlessly — only cv2 + QImage are
+involved, no main window. A tiny MJPG/.avi is written per test via the shared
+``make_test_video`` fixture (tests/conftest.py). MJPG on a uniform fill
+round-trips exactly, so frame ``i``'s red channel reads back as ``10*i`` and a
+forgotten BGR→RGB conversion is caught by a blue-vs-red assertion.
+"""
+
+import pytest
+from PyQt6.QtGui import QImage, qBlue, qGreen, qRed
+
+from digitalsreeni_image_annotator.core.slice_cache import (
+    LazySliceList,
+    get_shared_lru,
+)
+from digitalsreeni_image_annotator.core.video_handler import (
+    VideoHandler,
+    VideoSliceProvider,
+    frame_key,
+    is_video,
+    parse_frame_index,
+)
+
+
+# ── pure helpers (no video needed) ───────────────────────────────────────────
+
+def test_frame_key_zero_padded():
+    assert frame_key("v", 42) == "v_F00042"
+    assert frame_key("clip", 0) == "clip_F00000"
+
+
+def test_parse_frame_index_roundtrip():
+    assert parse_frame_index("v_F00042") == 42
+    assert parse_frame_index(frame_key("clip", 7)) == 7
+
+
+def test_parse_frame_index_ignores_multidim_keys():
+    # Anchored at END — a multi-dim slice key is NOT a frame key.
+    assert parse_frame_index("stack_T1_Z5") is None
+    assert parse_frame_index("plain") is None
+
+
+def test_is_video_case_insensitive():
+    assert is_video("clip.mp4")
+    assert is_video("CLIP.MP4")
+    assert is_video("movie.AVI")
+    assert is_video("take.mov")
+    assert not is_video("image.png")
+    assert not is_video("stack.tif")
+
+
+# ── VideoHandler ─────────────────────────────────────────────────────────────
+
+def test_metadata(make_test_video, tmp_path):
+    path = make_test_video(tmp_path, frames=8, width=32, height=24, fps=10.0)
+    handler = VideoHandler(path)
+    try:
+        meta = handler.metadata()
+        # The MJPG writer produces exactly 8 here; allow a codec that yields a
+        # few fewer, but never more.
+        assert 6 <= meta["total_frames"] <= 8
+        assert meta["width"] == 32
+        assert meta["height"] == 24
+        assert meta["fps"] > 0
+        assert meta["duration_s"] == pytest.approx(
+            meta["total_frames"] / meta["fps"]
+        )
+    finally:
+        handler.release()
+
+
+def test_get_frame_is_rgb_not_bgr(make_test_video, tmp_path):
+    """BGR→RGB regression: frame 3 was filled BGR (0,0,30); after cvtColor the
+    QImage pixel is red (30,0,0). Forgetting cvtColor would make it blue."""
+    path = make_test_video(tmp_path, frames=8)
+    handler = VideoHandler(path)
+    try:
+        qimg = handler.get_frame(3)
+        assert isinstance(qimg, QImage)
+        assert not qimg.isNull()
+        px = qimg.pixel(0, 0)
+        r, g, b = qRed(px), qGreen(px), qBlue(px)
+        assert r > g and r > b            # red channel dominant, not blue
+        assert r == pytest.approx(30, abs=8)
+    finally:
+        handler.release()
+
+
+def test_get_frame_out_of_range_returns_none(make_test_video, tmp_path):
+    path = make_test_video(tmp_path, frames=8)
+    handler = VideoHandler(path)
+    try:
+        assert handler.get_frame(-1) is None
+        assert handler.get_frame(handler.total_frames) is None
+        assert handler.get_frame(9999) is None
+    finally:
+        handler.release()
+
+
+def test_release_is_idempotent(make_test_video, tmp_path):
+    path = make_test_video(tmp_path, frames=8)
+    handler = VideoHandler(path)
+    handler.release()
+    handler.release()  # must not raise
+    # A released handler decodes nothing.
+    assert handler.get_frame(0) is None
+
+
+def test_constructor_raises_on_bad_path(tmp_path):
+    bad = tmp_path / "not_a_video.avi"
+    bad.write_bytes(b"not a video")
+    with pytest.raises(ValueError):
+        VideoHandler(str(bad))
+
+
+# ── VideoSliceProvider + LazySliceList ───────────────────────────────────────
+
+def test_provider_names_and_extract(make_test_video, tmp_path):
+    path = make_test_video(tmp_path, frames=8)
+    handler = VideoHandler(path)
+    try:
+        provider = VideoSliceProvider(handler, "clip")
+        assert provider.names == [
+            frame_key("clip", i) for i in range(handler.total_frames)
+        ]
+        img = provider.extract(frame_key("clip", 2))
+        assert isinstance(img, QImage) and not img.isNull()
+        # An unknown / non-frame name never decodes.
+        assert provider.extract("clip_T1_Z2") is None
+    finally:
+        handler.release()
+
+
+def test_lazy_slice_list_decodes_on_demand_through_lru(make_test_video, tmp_path):
+    """A LazySliceList over a VideoSliceProvider decodes each frame only when
+    asked and caches it in the shared SliceLRU (issue #45 reconciliation)."""
+    path = make_test_video(tmp_path, frames=8)
+    handler = VideoHandler(path)
+    try:
+        # Spy on the actual decode calls.
+        calls = {"n": 0}
+        original = handler.get_frame
+
+        def counting(idx):
+            calls["n"] += 1
+            return original(idx)
+
+        handler.get_frame = counting
+
+        provider = VideoSliceProvider(handler, "clip")
+        lazy = LazySliceList(provider)
+        pid = lazy.provider_id
+        lru = get_shared_lru()
+
+        assert len(lazy) == handler.total_frames
+        # Constructing the list decodes nothing.
+        assert calls["n"] == 0
+        assert lru.count_prefix(pid) == 0
+
+        first = lazy.get(lazy.names[0])
+        assert isinstance(first, QImage)
+        assert calls["n"] == 1
+        assert lru.count_prefix(pid) == 1
+
+        # A second get of the SAME frame is an LRU hit — no new decode.
+        lazy.get(lazy.names[0])
+        assert calls["n"] == 1
+
+        # A different frame decodes once more and caches.
+        lazy.get(lazy.names[2])
+        assert calls["n"] == 2
+        assert lru.count_prefix(pid) == 2
+
+        # release() drops this provider's cached frames from the shared LRU.
+        lazy.release()
+        assert lru.count_prefix(pid) == 0
+    finally:
+        handler.release()


### PR DESCRIPTION
## Summary

Treat a video as a stack whose slices are frames, **reusing the #45 lazy-slice machinery** (the #45/#47 reconciliation) instead of a parallel frame cache.

- `core/video_handler.py`: `VideoHandler` wraps `cv2.VideoCapture` (metadata once; `get_frame(idx)` seeks+decodes one frame, **BGR→RGB**, mandatory `.copy()`; idempotent `release`; GUI-thread only). `frame_key`/`parse_frame_index`/`FRAME_KEY_RE`/`is_video`/`VIDEO_EXTS`. `VideoSliceProvider` is duck-compatible with `slice_cache.SliceProvider`, so a video's `image_slices[base]` is a `LazySliceList` and the shared `SliceLRU` caps live frame QImages.
- `ImageController.load_video` + `is_video` branch in `add_images_to_list`; `open_images` accepts `*.mp4 *.avi *.mov`; base-name collision refused; handlers released on **every** drop path. `mw.video_handlers` init + released in `clear_all`. `.iap` round-trips `is_video`/`video_metadata`; load branches to `load_video`.

Because a video is a `LazySliceList`, `switch_slice`/`activate_slice`/`switch_image`, `.names`, `__iter__`, exporters, DINO batch, save-no-pixels and delete-release all work for video **unchanged**. Opening a video decodes only frame 0; save decodes zero frames (test-asserted).

## Verification

- Full suite **742 passed / 3 skipped** (+15 tests): BGR→RGB regression, out-of-range→None, lazy decode, save-decodes-zero-frames, full save/reload round-trip carrying `is_video`/`video_metadata`, base-name collision, video↔image navigation reuse branch, release idempotency. Ruff clean (only the pre-existing `annotator_window` F401 baseline).
- **Senior review** (no P0): the reachable P1 (YOLO-predict offered on a video → GUI-thread freeze then error) is fixed with an `is_video` guard on both the menu and `predict_single_image`; P2s (switch_image else-branch, `video_metadata` KeyError-hardening, relocate-dialog filter, ADR memory-claim correction, nav test) done.

## Docs

ADR-037, `docs/05/06/08/12` (glossary: Frame Key, Video).

## Phase chain

**Phase 5**, base = `perf/lazy-slice-loading` (Phase 4 / #45). Feeds #48 (timeline) and #51 (SAM 3 tracking).

Closes #47

🧙 Built with [WOZCODE](https://wozcode.com)