### PR TITLE
feat: video timeline UI + annotated-frame markers + frame export (#48)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ src/digitalsreeni_image_annotator/
 │   ├── canvas_renderer.py        # CanvasRenderer painting/overlays (ADR-034)
 │   ├── edit_gestures.py          # EditGestures + pure fns: #40/#35 handles (ADR-034)
 │   ├── canvas_context.py         # CanvasContext read accessor (ADR-018)
+│   ├── video_timeline.py         # VideoTimeline scrub bar + frame markers (#48)
 │   └── tools/                    # Per-tool handlers (ADR-019): rectangle,
 │                                 #   polygon, paint, eraser
 ├── inference/                    # sam_utils.py, dino_utils.py
@@ -277,6 +278,7 @@ See [Risks and Technical Debt](docs/11_risks_and_technical_debt.md) for full lis
 | Backspace (keypoint tool) | Remove the last placed keypoint |
 | Right-click a selected pose's point | Toggle its visibility (visible ↔ occluded) |
 | Up/Down | Navigate slices |
+| Home/End (video) | Jump to first/last frame (#48) |
 | -/= | Brush size |
 
 ## Quick Tips

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ digitalsreeni-image-annotator      # or:  sreeni      # or:  python -m digitalsr
 Golden path:
 
 1. **New Project** (Ctrl+N).
-2. **Add New Images** — including TIFF stacks and CZI files.
+2. **Add Images / Videos** — images (including TIFF stacks and CZI files) or videos (MP4/AVI/MOV).
 3. **Add a class** and pick its colour.
 4. **Annotate** — draw manually, or pick a SAM model and use **SAM-box** /
    **SAM-points** (Enter accepts the mask, Esc discards it). For text prompts,

--- a/docs/05_building_block_view.md
+++ b/docs/05_building_block_view.md
@@ -42,6 +42,7 @@ src/digitalsreeni_image_annotator/
 	│   ├── canvas_renderer.py         # CanvasRenderer - painting/overlays (ADR-034)
 	│   ├── edit_gestures.py           # EditGestures + pure fns - #40/#35 handles (ADR-034)
 	│   ├── canvas_context.py          # CanvasContext - narrow read view (ADR-018)
+	│   ├── video_timeline.py          # VideoTimeline scrub bar + frame markers (#48)
 	│   └── tools/                     # Per-tool handlers (ADR-019)
 	│       ├── base.py                # ToolHandler base
 	│       ├── rectangle_tool.py

--- a/docs/06_runtime_view.md
+++ b/docs/06_runtime_view.md
@@ -571,7 +571,7 @@ offered once the project is disk-backed.
 
 ## Video Loading (issue #47, ADR-037)
 
-1. User adds `clip.mp4` (or `.avi`/`.mov`) via Add New Images / Open Images.
+1. User adds `clip.mp4` (or `.avi`/`.mov`) via Add Images / Videos / Open Images.
 2. `add_images_to_list` detects the video extension (`is_video`) and calls
    `ImageController.load_video(path)`:
    - `VideoHandler(path)` opens the capture and reads metadata once

--- a/docs/06_runtime_view.md
+++ b/docs/06_runtime_view.md
@@ -591,6 +591,16 @@ offered once the project is disk-backed.
 5. Save writes `is_video`/`video_metadata` + per-frame annotations (no pixels);
    load branches to `load_video`. A missing video flows through the existing
    missing-images prompt.
+6. **Timeline (issue #48):** for a video, `ImageController.update_video_timeline`
+   shows `window.video_timeline` (a scrub slider + `F i/N • MM:SS / MM:SS`
+   label + a marker strip ticking every annotated frame). Scrubbing emits
+   `frameSelected(idx)` → `on_timeline_frame_selected` → `switch_slice`
+   (never a direct `current_image` write); `set_current_frame` re-syncs the
+   slider WITHOUT re-emitting. Marks refresh from `annotated_frame_indices`
+   at the `update_slice_list_colors` choke point, so they update live on
+   annotate/delete/undo/accept. `Home`/`End` jump to the first/last frame.
+   "Tools → Export Annotated Video Frames…" writes one `{frame_key}.png`
+   per annotated frame, decoding one frame at a time via `VideoHandler`.
 
 ## Multi-dimensional Image Loading
 

--- a/docs/08_crosscutting_concepts.md
+++ b/docs/08_crosscutting_concepts.md
@@ -883,8 +883,12 @@ only. It is a **view**, never a second source of truth for the current frame:
   `parse_frame_index`, exact) and refreshed at the `update_slice_list_colors`
   choke point — the same hook the slice list uses — so they stay correct after
   every save/accept/undo/delete without a frame switch.
-- **Palette-only colours** (`highlight`/`mid`/`text`) so ticks read in both
-  themes; the slider has `NoFocus` so it never swallows arrow-key slice nav.
+- **Palette-derived colours** (`highlight`/`mid`/`text`), no literals. The app
+  themes via QSS (no `setPalette`), so `highlight`/`mid` are effectively the
+  static default palette — chosen because a saturated accent + mid-grey both
+  read on the light and soft-dark backgrounds — while the `text` role (the
+  high-contrast current-frame tick) does follow the stylesheet. The slider has
+  `NoFocus` so it never swallows arrow-key slice nav.
 
 ## Image List Groups & Status Badges (issue #43)
 

--- a/docs/08_crosscutting_concepts.md
+++ b/docs/08_crosscutting_concepts.md
@@ -862,6 +862,30 @@ every slice consumer above works for video unchanged. Practical rules:
 - **Base-name collision** (`video.mp4` vs `video.tif` → same `image_slices` key) is
   refused in `add_images_to_list`.
 
+## Video Timeline — A Pure View (issue #48)
+
+`widgets/video_timeline.py::VideoTimeline` is a scrub slider + annotated-frame
+marker strip + `F i/N • MM:SS / MM:SS` label shown under the canvas for videos
+only. It is a **view**, never a second source of truth for the current frame:
+
+- **All frame changes route through `switch_slice`.** User scrubbing emits
+  `frameSelected(idx)`; the orchestrator's `on_timeline_frame_selected` maps
+  idx→slice-list row and calls `switch_slice` (keeping unsaved-changes checks,
+  annotation save, and the DINO temp re-sync intact). The timeline never writes
+  `current_image`.
+- **No signal feedback loop.** `set_current_frame` (called from `switch_slice`
+  via `update_video_timeline`) wraps `slider.setValue` in an `_updating` guard
+  so the programmatic sync can't re-emit `frameSelected` and re-enter
+  `switch_slice`. `set_video` is guarded the same way, so reconfiguring the
+  timeline on every annotation mutation never spuriously jumps to frame 0.
+- **Marks derive from `all_annotations` keys**, computed by
+  `ImageController.annotated_frame_indices(base)` (prefix `base + "_F"` +
+  `parse_frame_index`, exact) and refreshed at the `update_slice_list_colors`
+  choke point — the same hook the slice list uses — so they stay correct after
+  every save/accept/undo/delete without a frame switch.
+- **Palette-only colours** (`highlight`/`mid`/`text`) so ticks read in both
+  themes; the slider has `NoFocus` so it never swallows arrow-key slice nav.
+
 ## Image List Groups & Status Badges (issue #43)
 
 The image list gained two at-a-glance affordances, both layered on the

--- a/docs/09_architecture_decisions.md
+++ b/docs/09_architecture_decisions.md
@@ -1830,7 +1830,10 @@ lazy-slice machinery** rather than a parallel frame cache (the #45/#47 reconcili
 - `ImageController.load_video` builds the handler + provider + `LazySliceList` (stored as
   both `image_slices[base]` and `mw.slices`); `add_images_to_list` gains an
   `is_video(...)` branch setting `is_multi_slice=True`, `is_video=True`,
-  `video_metadata=handler.metadata()`; `open_images` accepts `*.mp4 *.avi *.mov`.
+  `video_metadata=handler.metadata()`. The Add/Open file dialogs accept `*.mp4 *.avi
+  *.mov` via the shared `video_handler.file_dialog_filter()` (video globs derived from
+  `VIDEO_EXTS`), used by `add_images` (the live "Add Images / Videos" button),
+  `open_images` and `load_missing_images` so the filter can't drift from `is_video()`.
   Handlers live in `mw.video_handlers[base]` and are `release()`d on every drop path
   (delete/remove/redefine/`open_images`/`clear_all`). `.iap` round-trips `is_video`
   +`video_metadata`; load branches to `load_video`.

--- a/src/digitalsreeni_image_annotator/annotator_window.py
+++ b/src/digitalsreeni_image_annotator/annotator_window.py
@@ -403,6 +403,31 @@ class ImageAnnotator(QMainWindow):
     def switch_image(self, item):
         return self.image_controller.switch_image(item)
 
+    def on_timeline_frame_selected(self, idx):
+        """Route a video-timeline scrub to the matching frame (issue #48).
+
+        Slice-list rows are in frame order, so ``idx`` maps 1:1 to a row. Go
+        through ``switch_slice`` (never set ``current_image`` directly) so the
+        unsaved-change check, annotation save, edit-mode exit and DINO temp
+        re-sync all run.
+        """
+        if 0 <= idx < self.slice_list.count():
+            self.switch_slice(self.slice_list.item(idx))
+
+    def update_video_timeline(self):
+        return self.image_controller.update_video_timeline()
+
+    def _current_image_is_video(self):
+        """True if the currently-selected image is a video (issue #48)."""
+        item = self.image_list.currentItem()
+        if item is None:
+            return False
+        info = next(
+            (img for img in self.all_images if img["file_name"] == item.text()),
+            None,
+        )
+        return bool(info and info.get("is_video"))
+
     def adjust_zoom_to_fit(self):
         if not self.current_image:
             return
@@ -502,6 +527,22 @@ class ImageAnnotator(QMainWindow):
             else:
                 # Pass the event to the parent for default handling
                 super().keyPressEvent(event)
+        elif event.key() == Qt.Key.Key_Home or event.key() == Qt.Key.Key_End:
+            # First / last frame jump for videos (issue #48). Gated on the
+            # active image being a video AND focus on the slice list or the
+            # canvas — QLineEdit/QTextEdit are already spared by the early
+            # return at the top, so this can't steal Home/End from text cursors.
+            # Routes through switch_slice (never sets current_image directly).
+            if self._current_image_is_video() and (
+                self.slice_list.hasFocus() or self.image_label.hasFocus()
+            ):
+                count = self.slice_list.count()
+                if count > 0:
+                    row = 0 if event.key() == Qt.Key.Key_Home else count - 1
+                    self.slice_list.setCurrentRow(row)
+                    self.switch_slice(self.slice_list.item(row))
+            else:
+                super().keyPressEvent(event)
         elif event.key() == Qt.Key.Key_Return or event.key() == Qt.Key.Key_Enter:
             # Handle accepting visible temporary classes
             if self.has_visible_temp_classes():
@@ -532,6 +573,9 @@ class ImageAnnotator(QMainWindow):
 
     def export_annotations(self):
         return io_controller.export_annotations(self)
+
+    def export_annotated_frames(self):
+        return io_controller.export_annotated_frames(self)
 
     def save_slices(self, directory):
         return io_controller.save_slices(self, directory)

--- a/src/digitalsreeni_image_annotator/annotator_window.py
+++ b/src/digitalsreeni_image_annotator/annotator_window.py
@@ -418,15 +418,8 @@ class ImageAnnotator(QMainWindow):
         return self.image_controller.update_video_timeline()
 
     def _current_image_is_video(self):
-        """True if the currently-selected image is a video (issue #48)."""
-        item = self.image_list.currentItem()
-        if item is None:
-            return False
-        info = next(
-            (img for img in self.all_images if img["file_name"] == item.text()),
-            None,
-        )
-        return bool(info and info.get("is_video"))
+        """True if the currently-selected image is a loaded video (issue #48)."""
+        return self.image_controller.current_video() is not None
 
     def adjust_zoom_to_fit(self):
         if not self.current_image:

--- a/src/digitalsreeni_image_annotator/annotator_window.py
+++ b/src/digitalsreeni_image_annotator/annotator_window.py
@@ -789,11 +789,10 @@ class ImageAnnotator(QMainWindow):
     def add_images(self):
         if not self.image_label.check_unsaved_changes():
             return
+        from .core.video_handler import file_dialog_filter
+
         file_names, _ = QFileDialog.getOpenFileNames(
-            self,
-            "Add Images or Videos",
-            "",
-            "Images & Videos (*.png *.jpg *.bmp *.tif *.tiff *.czi *.mp4 *.avi *.mov)",
+            self, "Add Images or Videos", "", file_dialog_filter()
         )
         if file_names:
             self.add_images_to_list(file_names)

--- a/src/digitalsreeni_image_annotator/annotator_window.py
+++ b/src/digitalsreeni_image_annotator/annotator_window.py
@@ -790,7 +790,10 @@ class ImageAnnotator(QMainWindow):
         if not self.image_label.check_unsaved_changes():
             return
         file_names, _ = QFileDialog.getOpenFileNames(
-            self, "Add Images", "", "Image Files (*.png *.jpg *.bmp *.tif *.tiff *.czi)"
+            self,
+            "Add Images or Videos",
+            "",
+            "Images & Videos (*.png *.jpg *.bmp *.tif *.tiff *.czi *.mp4 *.avi *.mov)",
         )
         if file_names:
             self.add_images_to_list(file_names)

--- a/src/digitalsreeni_image_annotator/controllers/class_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/class_controller.py
@@ -107,6 +107,13 @@ class ClassController(QObject):
         # keep one of those two routes.
         self.mw.image_controller.apply_image_filter()
 
+        # Repaint the video timeline's annotated-frame marks (issue #48). This
+        # is THE mark-refresh choke point (runs on every annotation mutation AND
+        # at the end of switch_image / switch_slice), so hooking here keeps the
+        # timeline in sync with a single call rather than duplicating it in each
+        # frame-switch path. No-op unless the active image is a video.
+        self.mw.image_controller.update_video_timeline()
+
     def add_class(self, class_name=None, color=None):
         if not self.mw.image_label.check_unsaved_changes():
             return

--- a/src/digitalsreeni_image_annotator/controllers/image_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/image_controller.py
@@ -616,6 +616,29 @@ class ImageController(QObject):
                     out.add(idx)
         return out
 
+    def current_video(self):
+        """``(base_name, handler, info)`` if the active image is a loaded video,
+        else ``None`` (issue #48).
+
+        Single source of truth for the ``currentItem → is_video → handler``
+        resolution shared by the timeline sync, Home/End nav and frame export,
+        so those three call sites can't drift.
+        """
+        item = self.mw.image_list.currentItem()
+        if item is None:
+            return None
+        info = next(
+            (img for img in self.mw.all_images if img["file_name"] == item.text()),
+            None,
+        )
+        if not (info and info.get("is_video")):
+            return None
+        base_name = os.path.splitext(info["file_name"])[0]
+        handler = self.mw.video_handlers.get(base_name)
+        if handler is None:
+            return None
+        return base_name, handler, info
+
     def update_video_timeline(self):
         """Sync the video timeline widget to the active image (issue #48).
 
@@ -630,28 +653,17 @@ class ImageController(QObject):
         if timeline is None:
             return
 
-        current_item = self.mw.image_list.currentItem()
-        info = None
-        if current_item is not None:
-            file_name = current_item.text()
-            info = next(
-                (img for img in self.mw.all_images if img["file_name"] == file_name),
-                None,
-            )
-
-        if info and info.get("is_video"):
-            base_name = os.path.splitext(info["file_name"])[0]
-            handler = self.mw.video_handlers.get(base_name)
-            if handler is not None:
-                timeline.set_video(handler.total_frames, handler.fps)
-                idx = parse_frame_index(self.mw.current_slice or "")
-                if idx is not None:
-                    timeline.set_current_frame(idx)
-                timeline.set_annotated_frames(self.annotated_frame_indices(base_name))
-                timeline.setVisible(True)
-                return
-
-        timeline.setVisible(False)
+        video = self.current_video()
+        if video is not None:
+            base_name, handler, _info = video
+            timeline.set_video(handler.total_frames, handler.fps)
+            idx = parse_frame_index(self.mw.current_slice or "")
+            if idx is not None:
+                timeline.set_current_frame(idx)
+            timeline.set_annotated_frames(self.annotated_frame_indices(base_name))
+            timeline.setVisible(True)
+        else:
+            timeline.setVisible(False)
 
     def update_all_images(self, new_image_info):
         for info in new_image_info:

--- a/src/digitalsreeni_image_annotator/controllers/image_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/image_controller.py
@@ -53,6 +53,7 @@ from ..core.video_handler import (
     VideoHandler,
     VideoSliceProvider,
     is_video,
+    parse_frame_index,
 )
 
 from ..core.logging_config import get_logger
@@ -597,6 +598,60 @@ class ImageController(QObject):
 
         logger.info(f"Loaded video {base_name}: {handler.total_frames} frames")
         return lazy
+
+    def annotated_frame_indices(self, base_name):
+        """Frame indices of ``base_name`` (a video) that carry annotations.
+
+        A frame is annotated if ``all_annotations[frame_key]`` is non-empty and
+        holds at least one non-empty class list. Prefix-match ``base + "_F"``
+        and parse the exact index (a bare ``base + "_"`` would also swallow
+        multi-dim slice keys) — see issue #48.
+        """
+        prefix = base_name + "_F"
+        out = set()
+        for key, by_class in self.mw.all_annotations.items():
+            if key.startswith(prefix) and by_class and any(by_class.values()):
+                idx = parse_frame_index(key)
+                if idx is not None:
+                    out.add(idx)
+        return out
+
+    def update_video_timeline(self):
+        """Sync the video timeline widget to the active image (issue #48).
+
+        Shows + configures the timeline when the active image is a video,
+        otherwise hides it. The timeline is a pure VIEW: it never changes the
+        frame itself (user scrubs route back through ``switch_slice`` via
+        ``on_timeline_frame_selected``). Called after every frame switch and at
+        the end of ``update_slice_list_colors`` so annotation marks stay current
+        without a frame change.
+        """
+        timeline = getattr(self.mw, "video_timeline", None)
+        if timeline is None:
+            return
+
+        current_item = self.mw.image_list.currentItem()
+        info = None
+        if current_item is not None:
+            file_name = current_item.text()
+            info = next(
+                (img for img in self.mw.all_images if img["file_name"] == file_name),
+                None,
+            )
+
+        if info and info.get("is_video"):
+            base_name = os.path.splitext(info["file_name"])[0]
+            handler = self.mw.video_handlers.get(base_name)
+            if handler is not None:
+                timeline.set_video(handler.total_frames, handler.fps)
+                idx = parse_frame_index(self.mw.current_slice or "")
+                if idx is not None:
+                    timeline.set_current_frame(idx)
+                timeline.set_annotated_frames(self.annotated_frame_indices(base_name))
+                timeline.setVisible(True)
+                return
+
+        timeline.setVisible(False)
 
     def update_all_images(self, new_image_info):
         for info in new_image_info:

--- a/src/digitalsreeni_image_annotator/controllers/image_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/image_controller.py
@@ -52,6 +52,7 @@ from ..core.slice_cache import (
 from ..core.video_handler import (
     VideoHandler,
     VideoSliceProvider,
+    file_dialog_filter,
     is_video,
     parse_frame_index,
 )
@@ -390,10 +391,7 @@ class ImageController(QObject):
 
     def open_images(self):
         file_names, _ = QFileDialog.getOpenFileNames(
-            self.mw,
-            "Open Images",
-            "",
-            "Image Files (*.png *.jpg *.bmp *.tif *.tiff *.czi *.mp4 *.avi *.mov)",
+            self.mw, "Open Images or Videos", "", file_dialog_filter()
         )
         if file_names:
             self.mw.image_list.clear()

--- a/src/digitalsreeni_image_annotator/controllers/io_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/io_controller.py
@@ -414,30 +414,15 @@ def export_annotated_frames(mw):
     """
     from ..core.video_handler import frame_key
 
-    current_item = mw.image_list.currentItem()
-    info = None
-    if current_item is not None:
-        info = next(
-            (img for img in mw.all_images if img["file_name"] == current_item.text()),
-            None,
-        )
-    if not (info and info.get("is_video")):
+    video = mw.image_controller.current_video()
+    if video is None:
         QMessageBox.information(
             mw,
             "Export Annotated Frames",
             "Open a video and select it first, then export its annotated frames.",
         )
         return
-
-    base_name = os.path.splitext(info["file_name"])[0]
-    handler = mw.video_handlers.get(base_name)
-    if handler is None:
-        QMessageBox.information(
-            mw,
-            "Export Annotated Frames",
-            "No video handler is loaded for the selected image.",
-        )
-        return
+    base_name, handler, _info = video
 
     directory = QFileDialog.getExistingDirectory(
         mw, "Select Output Directory for Annotated Frames"
@@ -450,20 +435,29 @@ def export_annotated_frames(mw):
 
     indices = sorted(mw.image_controller.annotated_frame_indices(base_name))
     written = 0
+    failed = 0
     for idx in indices:
         qimage = handler.get_frame(idx)  # one frame at a time (lazy, #47)
-        if qimage is not None:
-            qimage.save(
-                os.path.join(directory, f"{frame_key(base_name, idx)}.png"), "PNG"
-            )
+        # Count a frame as failed if it can't be decoded OR the PNG write
+        # fails (qimage.save returns False), so the summary can't claim
+        # success for a frame that silently vanished.
+        if qimage is not None and qimage.save(
+            os.path.join(directory, f"{frame_key(base_name, idx)}.png"), "PNG"
+        ):
             written += 1
+        else:
+            failed += 1
 
-    QMessageBox.information(
-        mw,
-        "Export Complete",
+    message = (
         f"{written} annotated frame{'' if written == 1 else 's'} "
-        f"written to:\n{directory}",
+        f"written to:\n{directory}"
     )
+    if failed:
+        message += (
+            f"\n\n{failed} frame{'' if failed == 1 else 's'} could not be "
+            "decoded or written."
+        )
+    QMessageBox.information(mw, "Export Complete", message)
 
 
 def save_slices(mw, directory):

--- a/src/digitalsreeni_image_annotator/controllers/io_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/io_controller.py
@@ -405,6 +405,67 @@ def export_annotations(mw):
     QMessageBox.information(mw, "Export Complete", message)
 
 
+def export_annotated_frames(mw):
+    """Save each annotated frame of the current video as a PNG (issue #48).
+
+    Requires a video to be the active image. Decodes ONE frame at a time via
+    the ``VideoHandler`` (the issue-#47 lazy fetch — never bulk pre-extracts)
+    and writes each under its frame key, e.g. ``clip_F00003.png``.
+    """
+    from ..core.video_handler import frame_key
+
+    current_item = mw.image_list.currentItem()
+    info = None
+    if current_item is not None:
+        info = next(
+            (img for img in mw.all_images if img["file_name"] == current_item.text()),
+            None,
+        )
+    if not (info and info.get("is_video")):
+        QMessageBox.information(
+            mw,
+            "Export Annotated Frames",
+            "Open a video and select it first, then export its annotated frames.",
+        )
+        return
+
+    base_name = os.path.splitext(info["file_name"])[0]
+    handler = mw.video_handlers.get(base_name)
+    if handler is None:
+        QMessageBox.information(
+            mw,
+            "Export Annotated Frames",
+            "No video handler is loaded for the selected image.",
+        )
+        return
+
+    directory = QFileDialog.getExistingDirectory(
+        mw, "Select Output Directory for Annotated Frames"
+    )
+    if not directory:
+        return
+
+    # Flush the current frame's in-progress annotations so it's counted.
+    mw.save_current_annotations()
+
+    indices = sorted(mw.image_controller.annotated_frame_indices(base_name))
+    written = 0
+    for idx in indices:
+        qimage = handler.get_frame(idx)  # one frame at a time (lazy, #47)
+        if qimage is not None:
+            qimage.save(
+                os.path.join(directory, f"{frame_key(base_name, idx)}.png"), "PNG"
+            )
+            written += 1
+
+    QMessageBox.information(
+        mw,
+        "Export Complete",
+        f"{written} annotated frame{'' if written == 1 else 's'} "
+        f"written to:\n{directory}",
+    )
+
+
 def save_slices(mw, directory):
     # Decode ONLY the annotated slices (issue #45): iterate names first (no
     # pixel work) and materialise a slice's QImage only when it has

--- a/src/digitalsreeni_image_annotator/controllers/project_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/project_controller.py
@@ -361,11 +361,10 @@ class ProjectController(QObject):
             self.load_missing_images(missing_images)
 
     def load_missing_images(self, missing_images):
+        from ..core.video_handler import file_dialog_filter
+
         files, _ = QFileDialog.getOpenFileNames(
-            self.mw,
-            "Select Missing Images",
-            "",
-            "Image Files (*.png *.jpg *.bmp *.tif *.tiff *.czi *.mp4 *.avi *.mov)",
+            self.mw, "Select Missing Images or Videos", "", file_dialog_filter()
         )
         if files:
             images_loaded = 0

--- a/src/digitalsreeni_image_annotator/core/constants.py
+++ b/src/digitalsreeni_image_annotator/core/constants.py
@@ -8,7 +8,8 @@ Dr. Sreenivas Bhattiprolu
 """
 
 # File dialog filters
-IMAGE_FILE_FILTER = "Image Files (*.png *.jpg *.bmp)"
+# (image/video open filter lives in video_handler.file_dialog_filter(), derived
+#  from VIDEO_EXTS so it can't drift from is_video() -- #47/#48)
 JSON_FILE_FILTER = "JSON Files (*.json)"
 
 # Default window size

--- a/src/digitalsreeni_image_annotator/core/video_handler.py
+++ b/src/digitalsreeni_image_annotator/core/video_handler.py
@@ -40,6 +40,24 @@ def is_video(file_name):
     return file_name.lower().endswith(VIDEO_EXTS)
 
 
+# Image container globs the app can open. Paired with VIDEO_EXTS to build the
+# file-open dialog filter. Kept next to VIDEO_EXTS so the dialog and is_video()
+# can never drift on the video part -- the #47 gap was exactly three filter
+# string literals updated for video and one (add_images) missed. (#47/#48)
+_IMAGE_GLOBS = "*.png *.jpg *.bmp *.tif *.tiff *.czi"
+
+
+def file_dialog_filter():
+    """Qt ``getOpenFileNames`` filter string for images + videos.
+
+    The video globs are derived from :data:`VIDEO_EXTS`, so registering a new
+    container there updates every Add/Open dialog at once instead of the app
+    silently accepting a format no file picker ever offers.
+    """
+    video_globs = " ".join(f"*{ext}" for ext in VIDEO_EXTS)
+    return f"Images & Videos ({_IMAGE_GLOBS} {video_globs})"
+
+
 def frame_key(base_name, idx):
     """Slice name for frame ``idx`` (0-based) of the video ``base_name``."""
     return f"{base_name}_F{idx:05d}"

--- a/src/digitalsreeni_image_annotator/dialogs/help_window.py
+++ b/src/digitalsreeni_image_annotator/dialogs/help_window.py
@@ -1,5 +1,4 @@
 from PyQt6.QtWidgets import QDialog, QVBoxLayout, QTextBrowser
-from PyQt6.QtCore import Qt
 from ..ui.soft_dark_stylesheet import soft_dark_stylesheet
 from ..ui.default_stylesheet import default_stylesheet
 
@@ -65,7 +64,7 @@ class HelpWindow(QDialog):
         <h3>Starting a New Project</h3>
         <ol>
             <li>Click "New Project" or use Ctrl+N to start a new project.</li>
-            <li>Click "Add New Images" to import multiple images you want to annotate, including TIFF stacks and CZI files.</li>
+            <li>Click "Add Images / Videos" to import images (including TIFF stacks and CZI files) or videos (MP4/AVI/MOV).</li>
             <li>For multi-dimensional images, you'll be prompted to assign dimensions (e.g., T for time, Z for depth, C for channels).</li>
             <li>Use "Add Classes" to define classes of interest.</li>
             <li>Start annotating by selecting a class and using the Polygon, Rectangle Tool, or SAM-Assisted tool.</li>

--- a/src/digitalsreeni_image_annotator/ui/menu_bar.py
+++ b/src/digitalsreeni_image_annotator/ui/menu_bar.py
@@ -151,6 +151,10 @@ def build_menu_bar(window):
     dicom_converter_action.triggered.connect(window.show_dicom_converter)
     tools_menu.addAction(dicom_converter_action)
 
+    export_frames_action = QAction("Export Annotated Video Frames…", window)
+    export_frames_action.triggered.connect(window.export_annotated_frames)
+    tools_menu.addAction(export_frames_action)
+
     tools_menu.addSeparator()
 
     unload_models_action = QAction("Unload AI Models (Free GPU Memory)", window)

--- a/src/digitalsreeni_image_annotator/ui/sidebar.py
+++ b/src/digitalsreeni_image_annotator/ui/sidebar.py
@@ -32,6 +32,7 @@ from ..core.constants import (
     ANNOT_COL_ID,
 )
 from ..dialogs.dino_phrase_editor import ClassThresholdTable, PhraseEditorPanel
+from ..widgets.video_timeline import VideoTimeline
 
 
 def _section_header(text):
@@ -368,6 +369,13 @@ def build_image_area(window):
     window.scroll_area.setWidget(window.image_label)
 
     window.image_layout.addWidget(window.scroll_area)
+
+    # Video scrub timeline (issue #48) sits BETWEEN the canvas and the zoom
+    # slider; hidden until a video is the active image (update_video_timeline).
+    window.video_timeline = VideoTimeline()
+    window.video_timeline.setVisible(False)
+    window.video_timeline.frameSelected.connect(window.on_timeline_frame_selected)
+    window.image_layout.addWidget(window.video_timeline)
 
     window.zoom_slider = QSlider(Qt.Orientation.Horizontal)
     window.zoom_slider.setMinimum(10)

--- a/src/digitalsreeni_image_annotator/ui/sidebar.py
+++ b/src/digitalsreeni_image_annotator/ui/sidebar.py
@@ -86,7 +86,7 @@ def build_sidebar(window):
     # Add spacing
     window.sidebar_layout.addSpacing(20)
 
-    window.add_images_button = QPushButton("Add New Images")
+    window.add_images_button = QPushButton("Add Images / Videos")
     window.add_images_button.clicked.connect(window.add_images)
     window.sidebar_layout.addWidget(window.add_images_button)
 

--- a/src/digitalsreeni_image_annotator/widgets/video_timeline.py
+++ b/src/digitalsreeni_image_annotator/widgets/video_timeline.py
@@ -9,9 +9,13 @@ pure VIEW — it never changes any frame itself. User interaction emits
 ``set_current_frame`` (which must NOT re-emit ``frameSelected``, or it would
 re-enter ``switch_slice``).
 
-Colours come exclusively from the widget PALETTE (``highlight`` / ``mid`` /
-``text``), never colour literals, so the marks stay visible in both the light
-and soft-dark themes (No Hardcoded Colors Rule, CLAUDE.md).
+Colours come from the widget PALETTE (``highlight`` / ``mid`` / ``text``), never
+colour literals (No Hardcoded Colors Rule, CLAUDE.md). Note the app themes via a
+QSS stylesheet and never calls ``setPalette``, so ``highlight``/``mid`` resolve
+to the *static default* palette (a saturated accent + mid-grey that both read on
+the light and soft-dark backgrounds), while the ``text`` role — used for the
+high-contrast current-frame tick — does follow the stylesheet's ``color`` rule.
+The marks are legible in both themes; the current tick additionally tracks it.
 
 A follow-up (issue #51) may extend ``set_annotated_frames`` to carry per-frame
 states (e.g. reviewed vs. auto-accepted) — kept deliberately simple here.

--- a/src/digitalsreeni_image_annotator/widgets/video_timeline.py
+++ b/src/digitalsreeni_image_annotator/widgets/video_timeline.py
@@ -1,0 +1,252 @@
+"""Video timeline scrub bar with annotated-frame markers (issue #48).
+
+A dumb, self-contained widget with **no main-window reference**: it renders a
+horizontal scrub slider, a thin marker strip that ticks every annotated frame
+plus the current one, and a ``F i/N  •  MM:SS / MM:SS`` position label. It is a
+pure VIEW — it never changes any frame itself. User interaction emits
+``frameSelected(idx)`` and the orchestrator routes that through the normal
+``ImageController.switch_slice`` path; programmatic sync comes back via
+``set_current_frame`` (which must NOT re-emit ``frameSelected``, or it would
+re-enter ``switch_slice``).
+
+Colours come exclusively from the widget PALETTE (``highlight`` / ``mid`` /
+``text``), never colour literals, so the marks stay visible in both the light
+and soft-dark themes (No Hardcoded Colors Rule, CLAUDE.md).
+
+A follow-up (issue #51) may extend ``set_annotated_frames`` to carry per-frame
+states (e.g. reviewed vs. auto-accepted) — kept deliberately simple here.
+"""
+
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtGui import QPainter, QPen
+from PyQt6.QtWidgets import (
+    QHBoxLayout,
+    QLabel,
+    QSizePolicy,
+    QSlider,
+    QVBoxLayout,
+    QWidget,
+)
+
+# fps guard: containers sometimes report 0/NaN fps; treat as 30 for MM:SS.
+_DEFAULT_FPS = 30.0
+
+
+class _MarkerStrip(QWidget):
+    """Thin painted strip that ticks annotated frames + the current frame.
+
+    Holds only its own render state (total / current / annotated set); the
+    parent :class:`VideoTimeline` pushes updates via :meth:`configure`.
+    """
+
+    _STRIP_HEIGHT = 6
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setFixedHeight(self._STRIP_HEIGHT)
+        self.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed
+        )
+        self._total = 0
+        self._current = 0
+        self._annotated = set()
+
+    def configure(self, total, current, annotated):
+        self._total = total
+        self._current = current
+        self._annotated = annotated
+        self.update()
+
+    def _x_for(self, idx, width):
+        # Guard total <= 1: a single (or zero) frame maps to the left edge
+        # rather than dividing by zero.
+        if self._total <= 1:
+            return 0
+        return int(idx / (self._total - 1) * (width - 1))
+
+    def paintEvent(self, event):
+        painter = QPainter(self)
+        pal = self.palette()
+        width = self.width()
+        height = self.height()
+
+        # Track baseline (mid) — theme-aware grey.
+        painter.setPen(QPen(pal.mid().color(), 1))
+        mid_y = height // 2
+        painter.drawLine(0, mid_y, width, mid_y)
+
+        if self._total <= 0:
+            return
+
+        # Annotated frames: 1px highlight (accent) ticks spanning the strip.
+        painter.setPen(QPen(pal.highlight().color(), 1))
+        for idx in self._annotated:
+            if 0 <= idx < self._total:
+                x = self._x_for(idx, width)
+                painter.drawLine(x, 0, x, height)
+
+        # Current frame: a distinct, high-contrast 2px tick. `text()` always
+        # contrasts the widget background in both themes, so it reads clearly
+        # over the accent-coloured annotated marks.
+        if 0 <= self._current < self._total:
+            painter.setPen(QPen(pal.text().color(), 2))
+            x = self._x_for(self._current, width)
+            painter.drawLine(x, 0, x, height)
+
+
+class VideoTimeline(QWidget):
+    """Scrub slider + annotated-frame markers + position label (issue #48).
+
+    Public API (relied on by the wiring in :mod:`annotator_window` and by the
+    #51 follow-up):
+
+    - ``set_video(total_frames: int, fps: float)``
+    - ``set_current_frame(idx: int)`` — programmatic, never emits ``frameSelected``
+    - ``set_annotated_frames(indices: set[int])``
+    - ``clear()``
+    - signal ``frameSelected = pyqtSignal(int)`` — user interaction only
+    - attribute ``annotated_frames`` — the stored annotated-index set
+    """
+
+    frameSelected = pyqtSignal(int)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._total_frames = 0
+        self._fps = _DEFAULT_FPS
+        self._current_frame = 0
+        # Re-entrancy guard: set True around programmatic slider.setValue so the
+        # resulting valueChanged never re-emits frameSelected (feedback loop).
+        self._updating = False
+        self.annotated_frames = set()
+
+        root = QHBoxLayout(self)
+        root.setContentsMargins(0, 0, 0, 0)
+
+        # Strip stacked directly on top of the slider so ticks line up with the
+        # groove.
+        bar = QVBoxLayout()
+        bar.setContentsMargins(0, 0, 0, 0)
+        bar.setSpacing(0)
+
+        self.strip = _MarkerStrip()
+        bar.addWidget(self.strip)
+
+        self.slider = QSlider(Qt.Orientation.Horizontal)
+        self.slider.setMinimum(0)
+        self.slider.setMaximum(0)
+        # Never swallow the arrow keys used for slice navigation.
+        self.slider.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+        bar.addWidget(self.slider)
+
+        root.addLayout(bar, 1)
+
+        self.label = QLabel()
+        root.addWidget(self.label)
+
+        # valueChanged covers keyboard/track-click/programmatic-user moves;
+        # gated on `not _updating` (no feedback loop) and `not isSliderDown`
+        # (throttle live scrub — each switch triggers a lazy frame decode, so we
+        # emit the drag's final position via sliderReleased instead of every
+        # intermediate frame).
+        self.slider.valueChanged.connect(self._on_value_changed)
+        self.slider.sliderReleased.connect(self._on_slider_released)
+
+        self._update_label()
+
+    # ── configuration ───────────────────────────────────────────────────────
+
+    def set_video(self, total_frames, fps):
+        """Configure for a video of ``total_frames`` frames at ``fps``.
+
+        Resets the marker set and the slider range (0..max(0, total-1)); the fps
+        guard keeps MM:SS finite when a container reports 0/NaN fps.
+        """
+        self._total_frames = max(0, int(total_frames))
+        self._fps = fps if fps and fps > 0 else _DEFAULT_FPS
+        self._current_frame = 0
+        self.annotated_frames = set()
+
+        self._updating = True
+        self.slider.setMaximum(max(0, self._total_frames - 1))
+        self.slider.setValue(0)
+        self._updating = False
+
+        self._refresh_strip()
+        self._update_label()
+
+    def set_current_frame(self, idx):
+        """Programmatically sync the slider/label/strip to frame ``idx``.
+
+        MUST NOT emit ``frameSelected`` — this is called from ``switch_slice``
+        and emitting would re-enter it (feedback loop). The ``_updating`` guard
+        suppresses the valueChanged emission.
+        """
+        self._current_frame = int(idx)
+        self._updating = True
+        self.slider.setValue(self._current_frame)
+        self._updating = False
+        self._refresh_strip()
+        self._update_label()
+
+    def set_annotated_frames(self, indices):
+        """Store the annotated-frame index set and repaint the strip.
+
+        Kept simple (a plain set of ints); issue #51 may extend this to carry
+        per-frame states.
+        """
+        self.annotated_frames = set(indices)
+        self._refresh_strip()
+
+    def clear(self):
+        """Reset to the empty state (no video)."""
+        self._total_frames = 0
+        self._fps = _DEFAULT_FPS
+        self._current_frame = 0
+        self.annotated_frames = set()
+        self._updating = True
+        self.slider.setMaximum(0)
+        self.slider.setValue(0)
+        self._updating = False
+        self._refresh_strip()
+        self._update_label()
+
+    # ── user-interaction handlers ───────────────────────────────────────────
+
+    def _on_value_changed(self, value):
+        # Suppress programmatic syncs (feedback loop) and live-drag intermediate
+        # steps (throttle — sliderReleased emits the final drag position).
+        if self._updating or self.slider.isSliderDown():
+            return
+        self._emit(value)
+
+    def _on_slider_released(self):
+        self._emit(self.slider.value())
+
+    def _emit(self, value):
+        self._current_frame = int(value)
+        self._refresh_strip()
+        self._update_label()
+        self.frameSelected.emit(int(value))
+
+    # ── rendering helpers ───────────────────────────────────────────────────
+
+    def _refresh_strip(self):
+        self.strip.configure(
+            self._total_frames, self._current_frame, self.annotated_frames
+        )
+
+    def _fmt_time(self, idx):
+        fps = self._fps if self._fps and self._fps > 0 else _DEFAULT_FPS
+        minutes, seconds = divmod(int(idx / fps), 60)
+        return f"{minutes:02d}:{seconds:02d}"
+
+    def _update_label(self):
+        if self._total_frames <= 0:
+            self.label.setText("")
+            return
+        last = self._total_frames - 1
+        self.label.setText(
+            f"F {self._current_frame + 1}/{self._total_frames}  •  "
+            f"{self._fmt_time(self._current_frame)} / {self._fmt_time(last)}"
+        )

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -40,6 +40,7 @@ INTERNAL_MODULES = [
     "digitalsreeni_image_annotator.controllers.annotation_history",
     # Widgets
     "digitalsreeni_image_annotator.widgets.image_label",
+    "digitalsreeni_image_annotator.widgets.video_timeline",
     # Inference
     "digitalsreeni_image_annotator.inference.sam_utils",
     "digitalsreeni_image_annotator.inference.dino_utils",

--- a/tests/integration/test_video_loading.py
+++ b/tests/integration/test_video_loading.py
@@ -204,7 +204,7 @@ def test_video_roundtrip_save_reload(
 def test_add_images_button_path_accepts_and_loads_video(
     window, make_test_video, tmp_path, monkeypatch
 ):
-    """The visible "Add New Images" button (``add_images``) must let the user
+    """The visible "Add Images / Videos" button (``add_images``) must let the user
     pick AND load a video.
 
     Regression for the #47/#48 gap: ``add_images`` — the only method the

--- a/tests/integration/test_video_loading.py
+++ b/tests/integration/test_video_loading.py
@@ -199,3 +199,45 @@ def test_video_roundtrip_save_reload(
     assert reloaded["video_metadata"]["total_frames"] == handler.total_frames
     # Reload rebuilt the lazy frame slices.
     assert isinstance(window.image_slices["clip"], LazySliceList)
+
+
+def test_add_images_button_path_accepts_and_loads_video(
+    window, make_test_video, tmp_path, monkeypatch
+):
+    """The visible "Add New Images" button (``add_images``) must let the user
+    pick AND load a video.
+
+    Regression for the #47/#48 gap: ``add_images`` — the only method the
+    sidebar button is wired to — kept an image-only file filter
+    (``*.png…*.czi``), so no ``.mp4/.avi/.mov`` could be selected even though
+    the downstream ``add_images_to_list`` fully supports video. The earlier
+    video tests all called ``add_images_to_list``/``load_video`` directly and
+    so drove *below* the dialog, missing this. This drives the full button
+    path: the dialog's filter must offer the video extensions, and a selected
+    video must load as lazy frame slices.
+    """
+    path = make_test_video(tmp_path, name="clip.avi", frames=8)
+
+    captured = {}
+
+    def fake_get_open(parent, caption, directory, filt):
+        captured["filter"] = filt
+        return ([path], "")
+
+    monkeypatch.setattr(
+        QFileDialog, "getOpenFileNames", staticmethod(fake_get_open)
+    )
+    monkeypatch.setattr(
+        QMessageBox, "question",
+        staticmethod(lambda *a, **k: QMessageBox.StandardButton.Yes),
+    )
+    for m in ("information", "warning", "critical"):
+        monkeypatch.setattr(QMessageBox, m, staticmethod(lambda *a, **k: None))
+
+    window.add_images()
+
+    # The dialog must offer the video container extensions...
+    filt = captured["filter"].lower()
+    assert ".mp4" in filt and ".avi" in filt and ".mov" in filt
+    # ...and the selected video must actually load as lazy frame slices.
+    assert isinstance(window.image_slices.get("clip"), LazySliceList)

--- a/tests/integration/test_video_timeline_wiring.py
+++ b/tests/integration/test_video_timeline_wiring.py
@@ -84,6 +84,30 @@ def test_annotating_a_frame_lights_its_mark(
     assert 2 in window.video_timeline.annotated_frames
 
 
+def test_annotation_refresh_does_not_emit_frame_selected(
+    window, make_test_video, tmp_path, no_native_dialogs
+):
+    """An annotation mutation refreshes the timeline (update_slice_list_colors ->
+    update_video_timeline -> set_video + set_current_frame) but must NOT emit
+    frameSelected, which would re-enter switch_slice and jump the frame."""
+    n = _load_video(window, make_test_video, tmp_path)
+    assert n >= 4
+    window.add_class("cell", QColor("#ff0000"))
+    window.image_controller.switch_slice(window.slice_list.item(3))
+    assert window.current_slice.endswith("_F00003")
+
+    emitted = []
+    window.video_timeline.frameSelected.connect(emitted.append)
+    # Real mutation path: annotate + save routes through update_slice_list_colors,
+    # which is the timeline-refresh hook.
+    window.image_label.annotations = {"cell": [dict(POLY)]}
+    window.save_current_annotations()
+
+    assert emitted == []                             # no feedback loop
+    assert window.current_slice.endswith("_F00003")  # frame unchanged
+    assert 3 in window.video_timeline.annotated_frames
+
+
 def test_timeline_hidden_for_plain_image(
     window, make_test_video, tmp_path, no_native_dialogs
 ):

--- a/tests/integration/test_video_timeline_wiring.py
+++ b/tests/integration/test_video_timeline_wiring.py
@@ -1,0 +1,132 @@
+"""Integration tests for the video-timeline wiring + frame export (issue #48).
+
+Drives a full offscreen ``ImageAnnotator``: loading a video shows the timeline,
+a user scrub routes through ``switch_slice``, annotating a frame lights its mark,
+switching to a plain image hides the timeline, and the Tools-menu frame export
+writes exactly the annotated frames.
+
+Uses the shared ``make_test_video`` fixture (tests/conftest.py). Modal dialogs
+are neutralised by ``no_native_dialogs`` (an offscreen modal hangs the run).
+"""
+
+import pytest
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QColor, QImage
+from PyQt6.QtWidgets import QFileDialog, QMessageBox
+
+from digitalsreeni_image_annotator.core.video_handler import frame_key
+
+
+POLY = {"segmentation": [1.0, 1.0, 10.0, 1.0, 10.0, 8.0], "area": 31.5,
+        "category_id": 1, "category_name": "cell", "number": 1}
+
+
+@pytest.fixture
+def window(qt_application):
+    from digitalsreeni_image_annotator.annotator_window import ImageAnnotator
+
+    w = ImageAnnotator()
+    w.auto_save = lambda: None  # no project file → skip recovery-snapshot writes
+    yield w
+    w.deleteLater()
+
+
+@pytest.fixture
+def no_native_dialogs(monkeypatch):
+    """Hard safety net: no modal may open in an offscreen run (it hangs)."""
+    monkeypatch.setattr(
+        QMessageBox, "question",
+        staticmethod(lambda *a, **k: QMessageBox.StandardButton.Yes),
+    )
+    for m in ("information", "warning", "critical"):
+        monkeypatch.setattr(QMessageBox, m, staticmethod(lambda *a, **k: None))
+
+
+def _load_video(window, make_test_video, tmp_path):
+    path = make_test_video(tmp_path, name="clip.avi", frames=8)
+    window.image_controller.add_images_to_list([path])
+    return window.video_handlers["clip"].total_frames
+
+
+def test_timeline_shown_for_video(window, make_test_video, tmp_path, no_native_dialogs):
+    _load_video(window, make_test_video, tmp_path)
+    window.update_video_timeline()
+    # Under offscreen isVisible() is unreliable; isHidden() reflects the
+    # explicit setVisible(True) the wiring performs.
+    assert not window.video_timeline.isHidden()
+
+
+def test_timeline_frame_selected_routes_through_switch_slice(
+    window, make_test_video, tmp_path, no_native_dialogs
+):
+    n = _load_video(window, make_test_video, tmp_path)
+    assert n >= 4
+
+    # A user scrub emits frameSelected → on_timeline_frame_selected → switch_slice.
+    window.video_timeline.frameSelected.emit(3)
+    assert window.current_slice.endswith("_F00003")
+
+
+def test_annotating_a_frame_lights_its_mark(
+    window, make_test_video, tmp_path, no_native_dialogs
+):
+    n = _load_video(window, make_test_video, tmp_path)
+    assert n >= 4
+    window.add_class("cell", QColor("#ff0000"))
+
+    # Annotate frame 2 through the normal save path.
+    window.image_controller.switch_slice(window.slice_list.item(2))
+    window.image_label.annotations = {"cell": [dict(POLY)]}
+    window.save_current_annotations()  # routes through update_slice_list_colors
+
+    assert 2 in window.image_controller.annotated_frame_indices("clip")
+    # save_current_annotations refreshed the timeline via the mark choke point.
+    assert 2 in window.video_timeline.annotated_frames
+
+
+def test_timeline_hidden_for_plain_image(
+    window, make_test_video, tmp_path, no_native_dialogs
+):
+    _load_video(window, make_test_video, tmp_path)
+
+    png = tmp_path / "plain.png"
+    plain = QImage(6, 5, QImage.Format.Format_RGB888)
+    plain.fill(QColor("darkGreen"))
+    plain.save(str(png))
+    window.image_controller.add_images_to_list([str(png)])
+
+    # Switch to the plain image → timeline hides.
+    items = window.image_list.findItems("plain.png", Qt.MatchFlag.MatchExactly)
+    assert items
+    window.image_controller.switch_image(items[0])
+    assert window.video_timeline.isHidden()
+
+
+def test_export_annotated_frames_writes_only_annotated(
+    window, make_test_video, tmp_path, no_native_dialogs, monkeypatch
+):
+    n = _load_video(window, make_test_video, tmp_path)
+    assert n >= 6
+    window.add_class("cell", QColor("#ff0000"))
+
+    def annotate(idx):
+        window.image_controller.switch_slice(window.slice_list.item(idx))
+        window.image_label.annotations = {"cell": [dict(POLY)]}
+        window.save_current_annotations()
+
+    annotate(2)
+    annotate(5)
+
+    out_dir = tmp_path / "frames_out"
+    out_dir.mkdir()
+    monkeypatch.setattr(
+        QFileDialog, "getExistingDirectory", staticmethod(lambda *a, **k: str(out_dir))
+    )
+
+    window.export_annotated_frames()
+
+    written = sorted(p.name for p in out_dir.glob("*.png"))
+    assert written == [f"{frame_key('clip', 2)}.png", f"{frame_key('clip', 5)}.png"]
+    for name in written:
+        img = QImage(str(out_dir / name))
+        assert not img.isNull()

--- a/tests/unit/test_video_handler.py
+++ b/tests/unit/test_video_handler.py
@@ -15,8 +15,10 @@ from digitalsreeni_image_annotator.core.slice_cache import (
     get_shared_lru,
 )
 from digitalsreeni_image_annotator.core.video_handler import (
+    VIDEO_EXTS,
     VideoHandler,
     VideoSliceProvider,
+    file_dialog_filter,
     frame_key,
     is_video,
     parse_frame_index,
@@ -28,6 +30,18 @@ from digitalsreeni_image_annotator.core.video_handler import (
 def test_frame_key_zero_padded():
     assert frame_key("v", 42) == "v_F00042"
     assert frame_key("clip", 0) == "clip_F00000"
+
+
+def test_file_dialog_filter_covers_every_video_ext():
+    """The open-dialog filter must offer every registered video container, so
+    the app can't silently accept a format the file picker never shows (the
+    #47 gap). Guards the VIDEO_EXTS-derived globs in file_dialog_filter():
+    add an ext to VIDEO_EXTS and this fails until the filter covers it."""
+    filt = file_dialog_filter()
+    for ext in VIDEO_EXTS:
+        assert f"*{ext}" in filt, f"{ext} missing from the open-dialog filter"
+    # ...and it advertises videos, not just images.
+    assert "Videos" in filt
 
 
 def test_parse_frame_index_roundtrip():

--- a/tests/unit/test_video_timeline.py
+++ b/tests/unit/test_video_timeline.py
@@ -1,0 +1,92 @@
+"""Unit tests for the VideoTimeline widget (issue #48).
+
+Widget-only: exercises ``widgets/video_timeline.py`` with no main window. The
+critical invariants are (1) ``set_current_frame`` NEVER re-emits
+``frameSelected`` (a feedback loop back into ``switch_slice``), (2) genuine user
+interaction DOES emit it exactly once, and (3) the fps guard keeps MM:SS finite.
+"""
+
+import pytest
+
+from digitalsreeni_image_annotator.widgets.video_timeline import VideoTimeline
+
+
+@pytest.fixture
+def timeline(qt_application):
+    tl = VideoTimeline()
+    yield tl
+    tl.deleteLater()
+
+
+def test_set_video_configures_slider_range(timeline):
+    timeline.set_video(100, 25.0)
+    assert timeline.slider.minimum() == 0
+    assert timeline.slider.maximum() == 99
+
+
+def test_set_current_frame_does_not_emit(timeline):
+    """Programmatic sync (from switch_slice) must NOT emit frameSelected —
+    otherwise it re-enters switch_slice (feedback loop)."""
+    timeline.set_video(100, 25.0)
+    emitted = []
+    timeline.frameSelected.connect(emitted.append)
+
+    timeline.set_current_frame(50)
+
+    assert emitted == []
+    assert timeline.slider.value() == 50
+
+
+def test_user_slider_move_emits_once(timeline):
+    """A user-driven slider change (not programmatic, not a live drag) emits
+    frameSelected exactly once."""
+    timeline.set_video(100, 25.0)
+    emitted = []
+    timeline.frameSelected.connect(emitted.append)
+
+    # _updating is False and the handle isn't held down → valueChanged is a
+    # genuine user move.
+    timeline.slider.setValue(50)
+
+    assert emitted == [50]
+
+
+def test_label_shows_mmss_at_frame(timeline):
+    """Frame 50 @ 25 fps is 2.0 s → 00:02 appears in the position label."""
+    timeline.set_video(100, 25.0)
+    timeline.set_current_frame(50)
+    assert "00:02" in timeline.label.text()
+
+
+def test_set_annotated_frames_stores(timeline):
+    timeline.set_video(100, 25.0)
+    timeline.set_annotated_frames({0, 99})
+    assert timeline.annotated_frames == {0, 99}
+
+
+def test_set_video_resets_annotated_marks(timeline):
+    timeline.set_video(100, 25.0)
+    timeline.set_annotated_frames({3, 4})
+    timeline.set_video(50, 30.0)  # reconfigure → marks reset
+    assert timeline.annotated_frames == set()
+
+
+def test_zero_fps_does_not_divide_by_zero(timeline):
+    """A 0/NaN fps container must not ZeroDivisionError; fps is guarded to 30."""
+    timeline.set_video(10, 0)
+    timeline.set_current_frame(5)  # _fmt_time would divide by zero without guard
+    assert timeline.label.text()  # non-empty, finite MM:SS
+
+
+def test_clear_resets_and_emits_nothing(timeline):
+    timeline.set_video(100, 25.0)
+    timeline.set_annotated_frames({1, 2})
+    emitted = []
+    timeline.frameSelected.connect(emitted.append)
+
+    timeline.clear()
+
+    assert emitted == []
+    assert timeline.annotated_frames == set()
+    assert timeline.slider.maximum() == 0
+    assert timeline.label.text() == ""

--- a/tests/unit/test_video_timeline.py
+++ b/tests/unit/test_video_timeline.py
@@ -24,6 +24,24 @@ def test_set_video_configures_slider_range(timeline):
     assert timeline.slider.maximum() == 99
 
 
+def test_set_video_clamp_does_not_emit(qt_application):
+    # THE feedback-loop invariant: set_video reconfigures the range, and if a
+    # smaller total clamps a non-zero slider value Qt fires valueChanged. The
+    # _updating guard must swallow it, or reconfiguring the timeline on an
+    # annotation mutation would spuriously emit frameSelected -> switch_slice
+    # -> jump to frame 0.
+    from digitalsreeni_image_annotator.widgets.video_timeline import VideoTimeline
+
+    tl = VideoTimeline()
+    tl.set_video(100, 25.0)
+    tl.set_current_frame(80)          # slider now at 80
+    emitted = []
+    tl.frameSelected.connect(emitted.append)
+    tl.set_video(10, 25.0)            # setMaximum(9) clamps 80 -> 9 (valueChanged)
+    assert emitted == []              # guard swallowed the clamp emission
+    tl.deleteLater()
+
+
 def test_set_current_frame_does_not_emit(timeline):
     """Programmatic sync (from switch_slice) must NOT emit frameSelected —
     otherwise it re-enters switch_slice (feedback loop)."""


### PR DESCRIPTION
## Summary

A proper timeline under the canvas for videos: a scrub slider, `F i/N • MM:SS / MM:SS` counter, marks on annotated frames, Home/End nav, and a "Tools → Export Annotated Video Frames…" action. The timeline is a **view** over the C1 frame/slice machinery — it never becomes a second source of truth for the current frame.

- `widgets/video_timeline.py::VideoTimeline` — dumb, no main-window ref: scrub `QSlider` + `_MarkerStrip` (palette-only ticks) + label. `frameSelected(int)` on user interaction only; `set_current_frame`/`set_video` are `_updating`-guarded so programmatic syncs (from `switch_slice`) never re-emit → **no feedback loop**. Slider `NoFocus`.
- Wiring: `build_image_area` inserts it between canvas and zoom slider; `frameSelected → on_timeline_frame_selected → switch_slice` (never a direct `current_image` write). `ImageController.current_video()` + `update_video_timeline()` (hooked at the `update_slice_list_colors` choke point → marks refresh on every mutation) + `annotated_frame_indices()`. Home/End in `keyPressEvent` (video + focus gated). `io_controller.export_annotated_frames` decodes one frame at a time.

## Verification

- Full suite **758 passed / 3 skipped** (+16 tests). Ruff clean (pre-existing `annotator_window` F401 baseline only).
- **Senior review** (no P0): the P1 (test gap on the `set_video`-clamp-no-emit invariant — THE feedback-loop risk) is now locked by a widget clamp test + a real annotate→save no-emit wiring test; P2s (3-way lookup consolidated into `current_video()`, export failure-counting, corrected dark-mode reasoning) done.

## Docs

`docs/05/06/08` + CLAUDE.md (Home/End shortcut, `video_timeline.py` in the tree). No new ADR (design didn't deviate architecturally).

## Phase chain

**Phase 6**, base = `feature/video-frames-as-slices` (Phase 5 / #47). #51 reuses this widget for tracked/needs-review segments.

Closes #48

🧙 Built with [WOZCODE](https://wozcode.com)