### PR TITLE
feat: SAM 3 text-prompt segmentation reusing the DINO review pipeline (#50)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ src/digitalsreeni_image_annotator/
 │   ├── video_timeline.py         # VideoTimeline scrub bar + frame markers (#48)
 │   └── tools/                    # Per-tool handlers (ADR-019): rectangle,
 │                                 #   polygon, paint, eraser
-├── inference/                    # sam_utils.py, dino_utils.py
+├── inference/                    # sam_utils.py, dino_utils.py, sam3_utils.py (ADR-039)
 ├── training/                     # SAM fine-tuning (ADR-021): sam_trainer.py
 │                                 #   (SAMFineTuner), sam_dataset.py;
 │                                 #   lr_schedule.py + early_stop.py (ADR-028)
@@ -88,6 +88,7 @@ src/digitalsreeni_image_annotator/
 | `DINOController` | controllers/dino_controller.py | DINO single/batch detection, batch review, temp-class workflow |
 | `YOLOController` | controllers/yolo_controller.py | YOLO training menu + prediction wiring |
 | `SAMUtils` | inference/sam_utils.py | Load SAM models (built-in + fine-tuned), run inference |
+| `SAM3Utils` | inference/sam3_utils.py | SAM 3 text-prompt segmentation (`SAM3SemanticPredictor`); a second producer into the DINO review pipeline, gated `sam3.pt` (ADR-038/039, #50) |
 | `DINOUtils` | inference/dino_utils.py | Grounding-DINO model load + inference |
 | `SAMFineTuner` | training/sam_trainer.py | Fine-tune SAM 2 decoder/encoder via custom loop over Ultralytics SAM2Model (ADR-021) |
 | `SAMTrainController` | controllers/sam_train_controller.py | SAM fine-tune menu, GPU gate, training thread, selector registration |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ src/digitalsreeni_image_annotator/
 | `DINOController` | controllers/dino_controller.py | DINO single/batch detection, batch review, temp-class workflow |
 | `YOLOController` | controllers/yolo_controller.py | YOLO training menu + prediction wiring |
 | `SAMUtils` | inference/sam_utils.py | Load SAM models (built-in + fine-tuned), run inference |
-| `SAM3Utils` | inference/sam3_utils.py | SAM 3 text-prompt segmentation (`SAM3SemanticPredictor`); a second producer into the DINO review pipeline, gated `sam3.pt` (ADR-038/039, #50) |
+| `SAM3Utils` | inference/sam3_utils.py | SAM 3 text-prompt segmentation (`SAM3SemanticPredictor`); a second producer into the DINO review pipeline, gated `sam3.pt` (ADR-038/039, #50). First SAM 3 use pip-installs `clip`+`timm` via ultralytics AutoUpdate (needs network; completes in-process, no restart needed); overrides force `save=False`/`verbose=False` to avoid `runs/` clutter. Real-model check verified 2026-07-22 on an RTX 4070 |
 | `DINOUtils` | inference/dino_utils.py | Grounding-DINO model load + inference |
 | `SAMFineTuner` | training/sam_trainer.py | Fine-tune SAM 2 decoder/encoder via custom loop over Ultralytics SAM2Model (ADR-021) |
 | `SAMTrainController` | controllers/sam_train_controller.py | SAM fine-tune menu, GPU gate, training thread, selector registration |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ python -m src.digitalsreeni_image_annotator.main
 
 ## Tech Stack
 
-Python 3.10+ | PyQt6 6.7+ | Ultralytics >=8.3.27,<9 (SAM 2) | NumPy | OpenCV | Shapely
+Python 3.10+ | PyQt6 6.7+ | Ultralytics >=8.3.237,<9 (SAM 2 / SAM 3) | NumPy | OpenCV | Shapely
 
 **Test suite**: `tests/` (pytest + pytest-qt). 688 tests pass on PyQt6 (3 skipped).
 

--- a/docs/05_building_block_view.md
+++ b/docs/05_building_block_view.md
@@ -51,9 +51,10 @@ src/digitalsreeni_image_annotator/
 	│       ├── eraser_tool.py
 	│       └── keypoint_tool.py       # KeypointTool - pose placement (ADR-029, #35)
 	├── controllers/                   # Project/Image/SAM/DINO/YOLO/Annotation/Class
-	├── inference/                     # sam_utils.py, dino_utils.py
+	├── inference/                     # sam_utils.py, dino_utils.py, sam3_utils.py
 	│   ├── sam_utils.py
-	│   └── dino_utils.py
+	│   ├── dino_utils.py
+	│   └── sam3_utils.py              # SAM3Utils - text-prompt segmentation (ADR-038/039, #50)
 	├── io/                            # export_formats.py, import_formats.py
 	│   ├── export_formats.py
 	│   └── import_formats.py
@@ -246,7 +247,8 @@ the controller graph.
 | `AnnotationController` | Annotation CRUD, list sorting, highlight, edit-mode entry/exit, `finish_polygon`, `finish_rectangle`, `replace_annotations` (eraser path). Validates writes before mutating `all_annotations`. |
 | `ClassController` | Class add / delete / rename / colour / visibility. `update_slice_list_colors`, `is_class_visible`. |
 | `SAMController` | SAM box/points tool lifecycle, debounce timer, `_sam_inference_in_flight` re-entrancy guard (ADR-013), model picker. |
-| `DINOController` | Single + batch detection, batch review navigation, temp-annotation accept/reject, custom-model browse, `DINOReviewEventFilter` ownership (ADR-015). |
+| `DINOController` | Single + batch detection, batch review navigation, temp-annotation accept/reject, custom-model browse, `DINOReviewEventFilter` ownership (ADR-015). **Dual-backend (ADR-039):** `_run_text_detection` routes to either the Grounding-DINO two-stage path OR SAM 3's one-stage `SAM3Utils.detect_text` (the "SAM 3 (text prompt)" picker entry); both feed the same review/batch/accept pipeline. |
+| `SAM3Utils` | inference/sam3_utils.py — in-process Ultralytics `SAM3SemanticPredictor` wrapper (text→masks). Reuses `SAMUtils`'s `_run_sync`/`_qimage_to_numpy`/`_mask_to_polygon` + shared in-flight flag; gated `sam3.pt` (never auto-downloaded). ADR-038/039, #50. |
 | `YOLOController` | Training menu, `TrainingThread`, prediction dialog, result processing. Surfaces the run's MLflow deep link (`_on_mlflow_run_url`, mirrors SAM) and reports the saved `best.pt` path on completion. |
 | `SAMTrainController` | SAM fine-tuning menu, GPU gate, `SAMTrainingThread`, config dialog, registers fine-tuned checkpoints into the SAM selector (ADR-021). |
 | `io_controller` *(module-level functions, not a class)* | Thin UI wrappers around the pure `io/export_formats.py` and `io/import_formats.py` modules. |

--- a/docs/06_runtime_view.md
+++ b/docs/06_runtime_view.md
@@ -381,9 +381,19 @@ User accepts prediction
     └─> Clear SAM state, reset to normal mode
 ```
 
-## LLM-Assisted Detection (Grounding DINO + SAM)
+## LLM-Assisted Detection (Grounding DINO + SAM, or SAM 3 one-stage)
 
-End-to-end flow when the user clicks "Detect Current Image" in the DINO panel:
+The DINO panel's model picker chooses the **producer** (ADR-039): the
+Grounding-DINO two-stage path below, or **"SAM 3 (text prompt)"** which does
+text→masks in ONE stage. `DINOController._run_text_detection(qimage)` is the
+fork: for SAM 3 it calls `SAM3Utils.detect_text` and splits each instance into
+the `(results, sam_results)` shape the DINO pipeline already zips; for DINO it
+runs the two stages. Everything after the fork — temp-annotation overlay,
+Enter/Escape accept/reject, batch over images+slices, auto-accept, persistence —
+is identical. SAM 3 skips the "No SAM Model" guard (it needs no SAM 2 refinement)
+and its temps carry `source: "sam3"`; the Grounding-DINO flow is unchanged:
+
+End-to-end flow when the user clicks "Detect Current Image" with a DINO model:
 
 ```
 User clicks "Detect Current Image"

--- a/docs/08_crosscutting_concepts.md
+++ b/docs/08_crosscutting_concepts.md
@@ -632,6 +632,14 @@ diagnostic channel, dialogs are the user channel; the two are independent
 
 ## DINO Temp Annotations — Single Field, Many Images
 
+> **Two producers (ADR-039):** the temp-annotation pipeline is fed by BOTH the
+> Grounding-DINO two-stage path and SAM 3's one-stage `SAM3Utils.detect_text`.
+> Temps are tagged `source: "dino"` or `source: "sam3"`; every `source ==`
+> check (the `DINOReviewEventFilter` Enter/Escape gate, commit/store/accept)
+> is `in ("dino", "sam3")`. SAM 3 batch results share the SAME
+> `dino_batch_results` dict, so the single-field re-sync rule below applies to
+> both unchanged.
+
 `ImageLabel.temp_annotations` is a **single list on the image_label**,
 not a per-image cache. It holds the pending DINO+SAM masks shown as
 an overlay while the user decides accept/reject. The per-image batch

--- a/docs/09_architecture_decisions.md
+++ b/docs/09_architecture_decisions.md
@@ -1982,8 +1982,10 @@ reuse everything downstream verbatim:
 - ✅ One-stage SAM 3 masks flow through the entire existing review/accept/batch/auto-accept/undo/persist
   machinery with zero new review UI; commits reuse `_commit_dino_results` (so `record_history` fires —
   undoable).
-- ✅ Grounding-DINO two-stage path is behaviourally unchanged (its tests pass unmodified); the model
-  picker's "SAM 3 (text prompt)" entry sits alongside the DINO models.
+- ✅ Grounding-DINO two-stage path is **functionally** unchanged — identical final annotations/temps,
+  so its tests pass unmodified. (The single path drops a transient "Running SAM…" status line and
+  unifies the two error-dialog titles into one — the only intra-run UX differences.) The model picker's
+  "SAM 3 (text prompt)" entry sits alongside the DINO models.
 - ✅ `ultralytics` floor raised to `>=8.3.237,<9` (ADR-038). SAM 3 lazy-imports, so older installs still
   launch and the app stays importable.
 - ⚠️ Real end-to-end verification needs a GPU + the gated 3.45 GB `sam3.pt` (cannot run in CI or a

--- a/docs/09_architecture_decisions.md
+++ b/docs/09_architecture_decisions.md
@@ -1960,8 +1960,10 @@ WITHOUT a second review UI.
 reuse everything downstream verbatim:
 - New `inference/sam3_utils.py::SAM3Utils` mirrors `SAMUtils`/`DINOUtils`: lazy-imports
   `SAM3SemanticPredictor` (ADR-012/016), constructs with `overrides=dict(model="sam3.pt",
-  task="segment", conf=<floor>)` — **no `quantize`/`mode`** (ADR-038: `quantize` raises in ultralytics
-  8.4.51) — and reuses `sam_utils._run_sync` / `_qimage_to_numpy` / `_mask_to_polygon` + the shared
+  task="segment", conf=<floor>, device=<resolved>, save=False, verbose=False)` — **no `quantize`/`mode`**
+  (ADR-038: `quantize` raises in ultralytics 8.4.51); `save`/`verbose` are `False` to stop a
+  `runs/segment/predict/` dir + per-call console summary on every detection — and reuses
+  `sam_utils._run_sync` / `_qimage_to_numpy` / `_mask_to_polygon` + the shared
   `_inference_in_flight` flag (so SAM 3 serialises against SAM 2/DINO on the GPU). `detect_text(image,
   class_configs)` returns per-instance `{class_name, score, segmentation, bbox}`; `box_thr` is the
   confidence filter (SAM 3's only knob — `txt_thr`/`nms_thr` ignored). Weights (`sam3.pt`, 3.45 GB,
@@ -1991,6 +1993,14 @@ reuse everything downstream verbatim:
 - ⚠️ Real end-to-end verification needs a GPU + the gated 3.45 GB `sam3.pt` (cannot run in CI or a
   weightless dev box) — the wiring is covered by monkeypatched/stubbed tests; the real-model check is a
   documented manual step (CLAUDE.md inference checklist). CPU is impractical — DINO stays the CPU fallback.
+- ✅ Real-model check **done** (2026-07-22, RTX 4070, ultralytics 8.4.51): `detect_text` on `bus.jpg`
+  returned sensible masks (bus 0.97 + 6 persons; `box_thr=0.25` filtered the raw 3 buss / 31 persons down
+  to 1 + 6), and the live `SAM3SemanticPredictor` API (`set_image(np)` + `__call__(text=…)` →
+  `.masks.data` / `.boxes.conf` / `.boxes.xyxy`) matches the code. Two real-only findings, both handled:
+  (a) first use pip-installs `clip` + `timm` via ultralytics AutoUpdate (needs network — documented, not
+  vendored; despite ultralytics' "restart runtime" warning the install+import complete in-process, so the
+  first detection succeeds without a restart — observed on a clean env); (b) `save`/`verbose` are forced
+  `False` (added to the overrides) to avoid a `runs/` dir + console spam on every detection.
 
 ---
 

--- a/docs/09_architecture_decisions.md
+++ b/docs/09_architecture_decisions.md
@@ -1861,7 +1861,7 @@ lazy-slice machinery** rather than a parallel frame cache (the #45/#47 reconcili
 
 ## ADR-038: SAM 3 Integration Path (Spike — #49)
 
-**Status**: Proposed (issue #49 spike; to be flipped to Accepted + amended by the D2/#50 PR)
+**Status**: Accepted (issue #49 spike; findings confirmed in-env and implemented by #50 — see ADR-039. The D3 video items — numpy-frame seeding, long-video memory — remain verify-first for #51.)
 
 **Context**: Milestone D plans two SAM 3 features — native text-prompt segmentation reusing the DINO
 review workflow (#50) and video object tracking (#51). Both hinge on facts that were unverified when
@@ -1943,6 +1943,52 @@ building on them.
 **Sources** (dated 2026-07-21): docs.ultralytics.com/models/sam-3/ ; github.com/ultralytics/ultralytics
 docs/en/models/sam-3.md ; newreleases.io … ultralytics v8.3.237 ; huggingface.co/facebook/sam3 (gated) +
 /blob/main/LICENSE ; github.com/orgs/ultralytics/discussions/22378 ; local `pip show ultralytics` (8.4.51).
+
+---
+
+## ADR-039: SAM 3 Text-Prompt Segmentation via the DINO Review-Pipeline Reuse
+
+**Status**: Accepted (issue #50; implements ADR-038's D2 recommendation)
+
+**Context**: Text-prompted segmentation existed as a two-stage pipeline — Grounding-DINO turns
+per-class phrases into boxes, then SAM 2 refines each box into a mask — wrapped in a mature review
+workflow (temp-annotation overlay, Enter/Escape accept/reject, batch over images+slices, auto-accept,
+`.iap` persistence). SAM 3 (ADR-038) does text→masks natively in one stage. The goal was to add SAM 3
+WITHOUT a second review UI.
+
+**Decision**: Plug SAM 3 in as a new **producer** at the exact spot "DINO boxes → SAM masks" sits, and
+reuse everything downstream verbatim:
+- New `inference/sam3_utils.py::SAM3Utils` mirrors `SAMUtils`/`DINOUtils`: lazy-imports
+  `SAM3SemanticPredictor` (ADR-012/016), constructs with `overrides=dict(model="sam3.pt",
+  task="segment", conf=<floor>)` — **no `quantize`/`mode`** (ADR-038: `quantize` raises in ultralytics
+  8.4.51) — and reuses `sam_utils._run_sync` / `_qimage_to_numpy` / `_mask_to_polygon` + the shared
+  `_inference_in_flight` flag (so SAM 3 serialises against SAM 2/DINO on the GPU). `detect_text(image,
+  class_configs)` returns per-instance `{class_name, score, segmentation, bbox}`; `box_thr` is the
+  confidence filter (SAM 3's only knob — `txt_thr`/`nms_thr` ignored). Weights (`sam3.pt`, 3.45 GB,
+  gated) are never auto-downloaded; `_weights_available()` drives a "request access + place sam3.pt"
+  status, mirroring the DINO gated-download UX.
+- `DINOController` gains a `_run_text_detection(qimage) -> (results, sam_results)` choke point used by
+  BOTH single + batch: for SAM 3 it splits each instance into a `results`-shaped `{class_name, score,
+  bbox, source:"sam3"}` and a parallel `sam_results`-shaped `{segmentation, score}` — SAME length +
+  order — so the existing zip/commit/temp-attach logic is byte-identical; for DINO it runs the unchanged
+  two-stage path. SAM 3 skips the "No SAM Model" guard; DINO keeps it.
+- Produced temps carry `"source": "sam3"`; every `source == "dino"` check (esp. the
+  `DINOReviewEventFilter` Enter/Escape gate) was widened to `in ("dino", "sam3")` via a
+  `.get("source", "dino")` default that keeps DINO's un-tagged dicts resolving to `"dino"`. SAM 3 batch
+  results land in the SAME `dino_batch_results` dict (the single-field `_refresh_dino_temp_for_current`
+  re-sync is untouched).
+
+**Consequences**:
+- ✅ One-stage SAM 3 masks flow through the entire existing review/accept/batch/auto-accept/undo/persist
+  machinery with zero new review UI; commits reuse `_commit_dino_results` (so `record_history` fires —
+  undoable).
+- ✅ Grounding-DINO two-stage path is behaviourally unchanged (its tests pass unmodified); the model
+  picker's "SAM 3 (text prompt)" entry sits alongside the DINO models.
+- ✅ `ultralytics` floor raised to `>=8.3.237,<9` (ADR-038). SAM 3 lazy-imports, so older installs still
+  launch and the app stays importable.
+- ⚠️ Real end-to-end verification needs a GPU + the gated 3.45 GB `sam3.pt` (cannot run in CI or a
+  weightless dev box) — the wiring is covered by monkeypatched/stubbed tests; the real-model check is a
+  documented manual step (CLAUDE.md inference checklist). CPU is impractical — DINO stays the CPU fallback.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "opencv-python>=4.8.0",
     "pyyaml>=6.0.0",
     "scikit-image>=0.21.0",
-    "ultralytics>=8.3.27,<9", # SAM 2 integration; trainer verified on 8.4.51
+    "ultralytics>=8.3.237,<9", # SAM 2/3 integration; SAM 3 text prompt (SAM3SemanticPredictor) needs >=8.3.237 — issue #50 / ADR-038; trainer verified on 8.4.51
     "plotly>=5.0.0",
     "shapely>=2.0.0",
     "pystackreg>=0.2.7",

--- a/src/digitalsreeni_image_annotator/annotator_window.py
+++ b/src/digitalsreeni_image_annotator/annotator_window.py
@@ -45,6 +45,7 @@ from .widgets.canvas_context import CanvasContext
 from .widgets.image_label import ImageLabel
 from .dialogs.image_patcher import show_image_patcher
 from .inference.sam_utils import SAMUtils
+from .inference.sam3_utils import SAM3Utils
 from .dialogs.slice_registration import SliceRegistrationTool
 from .dialogs.snake_game import SnakeGame
 from .dialogs.stack_interpolator import StackInterpolator
@@ -118,6 +119,11 @@ class ImageAnnotator(QMainWindow):
         self.dino_utils = DINOUtils()
         self.dino_model_loaded = False
         self.dino_custom_model_path = None
+
+        # SAM 3 text-prompt producer (issue #50, ADR-038). Plugs into the
+        # DINO review pipeline as an alternative to the two-stage
+        # DINO→SAM path; selected via the DINO model dropdown.
+        self.sam3_utils = SAM3Utils()
 
         # Debounce timer for SAM points: wait 1s after last click before inference
         self.sam_inference_timer = QTimer(self)
@@ -612,6 +618,7 @@ class ImageAnnotator(QMainWindow):
         """
         self.sam_utils.unload()
         self.dino_utils.unload()
+        self.sam3_utils.unload()
         # Reset the dropdowns to a neutral state so the user knows they
         # need to re-pick the model.
         self.sam_model_selector.setCurrentIndex(0)

--- a/src/digitalsreeni_image_annotator/controllers/dino_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/dino_controller.py
@@ -162,7 +162,7 @@ class DINOController(QObject):
         self.mw.dino_model_loaded = False
         sam3 = self.mw.sam3_utils
 
-        if not sam3._weights_available():
+        if not sam3.weights_available():
             self.mw.lbl_dino_status.setText(
                 "SAM 3 weights (sam3.pt) not found. Request access on Hugging "
                 "Face, then place sam3.pt in the working directory or the "
@@ -300,6 +300,10 @@ class DINOController(QObject):
             instances = self.mw.sam3_utils.detect_text(qimage, class_configs)
             if instances is None:
                 return None, None
+            # bbox is carried only for shape-parity with the DINO results dict
+            # (downstream commit/store/temp-attach/accept read segmentation/
+            # class_name/score/source, never bbox); keeping it avoids a
+            # divergent results shape between the two producers.
             results = [
                 {"class_name": inst["class_name"], "score": inst["score"],
                  "bbox": inst["bbox"], "source": "sam3"}

--- a/src/digitalsreeni_image_annotator/controllers/dino_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/dino_controller.py
@@ -40,6 +40,8 @@ from PyQt6.QtWidgets import (
 from ..core.constants import default_class_color
 from ..core.keypoint_schema import schema_k
 from ..core.slice_cache import slice_names
+from ..inference.sam3_utils import SAM3_MODEL_LABEL
+from ..inference.sam_utils import InferenceBusyError
 
 from ..core.logging_config import get_logger
 
@@ -75,7 +77,12 @@ class DINOReviewEventFilter(QObject):
         if isinstance(focused, (QLineEdit, QTextEdit)):
             return False
         temp = self.main_window.image_label.temp_annotations
-        if not temp or not any(a.get("source") == "dino" for a in temp):
+        # SAM 3 (issue #50) produces temp annotations tagged "sam3"; DINO
+        # tags "dino". Both reuse this Enter/Escape review gate — widen the
+        # membership so SAM 3 review isn't dead. See ADR-038.
+        if not temp or not any(
+            a.get("source") in ("dino", "sam3") for a in temp
+        ):
             return False
         if key in (Qt.Key.Key_Return, Qt.Key.Key_Enter):
             self.main_window.accept_dino_results()
@@ -96,9 +103,17 @@ class DINOController(QObject):
         from ..inference.dino_utils import GDINO_MODEL_PATHS
         return GDINO_MODEL_PATHS.get(model_name)
 
+    def _is_sam3_selected(self):
+        """True when the DINO dropdown is on the SAM 3 text-prompt entry."""
+        return self.mw.dino_model_selector.currentText() == SAM3_MODEL_LABEL
+
     def _on_dino_model_changed(self, text):
         """Selection → ready state. Downloads happen lazily on first Detect."""
         self.mw.dino_browse_row.setVisible(text == "Custom / fine-tuned (browse)")
+
+        if text == SAM3_MODEL_LABEL:
+            self._on_sam3_selected()
+            return
 
         if text == "Pick a DINO Model":
             self.mw.dino_model_loaded = False
@@ -133,6 +148,51 @@ class DINOController(QObject):
             self.mw.lbl_dino_status.setText(f"Ready: {text}")
         else:
             self.mw.lbl_dino_status.setText(f"{text} — will download on first detection")
+
+    def _on_sam3_selected(self):
+        """SAM 3 (text prompt) selected in the DINO dropdown.
+
+        SAM 3 needs no SAM 2 refinement, so the ``dino_model_loaded`` flag
+        stays False — detection is gated on ``sam3_utils.loaded`` instead.
+        If ``sam3.pt`` isn't on disk we show the gated-download status and
+        leave Detect disabled (weights are gated on HF; never auto-download).
+        Otherwise we load eagerly and, on failure, pop an error and reset
+        the picker — mirrors ``SAMController.change_sam_model``.
+        """
+        self.mw.dino_model_loaded = False
+        sam3 = self.mw.sam3_utils
+
+        if not sam3._weights_available():
+            self.mw.lbl_dino_status.setText(
+                "SAM 3 weights (sam3.pt) not found. Request access on Hugging "
+                "Face, then place sam3.pt in the working directory or the "
+                "models/sam/ folder."
+            )
+            self.mw.btn_detect_single.setEnabled(False)
+            self.mw.btn_detect_batch.setEnabled(False)
+            return
+
+        self.mw.lbl_dino_status.setText("Loading SAM 3 ...")
+        QApplication.processEvents()
+        try:
+            sam3.ensure_loaded()
+        except Exception as e:
+            logger.exception("Failed to load SAM 3")
+            QMessageBox.critical(
+                self.mw, "SAM 3 Model Error",
+                f"Failed to load SAM 3:\n\n{e}\n\n"
+                "Check that sam3.pt is a valid checkpoint and that torch is "
+                "correctly installed for your platform / GPU.",
+            )
+            self.mw.btn_detect_single.setEnabled(False)
+            self.mw.btn_detect_batch.setEnabled(False)
+            # Reset to the neutral entry (fires _on_dino_model_changed again).
+            self.mw.dino_model_selector.setCurrentIndex(0)
+            return
+
+        self.mw.btn_detect_single.setEnabled(True)
+        self.mw.btn_detect_batch.setEnabled(True)
+        self.mw.lbl_dino_status.setText(f"Ready: {SAM3_MODEL_LABEL}")
 
     def _ensure_dino_model_downloaded(self, model_name):
         """If the preset model isn't on disk yet, download it. Returns success."""
@@ -207,17 +267,82 @@ class DINOController(QObject):
 
     # --- Detection workflows ---
 
+    def _run_text_detection(self, qimage):
+        """Detect + mask for one image, returning ``(results, sam_results)``.
+
+        The single shared detect+mask step for BOTH the single and batch
+        paths. Returns two parallel lists the existing DINO pipeline zips:
+
+        - ``results``:     ``[{"class_name", "score", "bbox"[, "source"]}, ...]``
+        - ``sam_results``: ``[{"segmentation", "score"}, ...]``
+
+        SAME length + order, so every downstream consumer (auto-accept
+        commit, temp attach, ``_commit_dino_results``,
+        ``_store_dino_batch_results``) is byte-identical regardless of
+        producer.
+
+        SAM 3 path (issue #50): ``sam3_utils.detect_text`` already produces
+        per-instance masks+boxes; we split each instance into the two
+        shapes and tag ``source="sam3"`` on the ``results`` half so the
+        temp annotations carry it downstream.
+
+        DINO path (unchanged): the two-stage ``dino_utils.detect`` →
+        ``sam_utils.apply_sam_predictions_batch``.
+
+        Returns ``(None, None)`` when the producer returns None (model
+        resolution failure) and ``([], [])`` for "ran, nothing survived".
+        Raises on hard errors (incl. ``InferenceBusyError``) — callers
+        handle that.
+        """
+        class_configs = self._build_dino_class_configs()
+
+        if self._is_sam3_selected():
+            instances = self.mw.sam3_utils.detect_text(qimage, class_configs)
+            if instances is None:
+                return None, None
+            results = [
+                {"class_name": inst["class_name"], "score": inst["score"],
+                 "bbox": inst["bbox"], "source": "sam3"}
+                for inst in instances
+            ]
+            sam_results = [
+                {"segmentation": inst["segmentation"], "score": inst["score"]}
+                for inst in instances
+            ]
+            return results, sam_results
+
+        # DINO two-stage (byte-for-byte behaviourally unchanged).
+        model_name = self.mw.dino_model_selector.currentText()
+        results = self.mw.dino_utils.detect(
+            qimage, class_configs,
+            model_name=model_name,
+            custom_model_path=self.mw.dino_custom_model_path,
+        )
+        if results is None:
+            return None, None
+        if not results:
+            return [], []
+        bboxes = [r["bbox"] for r in results]
+        sam_results = self.mw.sam_utils.apply_sam_predictions_batch(qimage, bboxes)
+        return results, sam_results
+
     def run_dino_detection_single(self):
-        if not self.mw.dino_model_loaded:
-            QMessageBox.warning(self.mw, "No DINO Model",
-                                "Please pick a DINO model first.")
-            return
-        if not self.mw.sam_utils.current_sam_model:
-            QMessageBox.warning(
-                self.mw, "No SAM Model",
-                "DINO produces bounding boxes; SAM is needed to convert them "
-                "into segmentation masks. Please pick a SAM model first.",
-            )
+        is_sam3 = self._is_sam3_selected()
+        if not is_sam3:
+            if not self.mw.dino_model_loaded:
+                QMessageBox.warning(self.mw, "No DINO Model",
+                                    "Please pick a DINO model first.")
+                return
+            if not self.mw.sam_utils.current_sam_model:
+                QMessageBox.warning(
+                    self.mw, "No SAM Model",
+                    "DINO produces bounding boxes; SAM is needed to convert them "
+                    "into segmentation masks. Please pick a SAM model first.",
+                )
+                return
+        elif not self.mw.sam3_utils.loaded:
+            QMessageBox.warning(self.mw, "No SAM 3 Model",
+                                "Please load the SAM 3 model first.")
             return
         if not self.mw.current_image or self.mw.current_image.isNull():
             QMessageBox.warning(self.mw, "No Image",
@@ -241,7 +366,9 @@ class DINOController(QObject):
         # accept from a previous run doesn't bleed into the results handler.
         self.mw.image_label.temp_annotations = []
 
-        if not self._ensure_dino_model_downloaded(model_name):
+        # SAM 3 needs no gated-DINO download step (its weights are handled
+        # at model selection). Keep the download gate for the DINO path.
+        if not is_sam3 and not self._ensure_dino_model_downloaded(model_name):
             self.mw.btn_detect_single.setEnabled(True)
             self.mw.btn_detect_batch.setEnabled(True)
             return
@@ -251,14 +378,17 @@ class DINOController(QObject):
 
         logger.debug(f"detect_single: model={model_name!r} class_configs={class_configs}")
         try:
-            results = self.mw.dino_utils.detect(
-                self.mw.current_image, class_configs,
-                model_name=model_name,
-                custom_model_path=self.mw.dino_custom_model_path,
-            )
+            results, sam_results = self._run_text_detection(self.mw.current_image)
+        except InferenceBusyError:
+            # Another inference is still pumping (ADR-013). Skip; the user
+            # can retry once it finishes.
+            self.mw.btn_detect_single.setEnabled(True)
+            self.mw.btn_detect_batch.setEnabled(True)
+            self.mw.lbl_dino_status.setText("Busy — another inference is running.")
+            return
         except Exception as e:
-            logger.exception("DINO detect failed")
-            QMessageBox.critical(self.mw, "DINO Error", str(e))
+            logger.exception("Text detection failed")
+            QMessageBox.critical(self.mw, "Detection Error", str(e))
             self.mw.btn_detect_single.setEnabled(True)
             self.mw.btn_detect_batch.setEnabled(True)
             self.mw.lbl_dino_status.setText("Detection failed.")
@@ -281,23 +411,8 @@ class DINOController(QObject):
             self.mw.lbl_dino_status.setText("No detections found.")
             return
 
-        self.mw.lbl_dino_status.setText(f"{len(results)} detection(s). Running SAM...")
-        QApplication.processEvents()
-
-        bboxes = [r["bbox"] for r in results]
-        logger.debug(f"batch call: {len(bboxes)} bbox(es), first 3 = {bboxes[:3]}")
-        try:
-            sam_results = self.mw.sam_utils.apply_sam_predictions_batch(
-                self.mw.current_image, bboxes
-            )
-        except Exception as e:
-            logger.exception("SAM batch failed")
-            QMessageBox.critical(self.mw, "SAM Error", str(e))
-            self.mw.lbl_dino_status.setText("SAM segmentation failed.")
-            return
-
         if sam_results is None:
-            logger.warning("batch returned None (no SAM model loaded)")
+            logger.warning("mask step returned None (no SAM model loaded)")
             QMessageBox.warning(self.mw, "SAM Error",
                                 "Failed to segment detections with SAM.")
             self.mw.lbl_dino_status.setText("SAM segmentation failed.")
@@ -305,7 +420,7 @@ class DINOController(QObject):
 
         n_errors = sum(1 for s in sam_results if "error" in s)
         n_ok = sum(1 for s in sam_results if "segmentation" in s)
-        logger.debug(f"batch returned {len(sam_results)} result(s): {n_ok} ok, {n_errors} error(s)")
+        logger.debug(f"mask step returned {len(sam_results)} result(s): {n_ok} ok, {n_errors} error(s)")
 
         # Honor the batch-mode dropdown for the single-image case too:
         # "Auto-accept" means commit straight to annotations without
@@ -346,7 +461,7 @@ class DINOController(QObject):
                 "segmentation": s["segmentation"],
                 "category_name": r["class_name"],
                 "score": r["score"],
-                "source": "dino",
+                "source": r.get("source", "dino"),
                 "temp": True,
             })
 
@@ -359,16 +474,22 @@ class DINOController(QObject):
         logger.debug(f"detection complete: {len(results)} boxes, {len(temp_annotations)} masks attached to canvas")
 
     def run_dino_detection_batch(self):
-        if not self.mw.dino_model_loaded:
-            QMessageBox.warning(self.mw, "No DINO Model",
-                                "Please pick a DINO model first.")
-            return
-        if not self.mw.sam_utils.current_sam_model:
-            QMessageBox.warning(
-                self.mw, "No SAM Model",
-                "DINO produces bounding boxes; SAM is needed to convert them "
-                "into segmentation masks. Please pick a SAM model first.",
-            )
+        is_sam3 = self._is_sam3_selected()
+        if not is_sam3:
+            if not self.mw.dino_model_loaded:
+                QMessageBox.warning(self.mw, "No DINO Model",
+                                    "Please pick a DINO model first.")
+                return
+            if not self.mw.sam_utils.current_sam_model:
+                QMessageBox.warning(
+                    self.mw, "No SAM Model",
+                    "DINO produces bounding boxes; SAM is needed to convert them "
+                    "into segmentation masks. Please pick a SAM model first.",
+                )
+                return
+        elif not self.mw.sam3_utils.loaded:
+            QMessageBox.warning(self.mw, "No SAM 3 Model",
+                                "Please load the SAM 3 model first.")
             return
         if not self.mw.all_images:
             QMessageBox.warning(self.mw, "No Images",
@@ -389,7 +510,9 @@ class DINOController(QObject):
         # confusing the batch results handler or the DINOReviewEventFilter.
         self.mw.image_label.temp_annotations = []
 
-        if not self._ensure_dino_model_downloaded(model_name):
+        # SAM 3 handles its weights at model selection; only DINO needs the
+        # gated on-demand download here.
+        if not is_sam3 and not self._ensure_dino_model_downloaded(model_name):
             return
 
         auto_accept = (
@@ -425,25 +548,15 @@ class DINOController(QObject):
             QApplication.processEvents()
 
             try:
-                results = self.mw.dino_utils.detect(
-                    qimage, class_configs,
-                    model_name=model_name,
-                    custom_model_path=self.mw.dino_custom_model_path,
-                )
+                results, sam_results = self._run_text_detection(qimage)
+            except InferenceBusyError:
+                logger.warning(f"inference busy, skipping {image_name}")
+                continue
             except Exception:
-                logger.exception(f"DINO failed for {image_name}")
+                logger.exception(f"text detection failed for {image_name}")
                 continue
 
             if not results:
-                continue
-
-            bboxes = [r["bbox"] for r in results]
-            try:
-                sam_results = self.mw.sam_utils.apply_sam_predictions_batch(
-                    qimage, bboxes
-                )
-            except Exception:
-                logger.exception(f"SAM failed for {image_name}")
                 continue
             if sam_results is None:
                 continue
@@ -545,7 +658,7 @@ class DINOController(QObject):
                 "category_id": self.mw.class_mapping[class_name],
                 "category_name": class_name,
                 "score": r["score"],
-                "source": "dino",
+                "source": r.get("source", "dino"),
                 "number": number,
             }
             target.setdefault(class_name, []).append(ann)
@@ -563,7 +676,7 @@ class DINOController(QObject):
                     "segmentation": s["segmentation"],
                     "category_name": r["class_name"],
                     "score": r["score"],
-                    "source": "dino",
+                    "source": r.get("source", "dino"),
                     "temp": True,
                 })
         self.mw.dino_batch_results[image_name] = valid
@@ -672,7 +785,7 @@ class DINOController(QObject):
                 "category_id": self.mw.class_mapping[class_name],
                 "category_name": class_name,
                 "score": ann.get("score", 0.0),
-                "source": "dino",
+                "source": ann.get("source", "dino"),
             }
             self.mw.image_label.annotations.setdefault(class_name, []).append(new_ann)
             self.mw.add_annotation_to_list(new_ann)

--- a/src/digitalsreeni_image_annotator/inference/sam3_utils.py
+++ b/src/digitalsreeni_image_annotator/inference/sam3_utils.py
@@ -41,6 +41,16 @@ never a half-loaded state.
 inside the load function (ADR-012 / ADR-016): keeps app startup fast,
 keeps the app importable on older ultralytics that predate SAM 3, and
 avoids pulling torch in early.
+
+First-run note: SAM 3's text/vision encoders need ``clip``
+(``git+https://github.com/ultralytics/CLIP.git``) and ``timm``. Ultralytics
+AutoUpdate ``pip install``s them on the first predictor call, so the FIRST
+SAM 3 use needs network + pip (an offline box without them pre-installed
+fails here). Ultralytics prints "Restart runtime or rerun command for
+updates to take effect", but the install + import complete IN-PROCESS -- the
+first detection succeeds without a restart. Observed on a clean env in the
+#50 manual GPU run (2026-07-22, RTX 4070): AutoUpdate fetched both clip+timm,
+then the same run's detect_text returned masks.
 """
 
 from __future__ import annotations
@@ -159,15 +169,20 @@ class SAM3Utils(QObject):
         self._device, _ = resolve_torch_device()
 
         weights = self._resolve_weights_path() or SAM3_WEIGHTS_FILENAME
-        # NOTE (ADR-038): pass model/task/conf/device only. `quantize=` raises
-        # "'quantize' is not a valid YOLO argument" on ultralytics 8.4.51, and
-        # `mode=` is redundant. conf is the single threshold knob. `device` is
-        # REQUIRED (mirrors SAMUtils): resolve_torch_device() may force "cpu"
-        # even when CUDA is present (unsupported compute capability / probe
-        # failure); without it Ultralytics auto-picks cuda:0 and crashes on the
-        # exact GPU the fallback rejected.
+        # NOTE (ADR-038): pass model/task/conf/device/save/verbose only.
+        # `quantize=` raises "'quantize' is not a valid YOLO argument" on
+        # ultralytics 8.4.51, and `mode=` is redundant. conf is the single
+        # threshold knob. `device` is REQUIRED (mirrors SAMUtils):
+        # resolve_torch_device() may force "cpu" even when CUDA is present
+        # (unsupported compute capability / probe failure); without it
+        # Ultralytics auto-picks cuda:0 and crashes on the exact GPU the
+        # fallback rejected. `save=False`/`verbose=False` stop Ultralytics from
+        # writing a runs/segment/predict/ dir and printing a per-call summary
+        # on EVERY detection (confirmed effective + non-raising in the #50
+        # manual GPU run, 2026-07-22 -- unlike `quantize`, these don't raise).
         overrides = dict(
-            model=weights, task="segment", conf=self._conf, device=self._device
+            model=weights, task="segment", conf=self._conf,
+            device=self._device, save=False, verbose=False,
         )
         predictor = SAM3SemanticPredictor(overrides=overrides)
 

--- a/src/digitalsreeni_image_annotator/inference/sam3_utils.py
+++ b/src/digitalsreeni_image_annotator/inference/sam3_utils.py
@@ -91,7 +91,7 @@ class SAM3Utils(QObject):
     - ``ensure_loaded() -> None``
     - ``detect_text(image: QImage, class_configs: list[dict]) -> list[dict] | None``
     - ``unload() -> None``
-    - ``_weights_available() -> bool``
+    - ``weights_available() -> bool``
     - attributes ``loaded: bool`` and ``_predictor`` (None until loaded)
     """
 
@@ -123,7 +123,7 @@ class SAM3Utils(QObject):
                 return p
         return None
 
-    def _weights_available(self) -> bool:
+    def weights_available(self) -> bool:
         """True if ``sam3.pt`` is already on disk somewhere resolvable.
 
         Never triggers a download — the checkpoint is gated on HF. The
@@ -159,10 +159,16 @@ class SAM3Utils(QObject):
         self._device, _ = resolve_torch_device()
 
         weights = self._resolve_weights_path() or SAM3_WEIGHTS_FILENAME
-        # NOTE (ADR-038): pass ONLY model/task/conf. `quantize=` raises
-        # "'quantize' is not a valid YOLO argument" on ultralytics 8.4.51,
-        # and `mode=` is redundant. conf is the single threshold knob.
-        overrides = dict(model=weights, task="segment", conf=self._conf)
+        # NOTE (ADR-038): pass model/task/conf/device only. `quantize=` raises
+        # "'quantize' is not a valid YOLO argument" on ultralytics 8.4.51, and
+        # `mode=` is redundant. conf is the single threshold knob. `device` is
+        # REQUIRED (mirrors SAMUtils): resolve_torch_device() may force "cpu"
+        # even when CUDA is present (unsupported compute capability / probe
+        # failure); without it Ultralytics auto-picks cuda:0 and crashes on the
+        # exact GPU the fallback rejected.
+        overrides = dict(
+            model=weights, task="segment", conf=self._conf, device=self._device
+        )
         predictor = SAM3SemanticPredictor(overrides=overrides)
 
         # Flip state only after a clean construct — never half-loaded.

--- a/src/digitalsreeni_image_annotator/inference/sam3_utils.py
+++ b/src/digitalsreeni_image_annotator/inference/sam3_utils.py
@@ -32,7 +32,7 @@ Weights
 -------
 The real ``sam3.pt`` checkpoint is ~3.45 GB and gated on Hugging Face.
 We never auto-download it (mirrors DINO's gated-download UX): the
-controller calls :meth:`_weights_available` to decide between "Ready"
+controller calls :meth:`weights_available` to decide between "Ready"
 and a "request access + place sam3.pt" status. ``ensure_loaded`` only
 flips :attr:`loaded` / :attr:`_predictor` AFTER a successful construct —
 never a half-loaded state.

--- a/src/digitalsreeni_image_annotator/inference/sam3_utils.py
+++ b/src/digitalsreeni_image_annotator/inference/sam3_utils.py
@@ -1,0 +1,294 @@
+"""
+SAM 3 text-prompt utilities — runs Ultralytics ``SAM3SemanticPredictor``
+in-process (issue #50, ADR-038).
+
+Where it sits
+-------------
+SAM 3 is a **new producer** wired into the exact spot the two-stage
+"DINO boxes → SAM 2 masks" pipeline occupies today. Instead of DINO
+detecting boxes and SAM 2 refining them, SAM 3 takes a text phrase and
+emits masks + boxes + scores directly. Everything downstream (the
+temp-annotation review overlay, Enter/Escape accept-reject, batch over
+images + slices, auto-accept, ``.iap`` persistence) is reused verbatim —
+see ``controllers/dino_controller.py``. Grounding-DINO stays as a
+fallback and its path is behaviourally unchanged.
+
+Deliberately parallel to ``SAMUtils`` / ``DINOUtils``. The shared
+threading scaffolding (``_run_sync``, the module-level
+``_inference_in_flight`` busy flag, ``InferenceBusyError``) and the
+geometry / marshalling helpers (``_qimage_to_numpy``, ``_mask_to_polygon``)
+are imported from ``sam_utils`` — NOT forked — so SAM 3 serialises
+against SAM 2 and DINO on the one busy flag (desirable: they'd race on
+the GPU otherwise) and shares the exact contour/area-floor rules.
+
+Threading model
+---------------
+Same as ``SAMUtils``: model load and inference run on a worker thread
+via ``_run_sync`` while the caller's (GUI) thread pumps its event loop.
+The public API looks synchronous. Call it from the GUI thread only —
+the busy-flag tripwire in ``_run_sync`` enforces that.
+
+Weights
+-------
+The real ``sam3.pt`` checkpoint is ~3.45 GB and gated on Hugging Face.
+We never auto-download it (mirrors DINO's gated-download UX): the
+controller calls :meth:`_weights_available` to decide between "Ready"
+and a "request access + place sam3.pt" status. ``ensure_loaded`` only
+flips :attr:`loaded` / :attr:`_predictor` AFTER a successful construct —
+never a half-loaded state.
+
+``ultralytics.models.sam.SAM3SemanticPredictor`` is imported lazily
+inside the load function (ADR-012 / ADR-016): keeps app startup fast,
+keeps the app importable on older ultralytics that predate SAM 3, and
+avoids pulling torch in early.
+"""
+
+from __future__ import annotations
+
+import os
+
+from PyQt6.QtCore import QObject, pyqtSignal
+from PyQt6.QtGui import QImage
+
+from .sam_utils import (
+    InferenceBusyError,  # noqa: F401 — re-exported for callers/tests
+    SAM_MODELS_DIR,
+    _mask_to_polygon,
+    _qimage_to_numpy,
+    _run_sync,
+)
+
+from ..core.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+# Human-readable entry shown in the DINO model dropdown. Single source of
+# truth: imported by ui/sidebar.py (the addItem) and dino_controller.py
+# (the "is SAM 3 selected?" check) so the label can't drift between them.
+SAM3_MODEL_LABEL = "SAM 3 (text prompt)"
+
+# Bare checkpoint filename. Ultralytics resolves a bare name against cwd
+# and its own weights dir; we additionally look under the app models dir
+# (parallel to the SAM 2 weights) and an explicit env override.
+SAM3_WEIGHTS_FILENAME = "sam3.pt"
+
+# Construction-time confidence floor. SAM 3's ONLY threshold knob is
+# ``conf`` (set once at construct time), but the review UI carries a
+# per-class ``box_thr``. We construct with this low floor so the
+# predictor doesn't pre-filter above any class threshold, then apply
+# each class's ``box_thr`` in Python (authoritative). A user box_thr
+# below this floor can't recover instances the predictor already
+# dropped — acceptable; defaults are 0.25.
+SAM3_CONF_FLOOR = 0.05
+
+
+class SAM3Utils(QObject):
+    """In-process Ultralytics SAM 3 text-prompt wrapper with a cached model.
+
+    Public API (kept stable — #51 extends this with ``track``):
+
+    - ``ensure_loaded() -> None``
+    - ``detect_text(image: QImage, class_configs: list[dict]) -> list[dict] | None``
+    - ``unload() -> None``
+    - ``_weights_available() -> bool``
+    - attributes ``loaded: bool`` and ``_predictor`` (None until loaded)
+    """
+
+    model_changed = pyqtSignal(str)
+
+    def __init__(self, conf: float = SAM3_CONF_FLOOR):
+        super().__init__()
+        self.loaded = False
+        self._predictor = None       # SAM3SemanticPredictor once loaded
+        self._device: str | None = None
+        self._conf = float(conf)
+
+    # ── weights resolution (no download) ───────────────────────────────
+
+    def _candidate_weight_paths(self) -> list[str]:
+        """Locations we accept a pre-placed ``sam3.pt`` from (no download)."""
+        paths = []
+        env = os.environ.get("SAM3_MODEL_PATH")
+        if env:
+            paths.append(env)
+        paths.append(os.path.join(os.getcwd(), SAM3_WEIGHTS_FILENAME))
+        paths.append(os.path.join(SAM_MODELS_DIR, SAM3_WEIGHTS_FILENAME))
+        return paths
+
+    def _resolve_weights_path(self) -> str | None:
+        """First existing candidate path, or None if none is present."""
+        for p in self._candidate_weight_paths():
+            if p and os.path.exists(p):
+                return p
+        return None
+
+    def _weights_available(self) -> bool:
+        """True if ``sam3.pt`` is already on disk somewhere resolvable.
+
+        Never triggers a download — the checkpoint is gated on HF. The
+        controller uses this to choose between enabling detection and
+        showing a "request access + place sam3.pt" status.
+        """
+        return self._resolve_weights_path() is not None
+
+    # ── model lifecycle ────────────────────────────────────────────────
+
+    def ensure_loaded(self) -> None:
+        """Construct the predictor if not already loaded (lazy — ADR-012).
+
+        Runs the construct on a worker thread via ``_run_sync`` (torch /
+        model build can stall the UI). Only marks ``loaded`` / sets
+        ``_predictor`` on success; on failure leaves ``loaded=False`` /
+        ``_predictor=None`` and re-raises so the controller can surface
+        the error and reset the picker.
+        """
+        if self.loaded and self._predictor is not None:
+            return
+        _run_sync(self._load_model_blocking)
+        self.model_changed.emit(SAM3_MODEL_LABEL)
+        logger.info("SAM 3 predictor loaded")
+
+    def _load_model_blocking(self) -> None:
+        # Lazy import (ADR-016): inside the function so the app stays
+        # importable on ultralytics builds without SAM 3 and torch isn't
+        # pulled in at startup. Constructs the SAM 3 semantic predictor.
+        from ultralytics.models.sam import SAM3SemanticPredictor
+        from ..core.torch_utils import resolve_torch_device
+
+        self._device, _ = resolve_torch_device()
+
+        weights = self._resolve_weights_path() or SAM3_WEIGHTS_FILENAME
+        # NOTE (ADR-038): pass ONLY model/task/conf. `quantize=` raises
+        # "'quantize' is not a valid YOLO argument" on ultralytics 8.4.51,
+        # and `mode=` is redundant. conf is the single threshold knob.
+        overrides = dict(model=weights, task="segment", conf=self._conf)
+        predictor = SAM3SemanticPredictor(overrides=overrides)
+
+        # Flip state only after a clean construct — never half-loaded.
+        self._predictor = predictor
+        self.loaded = True
+
+    def unload(self) -> None:
+        """Free GPU/CPU memory held by the loaded predictor.
+
+        Mirrors ``SAMUtils.unload`` verbatim: move the nn.Module to CPU,
+        drop references, ``gc.collect()``, then
+        ``empty_cache()`` + ``ipc_collect()`` + ``synchronize()``. Caveat
+        (same as SAM 2 / DINO): PyTorch keeps a per-process CUDA context
+        that survives unload; full reclaim needs an app restart.
+        """
+        import gc
+        try:
+            model = getattr(self._predictor, "model", None)
+            if model is not None and hasattr(model, "cpu"):
+                model.cpu()
+        except Exception:
+            logger.warning(
+                "unload: moving SAM 3 model to CPU failed; GPU memory may not "
+                "be fully released", exc_info=True,
+            )
+        self._predictor = None
+        self.loaded = False
+        self._device = None
+        gc.collect()
+        try:
+            import torch
+            if torch.cuda.is_available():
+                torch.cuda.synchronize()
+                torch.cuda.empty_cache()
+                torch.cuda.ipc_collect()
+        except Exception:
+            logger.warning(
+                "CUDA cache cleanup failed during SAM 3 unload; GPU memory may "
+                "not be fully released", exc_info=True,
+            )
+        logger.info("SAM 3 unload complete")
+
+    # ── inference ──────────────────────────────────────────────────────
+
+    def detect_text(self, image: QImage, class_configs: list[dict]):
+        """Run text-prompted segmentation for each class config.
+
+        ``class_configs`` share the DINO shape (from
+        ``_build_dino_class_configs``): keys ``name``, ``phrases``,
+        ``box_thr``, ``txt_thr``, ``nms_thr``. For SAM 3 only ``name``,
+        ``phrases`` and ``box_thr`` are used — ``box_thr`` is the
+        confidence filter; ``txt_thr`` / ``nms_thr`` are **ignored**
+        (SAM 3 exposes a single confidence knob).
+
+        Returns a COMBINED per-instance list::
+
+            {"class_name": str, "score": float,
+             "segmentation": [x1, y1, x2, y2, ...],
+             "bbox": [x1, y1, x2, y2]}
+
+        or ``None`` if the model is not loaded (never half-work). An
+        instance whose mask falls below ``_mask_to_polygon``'s area-10
+        contour floor yields no entry. Runs entirely through
+        ``_run_sync`` (GUI-thread tripwire + shared in-flight guard).
+        """
+        if not self.loaded or self._predictor is None:
+            logger.warning("detect_text: SAM 3 not loaded")
+            return None
+        return _run_sync(
+            self._detect_text_blocking,
+            _qimage_to_numpy(image),
+            list(class_configs),
+        )
+
+    def _detect_text_blocking(self, image_np, class_configs: list[dict]):
+        # Worker thread. set_image once, then one predictor call per class
+        # with that class's phrase list. Filter each instance by the
+        # class's box_thr, convert its mask to a polygon.
+        if not self.loaded or self._predictor is None:
+            return None
+
+        self._predictor.set_image(image_np)
+
+        out = []
+        for cfg in class_configs:
+            name = cfg["name"]
+            phrases = self._clean_phrases(cfg, name)
+            box_thr = cfg.get("box_thr", 0.25)
+
+            results = self._predictor(text=phrases)
+            res = results[0] if isinstance(results, (list, tuple)) else results
+
+            masks = getattr(res, "masks", None)
+            boxes = getattr(res, "boxes", None)
+            if masks is None or boxes is None:
+                continue
+
+            mask_arr = masks.data.cpu().numpy()
+            conf_arr = boxes.conf.cpu().numpy()
+            box_arr = boxes.xyxy.cpu().numpy()
+
+            for i in range(len(mask_arr)):
+                score = float(conf_arr[i]) if i < len(conf_arr) else 0.0
+                if score < box_thr:
+                    continue
+                polygon = _mask_to_polygon(mask_arr[i])
+                if polygon is None:
+                    continue
+                bbox = (
+                    [float(v) for v in box_arr[i]]
+                    if i < len(box_arr) else [0.0, 0.0, 0.0, 0.0]
+                )
+                out.append({
+                    "class_name": name,
+                    "score": score,
+                    "segmentation": polygon,
+                    "bbox": bbox,
+                })
+
+        logger.debug("detect_text: %d instance(s) across %d class(es)",
+                     len(out), len(class_configs))
+        return out
+
+    @staticmethod
+    def _clean_phrases(cfg: dict, name: str) -> list[str]:
+        """Sanitise the phrase list; fall back to the class name."""
+        phrases = list(cfg.get("phrases") or [name])
+        clean = [p.strip().rstrip(".") for p in phrases if p and p.strip()]
+        return clean or [name]

--- a/src/digitalsreeni_image_annotator/ui/sidebar.py
+++ b/src/digitalsreeni_image_annotator/ui/sidebar.py
@@ -32,6 +32,7 @@ from ..core.constants import (
     ANNOT_COL_ID,
 )
 from ..dialogs.dino_phrase_editor import ClassThresholdTable, PhraseEditorPanel
+from ..inference.sam3_utils import SAM3_MODEL_LABEL
 from ..widgets.video_timeline import VideoTimeline
 
 
@@ -184,6 +185,9 @@ def build_sidebar(window):
     window.dino_model_selector.addItem("Pick a DINO Model")
     window.dino_model_selector.addItem("grounding-dino-base")
     window.dino_model_selector.addItem("grounding-dino-tiny")
+    # SAM 3 text-prompt producer (issue #50): reuses the whole DINO review
+    # pipeline; no SAM 2 refinement step. See dino_controller._run_text_detection.
+    window.dino_model_selector.addItem(SAM3_MODEL_LABEL)
     window.dino_model_selector.addItem("Custom / fine-tuned (browse)")
     window.dino_model_selector.currentTextChanged.connect(window._on_dino_model_changed)
     dino_layout.addWidget(window.dino_model_selector)

--- a/tests/integration/test_sam3_workflow.py
+++ b/tests/integration/test_sam3_workflow.py
@@ -30,7 +30,7 @@ class _Sam3Stub:
         self.loaded = True
         self.detect_calls = []
 
-    def _weights_available(self):
+    def weights_available(self):
         return True
 
     def ensure_loaded(self):
@@ -131,7 +131,7 @@ def test_sam3_gated_download_status_when_weights_absent(window, monkeypatch):
         monkeypatch.setattr(QMessageBox, m, staticmethod(lambda *a, **k: None))
 
     class _NoWeights(_Sam3Stub):
-        def _weights_available(self):
+        def weights_available(self):
             return False
 
         def ensure_loaded(self):
@@ -246,6 +246,32 @@ def test_batch_temp_resync_swaps_on_switch(sam3_ready, tmp_path, monkeypatch):
 
 
 # --- DINO fallback path is untouched ---------------------------------------
+
+def test_inflight_guard_absorbs_busy(sam3_ready, tmp_path, monkeypatch):
+    """A re-entrant SAM 3 call raises InferenceBusyError; both the single and
+    batch paths must absorb it (skip cleanly) rather than crash (ADR-013)."""
+    from digitalsreeni_image_annotator.inference.sam3_utils import (
+        InferenceBusyError,
+    )
+
+    window = sam3_ready
+    c = window.dino_controller
+
+    def _busy(image, class_configs):
+        raise InferenceBusyError("busy")
+
+    window.sam3_utils.detect_text = _busy
+
+    # Single: no crash, nothing attached.
+    c.run_dino_detection_single()
+    assert window.image_label.temp_annotations == []
+
+    # Batch: no crash either (each work item's busy is caught + skipped).
+    _seed_batch(window, tmp_path)
+    window.dino_batch_mode.setCurrentText("Review before accepting")
+    monkeypatch.setattr(c, "_show_dino_batch_review", lambda: None)
+    c.run_dino_detection_batch()  # must not raise
+
 
 def test_dino_path_does_not_call_sam3(sam3_ready, monkeypatch):
     window = sam3_ready

--- a/tests/integration/test_sam3_workflow.py
+++ b/tests/integration/test_sam3_workflow.py
@@ -1,0 +1,276 @@
+"""Integration tests for the SAM 3 text-prompt workflow (issue #50, ADR-038).
+
+SAM 3 is a new producer plugged into the exact spot the DINO->SAM pipeline
+occupies. These build one real ImageAnnotator (offscreen), replace
+``window.sam3_utils`` with a stub whose ``detect_text`` returns deterministic
+instances, and drive ``window.dino_controller`` — proving the whole downstream
+review machinery (temp overlay, accept/reject, batch keying, per-image temp
+re-sync, auto-accept) is reused verbatim.
+
+No model weights, no network, no worker threads on the real model.
+"""
+
+import pytest
+
+
+# Two deterministic instances SAM 3 "produced" — both class "cell".
+INSTANCES = [
+    {"class_name": "cell", "score": 0.9,
+     "segmentation": [1.0, 1.0, 10.0, 1.0, 10.0, 10.0], "bbox": [1.0, 1.0, 10.0, 10.0]},
+    {"class_name": "cell", "score": 0.8,
+     "segmentation": [20.0, 20.0, 30.0, 20.0, 30.0, 30.0], "bbox": [20.0, 20.0, 30.0, 30.0]},
+]
+
+
+class _Sam3Stub:
+    """Stands in for SAM3Utils. Records detect_text calls via a spy list."""
+
+    def __init__(self, instances):
+        self._instances = instances
+        self.loaded = True
+        self.detect_calls = []
+
+    def _weights_available(self):
+        return True
+
+    def ensure_loaded(self):
+        self.loaded = True
+
+    def detect_text(self, image, class_configs):
+        self.detect_calls.append((image, list(class_configs)))
+        # Fresh dicts each call (batch reuses across work items).
+        return [dict(i) for i in self._instances]
+
+    def unload(self):
+        self.loaded = False
+
+
+@pytest.fixture
+def window(qt_application):
+    from digitalsreeni_image_annotator.annotator_window import ImageAnnotator
+
+    w = ImageAnnotator()
+    yield w
+    w.deleteLater()
+
+
+@pytest.fixture
+def sam3_ready(window, monkeypatch):
+    """Window primed for SAM 3 text detection with a stubbed producer and the
+    picker set to the SAM 3 entry."""
+    from PyQt6.QtGui import QImage, QColor
+    from PyQt6.QtWidgets import QMessageBox
+    from digitalsreeni_image_annotator.inference.sam3_utils import SAM3_MODEL_LABEL
+    import digitalsreeni_image_annotator.core.torch_utils as torch_utils
+
+    c = window.dino_controller
+    stub = _Sam3Stub(INSTANCES)
+    window.sam3_utils = stub
+
+    monkeypatch.setattr(
+        c, "_build_dino_class_configs",
+        lambda: [{"name": "cell", "phrases": ["cell"],
+                  "box_thr": 0.3, "txt_thr": 0.25, "nms_thr": 0.5}],
+    )
+    monkeypatch.setattr(torch_utils, "maybe_warn_cpu_fallback", lambda *a, **k: None)
+    for m in ("information", "warning", "critical"):
+        monkeypatch.setattr(QMessageBox, m, staticmethod(lambda *a, **k: None))
+    monkeypatch.setattr(
+        QMessageBox, "question",
+        staticmethod(lambda *a, **k: QMessageBox.StandardButton.No),
+    )
+
+    img = QImage(64, 64, QImage.Format.Format_RGB888)
+    img.fill(0)
+    window.current_image = img
+    window.image_file_name = "img1.png"
+    window.current_slice = None
+    window.class_mapping = {"cell": 1}
+    window.image_label.class_colors["cell"] = QColor(255, 0, 0)
+
+    # Select SAM 3 in the DINO picker — fires _on_sam3_selected against the stub.
+    window.dino_model_selector.setCurrentText(SAM3_MODEL_LABEL)
+    return window
+
+
+def _seed_batch(window, tmp_path):
+    """One regular image (real PNG on disk) + one materialised slice."""
+    from PyQt6.QtGui import QImage
+    from PIL import Image
+
+    reg = tmp_path / "reg1.png"
+    Image.new("RGB", (8, 8), (10, 20, 30)).save(reg)
+
+    qimg = QImage(8, 8, QImage.Format.Format_RGB888)
+    qimg.fill(0)
+
+    window.all_images = [
+        {"file_name": "reg1.png"},
+        {"file_name": "stack.tif", "is_multi_slice": True},
+    ]
+    window.image_paths = {"reg1.png": str(reg)}
+    window.image_slices = {"stack": [("stack_T0_Z0", qimg)]}
+    return ["reg1.png", "stack_T0_Z0"]
+
+
+# --- model picker wiring ----------------------------------------------------
+
+def test_selecting_sam3_enables_detect(sam3_ready):
+    window = sam3_ready
+    assert window.sam3_utils.loaded is True
+    assert window.btn_detect_single.isEnabled()
+    assert window.btn_detect_batch.isEnabled()
+    assert window.dino_controller._is_sam3_selected() is True
+
+
+def test_sam3_gated_download_status_when_weights_absent(window, monkeypatch):
+    from PyQt6.QtWidgets import QMessageBox
+    from digitalsreeni_image_annotator.inference.sam3_utils import SAM3_MODEL_LABEL
+
+    for m in ("information", "warning", "critical"):
+        monkeypatch.setattr(QMessageBox, m, staticmethod(lambda *a, **k: None))
+
+    class _NoWeights(_Sam3Stub):
+        def _weights_available(self):
+            return False
+
+        def ensure_loaded(self):
+            raise AssertionError("must not load when weights are unavailable")
+
+    window.sam3_utils = _NoWeights(INSTANCES)
+    window.dino_model_selector.setCurrentText(SAM3_MODEL_LABEL)
+
+    # Gated: no load attempted, detect buttons stay disabled, status prompts
+    # the user to fetch the weights.
+    assert not window.btn_detect_single.isEnabled()
+    assert not window.btn_detect_batch.isEnabled()
+    assert "sam3.pt" in window.lbl_dino_status.text()
+
+
+# --- single detection -------------------------------------------------------
+
+def test_single_review_attaches_sam3_temp(sam3_ready):
+    window = sam3_ready
+    c = window.dino_controller
+    # dino_batch_mode left at the default "Review before accepting".
+
+    c.run_dino_detection_single()
+
+    temp = window.image_label.temp_annotations
+    assert len(temp) == 2
+    assert all(t["source"] == "sam3" for t in temp)
+    assert all(t["temp"] is True for t in temp)
+    assert all(t["category_name"] == "cell" for t in temp)
+    # Review mode commits nothing to the canvas.
+    assert "cell" not in window.image_label.annotations
+    # The stub producer was actually exercised.
+    assert len(window.sam3_utils.detect_calls) == 1
+
+
+def test_single_accept_commits_and_clears(sam3_ready):
+    window = sam3_ready
+    c = window.dino_controller
+    c.run_dino_detection_single()
+    assert len(window.image_label.temp_annotations) == 2
+
+    c.accept_dino_results()
+
+    cells = window.image_label.annotations.get("cell", [])
+    assert len(cells) == 2
+    assert all(a["source"] == "sam3" for a in cells)
+    assert window.image_label.temp_annotations == []
+    assert window.all_annotations.get("img1.png", {}).get("cell")
+
+
+def test_single_auto_accept_commits_directly(sam3_ready):
+    window = sam3_ready
+    c = window.dino_controller
+    window.dino_batch_mode.setCurrentText("Auto-accept all detections")
+
+    c.run_dino_detection_single()
+
+    # Single path honors the (batch-labelled) auto-accept dropdown.
+    assert window.image_label.temp_annotations == []
+    cells = window.image_label.annotations.get("cell", [])
+    assert len(cells) == 2
+    assert cells[0]["number"] == 1
+    assert cells[1]["number"] == 2
+    assert cells[0]["source"] == "sam3"
+
+
+# --- batch detection --------------------------------------------------------
+
+def test_batch_review_keys_per_image_and_slice(sam3_ready, tmp_path, monkeypatch):
+    window = sam3_ready
+    c = window.dino_controller
+    names = _seed_batch(window, tmp_path)
+    window.dino_batch_mode.setCurrentText("Review before accepting")
+    monkeypatch.setattr(c, "_show_dino_batch_review", lambda: None)
+
+    c.run_dino_detection_batch()
+
+    assert set(window.dino_batch_results) == set(names)
+    for res in window.dino_batch_results.values():
+        assert len(res) == 2
+        assert all(r["source"] == "sam3" for r in res)
+        assert all("segmentation" in r for r in res)
+    # detect_text ran once per work item.
+    assert len(window.sam3_utils.detect_calls) == len(names)
+
+
+def test_batch_temp_resync_swaps_on_switch(sam3_ready, tmp_path, monkeypatch):
+    window = sam3_ready
+    c = window.dino_controller
+    _seed_batch(window, tmp_path)
+    window.dino_batch_mode.setCurrentText("Review before accepting")
+    monkeypatch.setattr(c, "_show_dino_batch_review", lambda: None)
+    c.run_dino_detection_batch()
+
+    # Switch to the regular image -> its stored set becomes the live temp.
+    window.image_file_name = "reg1.png"
+    window.current_slice = None
+    c._refresh_dino_temp_for_current()
+    assert len(window.image_label.temp_annotations) == 2
+    assert all(t["source"] == "sam3" for t in window.image_label.temp_annotations)
+
+    # Switch to the slice -> the temp set swaps (no bleed across the switch).
+    window.current_slice = "stack_T0_Z0"
+    c._refresh_dino_temp_for_current()
+    assert len(window.image_label.temp_annotations) == 2
+
+    # Switch to an image with no pending results -> temp cleared.
+    window.current_slice = None
+    window.image_file_name = "unrelated.png"
+    c._refresh_dino_temp_for_current()
+    assert window.image_label.temp_annotations == []
+
+
+# --- DINO fallback path is untouched ---------------------------------------
+
+def test_dino_path_does_not_call_sam3(sam3_ready, monkeypatch):
+    window = sam3_ready
+    c = window.dino_controller
+
+    # Point the picker at a real DINO entry; wire the legacy two-stage stubs.
+    window.dino_model_loaded = True
+    window.sam_utils.current_sam_model = "SAM 2 tiny"
+    monkeypatch.setattr(c, "_ensure_dino_model_downloaded", lambda name: True)
+    window.dino_model_selector.setCurrentText("grounding-dino-base")
+    monkeypatch.setattr(
+        window.dino_utils, "detect",
+        lambda *a, **k: [{"class_name": "cell", "score": 0.9, "bbox": [1, 1, 10, 10]}],
+    )
+    monkeypatch.setattr(
+        window.sam_utils, "apply_sam_predictions_batch",
+        lambda img, boxes: [{"segmentation": [1.0, 1.0, 10.0, 1.0, 10.0, 10.0]}
+                            for _ in boxes],
+    )
+
+    c.run_dino_detection_single()
+
+    # SAM 3 stub must be untouched by the DINO path.
+    assert window.sam3_utils.detect_calls == []
+    # And the legacy path produced a DINO-sourced temp annotation.
+    temp = window.image_label.temp_annotations
+    assert len(temp) == 1
+    assert temp[0]["source"] == "dino"

--- a/tests/unit/test_sam3_utils.py
+++ b/tests/unit/test_sam3_utils.py
@@ -1,0 +1,262 @@
+"""Unit tests for ``SAM3Utils`` (issue #50, ADR-038).
+
+The real ``sam3.pt`` checkpoint is ~3.45 GB and gated on Hugging Face, so it
+is NOT present here or in CI. Every test therefore stubs the predictor — the
+real ``SAM3SemanticPredictor`` is never instantiated. We only exercise our
+own marshalling / filtering / polygon-conversion glue around it.
+"""
+
+import numpy as np
+import pytest
+
+from digitalsreeni_image_annotator.inference.sam3_utils import SAM3Utils
+
+
+# --- fakes mimicking the Ultralytics Results / tensor surface ---------------
+
+class _FakeTensor:
+    """Mimics a torch tensor's ``.cpu().numpy()`` chain over a numpy array."""
+
+    def __init__(self, arr):
+        self._arr = np.asarray(arr)
+
+    def cpu(self):
+        return self
+
+    def numpy(self):
+        return self._arr
+
+
+class _FakeMasks:
+    def __init__(self, masks_np):
+        self.data = _FakeTensor(masks_np)
+
+
+class _FakeBoxes:
+    def __init__(self, conf_np, xyxy_np):
+        self.conf = _FakeTensor(conf_np)
+        self.xyxy = _FakeTensor(xyxy_np)
+
+
+class _FakeResults:
+    def __init__(self, masks_np, conf_np, xyxy_np):
+        self.masks = _FakeMasks(masks_np) if masks_np is not None else None
+        self.boxes = (
+            _FakeBoxes(conf_np, xyxy_np) if masks_np is not None else None
+        )
+
+
+class _FakePredictor:
+    """Records calls; returns a preset Results (object or list)."""
+
+    def __init__(self, results):
+        self._results = results
+        self.set_image_calls = []
+        self.text_calls = []
+
+    def set_image(self, image_np):
+        self.set_image_calls.append(image_np)
+
+    def __call__(self, text=None):
+        self.text_calls.append(text)
+        return self._results
+
+
+def _square_mask(h=64, w=64, x0=5, y0=5, size=20):
+    """A filled square well above the area-10 contour floor."""
+    m = np.zeros((h, w), dtype=np.uint8)
+    m[y0:y0 + size, x0:x0 + size] = 1
+    return m
+
+
+def _tiny_mask(h=64, w=64):
+    """A 2x2 blob — area 4, below the area-10 floor -> no polygon."""
+    m = np.zeros((h, w), dtype=np.uint8)
+    m[0:2, 0:2] = 1
+    return m
+
+
+def _cfg(box_thr=0.3, phrases=("cell",)):
+    return {"name": "cell", "phrases": list(phrases),
+            "box_thr": box_thr, "txt_thr": 0.25, "nms_thr": 0.5}
+
+
+def _blank_qimage():
+    from PyQt6.QtGui import QImage
+    img = QImage(64, 64, QImage.Format.Format_RGB888)
+    img.fill(0)
+    return img
+
+
+@pytest.fixture
+def sam3(qt_application):
+    """A fresh (unloaded) SAM3Utils. ``qt_application`` so ``_run_sync`` has
+    a GUI thread to run against."""
+    return SAM3Utils()
+
+
+def _load_fake(s, results):
+    s._predictor = _FakePredictor(results)
+    s.loaded = True
+    return s._predictor
+
+
+# --- detect_text: output shape ---------------------------------------------
+
+def test_detect_text_returns_instance_shape(sam3):
+    masks = np.stack([_square_mask(x0=5), _square_mask(x0=35)])
+    conf = np.array([0.9, 0.8], dtype=np.float32)
+    xyxy = np.array([[5, 5, 25, 25], [35, 5, 55, 25]], dtype=np.float32)
+    _load_fake(sam3, _FakeResults(masks, conf, xyxy))
+
+    out = sam3.detect_text(_blank_qimage(), [_cfg()])
+
+    assert len(out) == 2
+    for inst in out:
+        assert set(inst) == {"class_name", "score", "segmentation", "bbox"}
+        assert inst["class_name"] == "cell"
+        assert isinstance(inst["segmentation"], list)
+        assert len(inst["segmentation"]) >= 6
+        assert len(inst["bbox"]) == 4
+    assert out[0]["score"] == pytest.approx(0.9)
+    assert out[1]["score"] == pytest.approx(0.8)
+
+
+def test_detect_text_accepts_results_as_list(sam3):
+    # The spike describes a Results object; be defensive about a 1-element
+    # list too (the usual Ultralytics predictor return).
+    masks = np.stack([_square_mask()])
+    conf = np.array([0.9], dtype=np.float32)
+    xyxy = np.array([[5, 5, 25, 25]], dtype=np.float32)
+    _load_fake(sam3, [_FakeResults(masks, conf, xyxy)])
+
+    out = sam3.detect_text(_blank_qimage(), [_cfg()])
+
+    assert len(out) == 1
+
+
+# --- detect_text: confidence (box_thr) filtering ----------------------------
+
+def test_detect_text_drops_instance_below_box_thr(sam3):
+    masks = np.stack([_square_mask(x0=5), _square_mask(x0=35)])
+    conf = np.array([0.9, 0.1], dtype=np.float32)   # 0.1 < box_thr 0.3
+    xyxy = np.array([[5, 5, 25, 25], [35, 5, 55, 25]], dtype=np.float32)
+    _load_fake(sam3, _FakeResults(masks, conf, xyxy))
+
+    out = sam3.detect_text(_blank_qimage(), [_cfg(box_thr=0.3)])
+
+    assert len(out) == 1
+    assert out[0]["score"] == pytest.approx(0.9)
+
+
+# --- detect_text: area floor delegated to _mask_to_polygon ------------------
+
+def test_detect_text_small_mask_yields_no_instance(sam3):
+    masks = np.stack([_tiny_mask()])
+    conf = np.array([0.99], dtype=np.float32)
+    xyxy = np.array([[0, 0, 2, 2]], dtype=np.float32)
+    _load_fake(sam3, _FakeResults(masks, conf, xyxy))
+
+    out = sam3.detect_text(_blank_qimage(), [_cfg()])
+
+    assert out == []
+
+
+def test_detect_text_delegates_polygon_to_mask_to_polygon(sam3, monkeypatch):
+    import digitalsreeni_image_annotator.inference.sam3_utils as mod
+
+    calls = []
+    real = mod._mask_to_polygon
+
+    def spy(mask):
+        calls.append(getattr(mask, "shape", None))
+        return real(mask)
+
+    monkeypatch.setattr(mod, "_mask_to_polygon", spy)
+
+    masks = np.stack([_square_mask()])
+    conf = np.array([0.9], dtype=np.float32)
+    xyxy = np.array([[5, 5, 25, 25]], dtype=np.float32)
+    _load_fake(sam3, _FakeResults(masks, conf, xyxy))
+
+    out = sam3.detect_text(_blank_qimage(), [_cfg()])
+
+    assert calls  # conversion went through the shared helper
+    assert len(out) == 1
+
+
+# --- detect_text: unloaded model never half-works ---------------------------
+
+def test_detect_text_unloaded_returns_none(sam3):
+    # Fresh instance: loaded is False, _predictor is None.
+    assert sam3.loaded is False
+    assert sam3.detect_text(_blank_qimage(), [_cfg()]) is None
+
+
+# --- model load: overrides must omit quantize / mode ------------------------
+
+def test_load_overrides_omit_quantize_and_mode(sam3, monkeypatch):
+    captured = {}
+
+    class _Recorder:
+        def __init__(self, overrides=None, **kwargs):
+            captured["overrides"] = overrides
+            captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(
+        "ultralytics.models.sam.SAM3SemanticPredictor", _Recorder
+    )
+
+    # Pure Python; safe to call directly (no worker thread needed).
+    sam3._load_model_blocking()
+
+    assert sam3.loaded is True
+    assert sam3._predictor is not None
+    ov = captured["overrides"]
+    assert set(ov) == {"model", "task", "conf"}
+    assert "quantize" not in ov
+    assert "mode" not in ov
+    assert ov["task"] == "segment"
+    assert isinstance(ov["conf"], float)
+    # Constructor gets ONLY overrides=...; no stray kwargs.
+    assert captured["kwargs"] == {}
+
+
+def test_failed_load_leaves_unloaded_and_reraises(sam3, monkeypatch):
+    class _Boom:
+        def __init__(self, *a, **k):
+            raise RuntimeError("weights corrupt")
+
+    monkeypatch.setattr(
+        "ultralytics.models.sam.SAM3SemanticPredictor", _Boom
+    )
+
+    with pytest.raises(RuntimeError):
+        sam3._load_model_blocking()
+
+    # Never a half-loaded state.
+    assert sam3.loaded is False
+    assert sam3._predictor is None
+
+
+# --- weights resolution (no download) ---------------------------------------
+
+def test_weights_available_reflects_resolvable_path(sam3, monkeypatch, tmp_path):
+    absent = tmp_path / "absent.pt"
+    monkeypatch.setattr(sam3, "_candidate_weight_paths", lambda: [str(absent)])
+    assert sam3._resolve_weights_path() is None
+    assert sam3._weights_available() is False
+
+    present = tmp_path / "sam3.pt"
+    present.write_bytes(b"not-a-real-checkpoint")
+    monkeypatch.setattr(sam3, "_candidate_weight_paths", lambda: [str(present)])
+    assert sam3._resolve_weights_path() == str(present)
+    assert sam3._weights_available() is True
+
+
+def test_env_override_is_a_candidate_path(sam3, monkeypatch, tmp_path):
+    present = tmp_path / "custom-sam3.pt"
+    present.write_bytes(b"x")
+    monkeypatch.setenv("SAM3_MODEL_PATH", str(present))
+    assert str(present) in sam3._candidate_weight_paths()
+    assert sam3._resolve_weights_path() == str(present)

--- a/tests/unit/test_sam3_utils.py
+++ b/tests/unit/test_sam3_utils.py
@@ -213,11 +213,14 @@ def test_load_overrides_omit_quantize_and_mode(sam3, monkeypatch):
     assert sam3.loaded is True
     assert sam3._predictor is not None
     ov = captured["overrides"]
-    assert set(ov) == {"model", "task", "conf"}
+    # device is REQUIRED (CPU-fallback safety, mirrors SAMUtils); quantize/mode
+    # must be absent (quantize raises in ultralytics 8.4.51, mode is redundant).
+    assert set(ov) == {"model", "task", "conf", "device"}
     assert "quantize" not in ov
     assert "mode" not in ov
     assert ov["task"] == "segment"
     assert isinstance(ov["conf"], float)
+    assert ov["device"] == sam3._device
     # Constructor gets ONLY overrides=...; no stray kwargs.
     assert captured["kwargs"] == {}
 
@@ -245,13 +248,13 @@ def test_weights_available_reflects_resolvable_path(sam3, monkeypatch, tmp_path)
     absent = tmp_path / "absent.pt"
     monkeypatch.setattr(sam3, "_candidate_weight_paths", lambda: [str(absent)])
     assert sam3._resolve_weights_path() is None
-    assert sam3._weights_available() is False
+    assert sam3.weights_available() is False
 
     present = tmp_path / "sam3.pt"
     present.write_bytes(b"not-a-real-checkpoint")
     monkeypatch.setattr(sam3, "_candidate_weight_paths", lambda: [str(present)])
     assert sam3._resolve_weights_path() == str(present)
-    assert sam3._weights_available() is True
+    assert sam3.weights_available() is True
 
 
 def test_env_override_is_a_candidate_path(sam3, monkeypatch, tmp_path):

--- a/tests/unit/test_sam3_utils.py
+++ b/tests/unit/test_sam3_utils.py
@@ -215,9 +215,14 @@ def test_load_overrides_omit_quantize_and_mode(sam3, monkeypatch):
     ov = captured["overrides"]
     # device is REQUIRED (CPU-fallback safety, mirrors SAMUtils); quantize/mode
     # must be absent (quantize raises in ultralytics 8.4.51, mode is redundant).
-    assert set(ov) == {"model", "task", "conf", "device"}
+    # save/verbose are forced False to suppress the runs/ dir + per-call console
+    # summary Ultralytics writes on every detection (verified in the #50 manual
+    # GPU run, 2026-07-22 -- accepted without raising).
+    assert set(ov) == {"model", "task", "conf", "device", "save", "verbose"}
     assert "quantize" not in ov
     assert "mode" not in ov
+    assert ov["save"] is False
+    assert ov["verbose"] is False
     assert ov["task"] == "segment"
     assert isinstance(ov["conf"], float)
     assert ov["device"] == sam3._device


### PR DESCRIPTION
## Summary

SAM 3 is plugged in as a second **producer** at the "DINO boxes → SAM masks" spot; all downstream review UI (temp overlay, Enter/Escape, batch over images+slices, auto-accept, `.iap` persistence, undo) is reused verbatim. Grounding-DINO stays a fallback, functionally unchanged (its tests pass unmodified).

- `inference/sam3_utils.py::SAM3Utils`: lazy-imports `SAM3SemanticPredictor`, constructs with `overrides=dict(model="sam3.pt", task="segment", conf=<floor>, device=<resolved>)` — **no `quantize`/`mode`** (ADR-038 verified `quantize` raises in ultralytics 8.4.51), `device` passed for CPU-fallback safety. Reuses `sam_utils._run_sync`/`_qimage_to_numpy`/`_mask_to_polygon` + the shared in-flight flag. `detect_text` → per-instance `{class_name,score,segmentation,bbox}`; `box_thr` is the confidence filter. Gated `sam3.pt` (3.45 GB) never auto-downloaded; `weights_available()` drives a request-access status.
- `DINOController._run_text_detection(qimage)` choke point (single + batch): SAM 3 splits each instance into the `(results, sam_results)` shape the DINO pipeline already zips; SAM 3 skips the "No SAM Model" guard. Temps tagged `source="sam3"`; all 5 `source=="dino"` checks widened to `("dino","sam3")`.
- `pyproject`: ultralytics floor `>=8.3.237,<9` (ADR-038).

## Verification

- Full suite **777 passed / 3 skipped** (+19 tests): source=="sam3" review/accept/auto-accept(single+batch)/batch-keying/temp-resync, DINO-not-called, overrides omit quantize/mode + include device, load-failure discipline, in-flight busy skip (both paths). Ruff clean. **Real-model check needs a GPU + gated weights → documented manual step; wiring is fully stubbed.**
- **Senior review** (no P0): the P1 (device-fallback crash) is fixed + tested; P2s (busy-branch test, public `weights_available`, ADR honesty, version-line, bbox comment) done.

## Docs

ADR-038 → Accepted; new ADR-039; `docs/05/06/08` + CLAUDE.md.

## Phase chain

**Phase 8**, base = `spike/sam3-availability` (Phase 7 / #49). #51 extends `SAM3Utils` with `track`.

Closes #50

🧙 Built with [WOZCODE](https://wozcode.com)